### PR TITLE
Llama flash attn

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -107,4 +107,17 @@ sudo systemctl status nvidia-fabricmanager
 tensorboard --logdir=runs/
 ```
 
+### To use flash attention with LLaMa, need cuda 11.7 so flash attention module compiles against torch
+From [cuda toolkit](https://developer.nvidia.com/cuda-11-7-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=Ubuntu&target_version=20.04&target_type=runfile_local):
+```bash
+wget https://developer.download.nvidia.com/compute/cuda/11.7.0/local_installers/cuda_11.7.0_515.43.04_linux.run
+sudo bash ./cuda_11.7.0_515.43.04_linux.run
+```
+Then No for symlink change, say continue (not abort), accept license, keep only toolkit selected, select install.
+
+If cuda 11.7 is not your base installation, then when doing pip install -r requirements.txt do instead:
+```bash
+CUDA_HOME=/usr/local/cuda-11.7 pip install -r requirements.txt 
+```
+
 Now you're ready to go back to [data prep and fine-tuning](FINETUNE.md)!

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -92,6 +92,15 @@ sudo systemctl status nvidia-fabricmanager
 ```
 See [Fabric Manager](https://docs.nvidia.com/datacenter/tesla/fabric-manager-user-guide/index.html)
 
+Once have installed and reboot system, just do:
+
+```bash
+sudo systemctl --now enable nvidia-dcgm
+dcgmi discovery -l
+sudo systemctl start nvidia-fabricmanager
+sudo systemctl status nvidia-fabricmanager
+```
+
 ### Tensorboard (optional) to inspect training
 
 ```bash

--- a/finetune.py
+++ b/finetune.py
@@ -320,8 +320,8 @@ def train(
                 layer_norm_names=["layer_norm", "layernorm"],  # keep all layer norms in higher precision
             )
 
-    from peft import mapping, LoraConfig, get_peft_model, set_peft_model_state_dict
-    lora_mappings = mapping.TRANSFORMERS_MODELS_TO_LORA_TARGET_MODULES_MAPPING.copy()
+    from peft import LoraConfig, get_peft_model, set_peft_model_state_dict, utils
+    lora_mappings = utils.TRANSFORMERS_MODELS_TO_LORA_TARGET_MODULES_MAPPING.copy()
     lora_mappings['distilgpt2'] = ["c_attn"]
 
     if lora_weights:

--- a/finetune.py
+++ b/finetune.py
@@ -160,6 +160,7 @@ def train(
         warmup_steps: int = 100,
         logging_steps: int = 1,
         save_steps: int = None,  # must be round multiple of eval_steps
+        save_total_limit: int = 3,
         add_eos_token: bool = False,
 ):
 
@@ -597,7 +598,7 @@ def train(
             eval_steps=eval_steps if val_set_size > 0 else None,
             save_steps=save_steps,
             output_dir=output_dir,
-            save_total_limit=3,
+            save_total_limit=save_total_limit,
             load_best_model_at_end=True if val_set_size > 0 else False,
             ddp_find_unused_parameters=False if ddp else None,
             group_by_length=group_by_length,

--- a/finetune.py
+++ b/finetune.py
@@ -196,6 +196,18 @@ def train(
     if llama_type is None:
         llama_type = "llama" in base_model.lower()
     if llama_type and llama_flash_attn:
+        import pkg_resources
+        try:
+            pkg_resources.get_distribution('flash_attn')
+            can_do_flash_attn = True
+        except (pkg_resources.DistributionNotFound, pkg_resources.ContextualVersionConflict):
+            can_do_flash_attn = False
+
+        if not can_do_flash_attn:
+            raise RuntimeError("""Flash attention not installed.
+            NOTE: for current pytorch 2.0, flash attention requires installing cuda 11.7 via https://developer.nvidia.com/cuda-11-7-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=Ubuntu&target_version=20.04&target_type=runfile_local and then when running, to avoid installing driver, docs, samples, just install toolkit.  Then when pip installing flash attention do:
+
+            CUDA_HOME=/usr/local/cuda-11.7 pip install flash-attn""")
         from llama_flash_attn_monkey_patch import replace_llama_attn_with_flash_attn
         replace_llama_attn_with_flash_attn()
     assert (

--- a/finetune.py
+++ b/finetune.py
@@ -12,6 +12,8 @@ import torch
 
 def log(*args, **kwargs):
     if int(os.environ.get("LOCAL_RANK", 0)) == 0:
+        if 'flush' not in kwargs:
+            kwargs['flush'] = True
         print(*args, **kwargs)
 
 

--- a/llama_flash_attn_monkey_patch.py
+++ b/llama_flash_attn_monkey_patch.py
@@ -1,7 +1,6 @@
 from typing import List, Optional, Tuple
 
 import torch
-from torch import nn
 
 import transformers
 from transformers.models.llama.modeling_llama import apply_rotary_pos_emb

--- a/llama_flash_attn_monkey_patch.py
+++ b/llama_flash_attn_monkey_patch.py
@@ -1,0 +1,113 @@
+from typing import List, Optional, Tuple
+
+import torch
+from torch import nn
+
+import transformers
+from transformers.models.llama.modeling_llama import apply_rotary_pos_emb
+
+from einops import rearrange
+
+from flash_attn.flash_attn_interface import flash_attn_unpadded_qkvpacked_func
+from flash_attn.bert_padding import unpad_input, pad_input
+
+
+def forward(
+    self,
+    hidden_states: torch.Tensor,
+    attention_mask: Optional[torch.Tensor] = None,
+    position_ids: Optional[torch.Tensor] = None,
+    past_key_value: Optional[Tuple[torch.Tensor]] = None,
+    output_attentions: bool = False,
+    use_cache: bool = False,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
+    """Input shape: Batch x Time x Channel
+    attention_mask: [bsz, q_len]
+    """
+    bsz, q_len, _ = hidden_states.size()
+
+    query_states = (
+        self.q_proj(hidden_states)
+        .view(bsz, q_len, self.num_heads, self.head_dim)
+        .transpose(1, 2)
+    )
+    key_states = (
+        self.k_proj(hidden_states)
+        .view(bsz, q_len, self.num_heads, self.head_dim)
+        .transpose(1, 2)
+    )
+    value_states = (
+        self.v_proj(hidden_states)
+        .view(bsz, q_len, self.num_heads, self.head_dim)
+        .transpose(1, 2)
+    )
+    # [bsz, q_len, nh, hd]
+    # [bsz, nh, q_len, hd]
+
+    kv_seq_len = key_states.shape[-2]
+    assert past_key_value is None, "past_key_value is not supported"
+
+    cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
+    query_states, key_states = apply_rotary_pos_emb(
+        query_states, key_states, cos, sin, position_ids
+    )
+    # [bsz, nh, t, hd]
+    assert not output_attentions, "output_attentions is not supported"
+    assert not use_cache, "use_cache is not supported"
+
+    # Flash attention codes from
+    # https://github.com/HazyResearch/flash-attention/blob/main/flash_attn/flash_attention.py
+
+    # transform the data into the format required by flash attention
+    qkv = torch.stack(
+        [query_states, key_states, value_states], dim=2
+    )  # [bsz, nh, 3, q_len, hd]
+    qkv = qkv.transpose(1, 3)  # [bsz, q_len, 3, nh, hd]
+    # We have disabled _prepare_decoder_attention_mask in LlamaModel
+    # the attention_mask should be the same as the key_padding_mask
+    key_padding_mask = attention_mask
+
+    if key_padding_mask is None:
+        qkv = rearrange(qkv, "b s ... -> (b s) ...")
+        max_s = q_len
+        cu_q_lens = torch.arange(
+            0, (bsz + 1) * q_len, step=q_len, dtype=torch.int32, device=qkv.device
+        )
+        output = flash_attn_unpadded_qkvpacked_func(
+            qkv, cu_q_lens, max_s, 0.0, softmax_scale=None, causal=True
+        )
+        output = rearrange(output, "(b s) ... -> b s ...", b=bsz)
+    else:
+        nheads = qkv.shape[-2]
+        x = rearrange(qkv, "b s three h d -> b s (three h d)")
+        x_unpad, indices, cu_q_lens, max_s = unpad_input(x, key_padding_mask)
+        x_unpad = rearrange(
+            x_unpad, "nnz (three h d) -> nnz three h d", three=3, h=nheads
+        )
+        output_unpad = flash_attn_unpadded_qkvpacked_func(
+            x_unpad, cu_q_lens, max_s, 0.0, softmax_scale=None, causal=True
+        )
+        output = rearrange(
+            pad_input(
+                rearrange(output_unpad, "nnz h d -> nnz (h d)"), indices, bsz, q_len
+            ),
+            "b s (h d) -> b s h d",
+            h=nheads,
+        )
+    return self.o_proj(rearrange(output, "b s h d -> b s (h d)")), None, None
+
+
+# Disable the transformation of the attention mask in LlamaModel as the flash attention
+# requires the attention mask to be the same as the key_padding_mask
+def _prepare_decoder_attention_mask(
+    self, attention_mask, input_shape, inputs_embeds, past_key_values_length
+):
+    # [bsz, seq_len]
+    return attention_mask
+
+
+def replace_llama_attn_with_flash_attn():
+    transformers.models.llama.modeling_llama.LlamaModel._prepare_decoder_attention_mask = (
+        _prepare_decoder_attention_mask
+    )
+    transformers.models.llama.modeling_llama.LlamaAttention.forward = forward

--- a/llama_flash_attn_monkey_patch.py
+++ b/llama_flash_attn_monkey_patch.py
@@ -106,6 +106,7 @@ def _prepare_decoder_attention_mask(
 
 
 def replace_llama_attn_with_flash_attn():
+    print("Replacing original LLaMa attention with flash attention", flush=True)
     transformers.models.llama.modeling_llama.LlamaModel._prepare_decoder_attention_mask = (
         _prepare_decoder_attention_mask
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ bitsandbytes==0.38.1
 git+https://github.com/huggingface/peft.git@098962fa6515f2e4fe83a757f5995d3ffbb1c373
 transformers==4.28.1
 tokenizers==0.13.3
+flash-attn==1.0.3
 
 # optional for generate
 pynvml==11.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ bitsandbytes==0.38.1
 git+https://github.com/huggingface/peft.git@098962fa6515f2e4fe83a757f5995d3ffbb1c373
 transformers==4.28.1
 tokenizers==0.13.3
+# optional
 flash-attn==1.0.3.post0
 
 # optional for generate

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ bitsandbytes==0.38.1
 git+https://github.com/huggingface/peft.git@098962fa6515f2e4fe83a757f5995d3ffbb1c373
 transformers==4.28.1
 tokenizers==0.13.3
-flash-attn==1.0.3
+flash-attn==1.0.3.post0
 
 # optional for generate
 pynvml==11.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,11 +19,11 @@ pandas==2.0.0
 matplotlib==3.7.1
 loralib==0.1.1
 bitsandbytes==0.38.1
-git+https://github.com/huggingface/peft.git@098962fa6515f2e4fe83a757f5995d3ffbb1c373
+git+https://github.com/huggingface/peft.git@e8f66b8a425eced6c592089d40b8d33d82c2b2f0
 transformers==4.28.1
 tokenizers==0.13.3
 # optional
-flash-attn==1.0.3.post0
+flash-attn==1.0.4
 
 # optional for generate
 pynvml==11.5.0

--- a/tests/test_check_requirements.py
+++ b/tests/test_check_requirements.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+import pkg_resources
+from pkg_resources import DistributionNotFound, VersionConflict
+
+
+
+def test_requirements():
+    """Test that each required package is available."""
+    packages_all = []
+    packages_dist = []
+    packages_version = []
+    packages_unkn = []
+    req_file = "requirements.txt"
+    req_tmp_file = req_file + '.tmp.txt'
+
+    reqs_http = []
+    
+    with open(req_file, 'rt') as f:
+        contents = f.readlines()
+        with open(req_tmp_file, 'wt') as g:
+            for line in contents:
+                if 'http://' not in line and 'https://' not in line:
+                    g.write(line)
+                else:
+                    reqs_http.append(line.replace('\n', ''))
+    reqs_http = [x for x in reqs_http if x]
+    print('reqs_http: %s' % reqs_http, flush=True)
+            
+    _REQUIREMENTS_PATH = Path(__file__).parent.with_name(req_tmp_file)
+    requirements = pkg_resources.parse_requirements(_REQUIREMENTS_PATH.open())
+    for requirement in requirements:
+        try:
+            requirement = str(requirement)
+            pkg_resources.require(requirement)
+        except DistributionNotFound:
+            packages_all.append(requirement)
+            packages_dist.append(requirement)
+        except VersionConflict:
+            packages_all.append(requirement)
+            packages_version.append(requirement)
+        except pkg_resources.extern.packaging.requirements.InvalidRequirement:
+            packages_all.append(requirement)
+            packages_unkn.append(requirement)
+
+    packages_all.extend(reqs_http)
+    if packages_dist or packages_version:
+        print('Missing packages: %s' % packages_dist, flush=True)
+        print('Wrong version of packages: %s' % packages_version, flush=True)
+        print("Can't determine (e.g. http) packages: %s" % packages_unkn, flush=True)
+        print('\n\nRUN THIS:\n\n', flush=True)
+        print('pip install %s --upgrade' % str(' '.join(packages_all)), flush=True)
+        print('\n\n', flush=True)
+
+        raise ValueError(packages_all)
+    

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -49,7 +49,7 @@ def test_requirements():
         print('Wrong version of packages: %s' % packages_version, flush=True)
         print("Can't determine (e.g. http) packages: %s" % packages_unkn, flush=True)
         print('\n\nRUN THIS:\n\n', flush=True)
-        print('pip uninstall peft -y ; pip install %s --upgrade' % str(' '.join(packages_all)), flush=True)
+        print('pip uninstall peft -y ; CUDA_HOME=/usr/local/cuda-11.7 pip install %s --upgrade' % str(' '.join(packages_all)), flush=True)
         print('\n\n', flush=True)
 
         raise ValueError(packages_all)

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -49,7 +49,7 @@ def test_requirements():
         print('Wrong version of packages: %s' % packages_version, flush=True)
         print("Can't determine (e.g. http) packages: %s" % packages_unkn, flush=True)
         print('\n\nRUN THIS:\n\n', flush=True)
-        print('pip install %s --upgrade' % str(' '.join(packages_all)), flush=True)
+        print('pip uninstall peft -y ; pip install %s --upgrade' % str(' '.join(packages_all)), flush=True)
         print('\n\n', flush=True)
 
         raise ValueError(packages_all)


### PR DESCRIPTION
- [ ] Compare with quantized versions, e.g. https://huggingface.co/elinas/alpaca-30b-lora-int4
- [ ] Compare with existing 30B loras: https://huggingface.co/serpdotai/llama-oasst-lora-30B
- [x] Run with 8-bit to see memory/speed difference
- [x] Run with larger lora
- [x] Run with more layers using lora, not just attention
- [x] Run without fast attention to see how fast or how much memory for case when fits (e.g. smaller cutoff length).  Indirectly so far, on 20B neox without fast attention.  Even with batching setup to be efficient, neox 24x slower for 512 cutoff.
- [ ] Separate out optional requirements, since flash attention only works for A100+ OOTB

Note:

Requires A100+ to work OOTB without patching transformers or using nightly torch to avoid errors.

Would need to patch transformers https://github.com/lm-sys/FastChat/issues/581#issuecomment-1522860263

We could also try bettertransformers wrapper, which wraps HF models into BT models, using native torch version of flash attention (they say slower but more memory efficient): 

https://pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html#:~:text=Scaled%20dot%20product%20attention%20attempts,for%20enabling%20and%20disabling%20implementations.

That might require pytorch nightly to fix a related bug where they should have disabled fast attention for some head sizes if don't have sm80.  But we can then at least test on A6000/4090.  But should then all work on A100 and use flash attention to some degree without limit on head sizes.

See also:
https://github.com/pytorch/pytorch/pull/99105
https://github.com/pytorch/pytorch/issues/98771
https://github.com/pytorch/pytorch/issues/98140
https://github.com/huggingface/transformers/pull/18439
https://github.com/lm-sys/FastChat/issues/459
https://github.com/pytorch/pytorch/issues/94883