### PR TITLE
h2o theme for background

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -544,7 +544,7 @@ def go_gradio(**kwargs):
         task_info_md = ''
 
     css_code = """footer {visibility: hidden;}
-body{background:linear-gradient(#f2f2f2,#cccccc);}
+body{background:linear-gradient(#f5f5f5,#e5e5e5);}
 body.dark{background:linear-gradient(#0d0d0d,#333333);}"""
 
     from gradio.themes.utils import Color, colors, fonts, sizes

--- a/generate.py
+++ b/generate.py
@@ -543,14 +543,43 @@ def go_gradio(**kwargs):
     else:
         task_info_md = ''
 
-    css_code = """footer {visibility: hidden}
-body{background-image:url("https://h2o.ai/content/experience-fragments/h2o/us/en/site/header/master/_jcr_content/root/container/header_copy/logo.coreimg.svg/1678976605175/h2o-logo.svg");}}"""
+    css_code = """footer {visibility: hidden;}
+body{background:linear-gradient(#f2f2f2,#cccccc);}
+body.dark{background:linear-gradient(#0d0d0d,#333333);}"""
 
-    from gradio.themes.utils import colors, fonts, sizes
+    from gradio.themes.utils import Color, colors, fonts, sizes
     if kwargs['h2ocolors']:
-        colors_dict = dict(primary_hue=colors.yellow,
-                           secondary_hue=colors.yellow,
-                           neutral_hue=colors.gray,
+        h2o_yellow = Color(
+            name="yellow",
+            c50="#fffef2",
+            c100="#fff9e6",
+            c200="#ffecb3",
+            c300="#ffe28c",
+            c400="#ffd659",
+            c500="#fec925",
+            c600="#e6ac00",
+            c700="#bf8f00",
+            c800="#a67c00",
+            c900="#664d00",
+            c950="#403000",
+        )
+        h2o_gray = Color(
+            name="gray",
+            c50="#f2f2f2",
+            c100="#e5e5e5",
+            c200="#cccccc",
+            c300="#b2b2b2",
+            c400="#999999",
+            c500="#7f7f7f",
+            c600="#666666",
+            c700="#4c4c4c",
+            c800="#333333",
+            c900="#191919",
+            c950="#0d0d0d",
+        )
+        colors_dict = dict(primary_hue=h2o_yellow,
+                           secondary_hue=h2o_yellow,
+                           neutral_hue=h2o_gray,
                            spacing_size=sizes.spacing_md,
                            radius_size=sizes.radius_md,
                            text_size=sizes.text_md,


### PR DESCRIPTION
This PR removes the repeating H2O logo from the background, and - hopefully - incorporates the H2O color theme to the app. I say hopefully, because I have not yet got a local dev environment running, lacking CUDA, and probably some other things necessary to successfully run `generate.py` - so I was not able to test this locally.

This is just a simple fix - but it might be good to start working more on a customized UI of some sort, if that is warranted at this point.

The UI should look something similar to this (though with slightly different colors for the yellows and grays):

Light mode:
<img width="1917" alt="Screenshot 2023-04-20 at 6 23 43 PM" src="https://user-images.githubusercontent.com/641147/233518842-b03acb7b-c5d0-4ed7-baa1-fdecde0db8ff.png">

Dark mode:
<img width="1914" alt="Screenshot 2023-04-20 at 6 15 29 PM" src="https://user-images.githubusercontent.com/641147/233518530-21cdf1f9-75ef-4b42-9df6-c50a2d144bcf.png">
