### PR TITLE
Add Triton deployment template.

### DIFF
--- a/INSTALL-DOCKER.md
+++ b/INSTALL-DOCKER.md
@@ -9,6 +9,7 @@ distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \
         sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
         sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
 sudo apt-get update && sudo apt-get install -y nvidia-container-toolkit-base
+sudo apt install nvidia-container-runtime
 sudo nvidia-ctk runtime configure --runtime=docker
 sudo systemctl restart docker
 ```

--- a/TRITON.md
+++ b/TRITON.md
@@ -40,6 +40,8 @@ export TRITON_DOCKER_IMAGE=triton_with_ft:${CONTAINER_VERSION}
 # Go into Docker
 docker run -it --rm --runtime=nvidia --shm-size=1g \
        --ulimit memlock=-1 -v ${WORKSPACE}:${WORKSPACE} \
+       -e MODEL=${MODEL} \
+       -e WORKSPACE=${WORKSPACE} \
        -w ${WORKSPACE} ${TRITON_DOCKER_IMAGE} bash
 export PYTHONPATH=${WORKSPACE}/FasterTransformer/:$PYTHONPATH
 python3 ${WORKSPACE}/FasterTransformer/examples/pytorch/gptneox/utils/huggingface_gptneox_convert.py \

--- a/TRITON.md
+++ b/TRITON.md
@@ -8,6 +8,7 @@ To build in Docker, we follow the [instructions](https://github.com/triton-infer
 
 ```bash
 git clone https://github.com/triton-inference-server/fastertransformer_backend.git
+git clone https://github.com/NVIDIA/FasterTransformer.git
 cd fastertransformer_backend
 export WORKSPACE=$(pwd)
 export CONTAINER_VERSION=22.12
@@ -17,23 +18,57 @@ docker build --rm   \
     -t ${TRITON_DOCKER_IMAGE} \
     -f docker/Dockerfile \
     .
+docker run -it --rm --runtime=nvidia --shm-size=1g --ulimit memlock=-1 -v ${WORKSPACE}:${WORKSPACE} -w ${WORKSPACE} ${TRITON_DOCKER_IMAGE} bash
 ```
 
 ### Create model definition files
 
-TODO
+We convert the h2oGPT model from [HF to FT format](https://github.com/NVIDIA/FasterTransformer/pull/569):
+
+####  Fetch model from Hugging Face
+```bash
+export WORKSPACE=$(pwd)
+export SRC_MODELS_DIR=${WORKSPACE}/models
+export PYTHONPATH=$PWD/FasterTransformer/:$PYTHONPATH
+export MODEL=h2ogpt-oig-oasst1-512-6.9b
+if [ ! -d ${MODEL} ]; then
+    git lfs clone https://huggingface.co/h2oai/${MODEL}
+fi
+```
+
+####  Convert to FasterTransformer format
+
+```bash
+export WORKSPACE=$(pwd)
+export SRC_MODELS_DIR=${WORKSPACE}/models
+export PYTHONPATH=$PWD/FasterTransformer/:$PYTHONPATH
+python3 ${WORKSPACE}/FasterTransformer/examples/pytorch/gptneox/utils/huggingface_gptneox_convert.py \
+        -i_g 1 \
+        -m_n gptneox \
+        -i ${WORKSPACE}/${MODEL} \
+        -o ${WORKSPACE}/FT-${MODEL}
+```
+
+####  Run the model
+
+FIXME - not yet working
+```bash
+echo "Hi, who are you?" > gptneox_input
+echo "And you are?" >> gptneox_input
+python3 ${WORKSPACE}/FasterTransformer/examples/pytorch/gptneox/gptneox_example.py \
+         --ckpt_path ${WORKSPACE}/FT-${MODEL}/1-gpu \
+         --tokenizer_path ${WORKSPACE}/${MODEL} \
+         --sample_input_file gptneox_input
+```
 
 ### Launch Triton
 
 ```bash
-docker run -it --rm --runtime=nvidia --shm-size=1g --ulimit memlock=-1 -v ${WORKSPACE}:${WORKSPACE} -w ${WORKSPACE} ${TRITON_DOCKER_IMAGE} bash
-
-# Now inside Docker, start Triton
-
 export WORKSPACE=$(pwd)
 export SRC_MODELS_DIR=${WORKSPACE}/models
-
-CUDA_VISIBLE_DEVICES=0,1 mpirun -n 1 --allow-run-as-root /opt/tritonserver/bin/tritonserver  --model-repository=${WORKSPACE}/all_models/gptneox/
+CUDA_VISIBLE_DEVICES=0,1 mpirun -n 1 \
+        --allow-run-as-root /opt/tritonserver/bin/tritonserver  \
+        --model-repository=${WORKSPACE}/all_models/gptneox/fastertransformer/
 ```
 
 ### Run client test

--- a/TRITON.md
+++ b/TRITON.md
@@ -18,9 +18,6 @@ docker build --rm   \
     -t ${TRITON_DOCKER_IMAGE} \
     -f docker/Dockerfile \
     .
-docker run -it --rm --runtime=nvidia --shm-size=1g \
-       --ulimit memlock=-1 -v ${WORKSPACE}:${WORKSPACE} \
-       -w ${WORKSPACE} ${TRITON_DOCKER_IMAGE} bash
 ```
 
 ### Create model definition files
@@ -29,9 +26,6 @@ We convert the h2oGPT model from [HF to FT format](https://github.com/NVIDIA/Fas
 
 ####  Fetch model from Hugging Face
 ```bash
-export WORKSPACE=$(pwd)
-export SRC_MODELS_DIR=${WORKSPACE}/models
-export PYTHONPATH=$PWD/FasterTransformer/:$PYTHONPATH
 export MODEL=h2ogpt-oig-oasst1-512-6.9b
 if [ ! -d ${MODEL} ]; then
     git lfs clone https://huggingface.co/h2oai/${MODEL}
@@ -43,6 +37,10 @@ fi
 ```bash
 export WORKSPACE=$(pwd)
 export SRC_MODELS_DIR=${WORKSPACE}/models
+# Go into Docker
+docker run -it --rm --runtime=nvidia --shm-size=1g \
+       --ulimit memlock=-1 -v ${WORKSPACE}:${WORKSPACE} \
+       -w ${WORKSPACE} ${TRITON_DOCKER_IMAGE} bash
 export PYTHONPATH=$PWD/FasterTransformer/:$PYTHONPATH
 python3 ${WORKSPACE}/FasterTransformer/examples/pytorch/gptneox/utils/huggingface_gptneox_convert.py \
         -i_g 1 \

--- a/TRITON.md
+++ b/TRITON.md
@@ -58,7 +58,7 @@ python3 ${WORKSPACE}/FasterTransformer/examples/pytorch/gptneox/utils/huggingfac
 
 ####  Test the FasterTransformer model
 
-FIXME - not yet working
+FIXME
 ```bash
 echo "Hi, who are you?" > gptneox_input
 echo "And you are?" >> gptneox_input

--- a/TRITON.md
+++ b/TRITON.md
@@ -51,7 +51,7 @@ python3 ${WORKSPACE}/FasterTransformer/examples/pytorch/gptneox/utils/huggingfac
         -o ${WORKSPACE}/FT-${MODEL}
 ```
 
-####  Run the model
+####  Test the FasterTransformer model
 
 FIXME - not yet working
 ```bash
@@ -63,13 +63,38 @@ python3 ${WORKSPACE}/FasterTransformer/examples/pytorch/gptneox/gptneox_example.
          --sample_input_file gptneox_input
 ```
 
-### Launch Triton
+#### Update Triton configuration files
+
+Fix a typo in the example:
+```bash
+sed -i -e 's@postprocessing@preprocessing@' all_models/gptneox/preprocessing/config.pbtxt
+```
+
+Update the path to the PyTorch model:
+```bash
+sed -i -e "s@/workspace/ft/models/ft/gptneox/@${WORKSPACE}/FT-${MODEL}/1-gpu@" all_models/gptneox/fastertransformer/config.pbtxt
+```
+
+#### Launch Triton
 
 ```bash
-CUDA_VISIBLE_DEVICES=0,1 mpirun -n 1 \
+CUDA_VISIBLE_DEVICES=0 mpirun -n 1 \
         --allow-run-as-root /opt/tritonserver/bin/tritonserver  \
-        --model-repository=${WORKSPACE}/all_models/gptneox/fastertransformer/
+        --model-repository=${WORKSPACE}/all_models/gptneox/fastertransformer
 ```
+
+Now, you should see something like this:
+```bash
++-------------------+---------+--------+
+| Model             | Version | Status |
++-------------------+---------+--------+
+| ensemble          | 1       | READY  |
+| fastertransformer | 1       | READY  |
+| postprocessing    | 1       | READY  |
+| preprocessing     | 1       | READY  |
++-------------------+---------+--------+
+```
+which means the pipeline is ready to make predictions!
 
 ### Run client test
 

--- a/TRITON.md
+++ b/TRITON.md
@@ -18,7 +18,9 @@ docker build --rm   \
     -t ${TRITON_DOCKER_IMAGE} \
     -f docker/Dockerfile \
     .
-docker run -it --rm --runtime=nvidia --shm-size=1g --ulimit memlock=-1 -v ${WORKSPACE}:${WORKSPACE} -w ${WORKSPACE} ${TRITON_DOCKER_IMAGE} bash
+docker run -it --rm --runtime=nvidia --shm-size=1g \
+       --ulimit memlock=-1 -v ${WORKSPACE}:${WORKSPACE} \
+       -w ${WORKSPACE} ${TRITON_DOCKER_IMAGE} bash
 ```
 
 ### Create model definition files

--- a/TRITON.md
+++ b/TRITON.md
@@ -40,6 +40,7 @@ export TRITON_DOCKER_IMAGE=triton_with_ft:${CONTAINER_VERSION}
 # Go into Docker
 docker run -it --rm --runtime=nvidia --shm-size=1g \
        --ulimit memlock=-1 -v ${WORKSPACE}:${WORKSPACE} \
+       -e CUDA_VISIBLE_DEVICES=0 \
        -e MODEL=${MODEL} \
        -e WORKSPACE=${WORKSPACE} \
        -w ${WORKSPACE} ${TRITON_DOCKER_IMAGE} bash
@@ -70,9 +71,10 @@ Fix a typo in the example:
 sed -i -e 's@postprocessing@preprocessing@' all_models/gptneox/preprocessing/config.pbtxt
 ```
 
-Update the path to the PyTorch model:
+Update the path to the PyTorch model, and set to use 1 GPU:
 ```bash
 sed -i -e "s@/workspace/ft/models/ft/gptneox/@${WORKSPACE}/FT-${MODEL}/1-gpu@" all_models/gptneox/fastertransformer/config.pbtxt
+sed -i -e 's@string_value: "2"@string_value: "1"@' all_models/gptneox/fastertransformer/config.pbtxt
 ```
 
 #### Launch Triton
@@ -80,7 +82,7 @@ sed -i -e "s@/workspace/ft/models/ft/gptneox/@${WORKSPACE}/FT-${MODEL}/1-gpu@" a
 ```bash
 CUDA_VISIBLE_DEVICES=0 mpirun -n 1 \
         --allow-run-as-root /opt/tritonserver/bin/tritonserver  \
-        --model-repository=${WORKSPACE}/all_models/gptneox/fastertransformer &
+        --model-repository=${WORKSPACE}/all_models/gptneox/ &
 ```
 
 Now, you should see something like this:

--- a/TRITON.md
+++ b/TRITON.md
@@ -1,0 +1,45 @@
+## Triton Inference Server
+
+To get optimal performance for inference for h2oGPT models, we will be using the [FastTransformer Backend for Triton](https://github.com/triton-inference-server/fastertransformer_backend/).
+
+To build in Docker, we follow the [instructions](https://github.com/triton-inference-server/fastertransformer_backend/blob/main/README.md#setup):
+
+### Build Docker image for Triton with FasterTransformer backend:
+
+```bash
+git clone https://github.com/triton-inference-server/fastertransformer_backend.git
+cd fastertransformer_backend
+export WORKSPACE=$(pwd)
+export CONTAINER_VERSION=22.12
+export TRITON_DOCKER_IMAGE=triton_with_ft:${CONTAINER_VERSION}
+docker build --rm   \
+    --build-arg TRITON_VERSION=${CONTAINER_VERSION}   \
+    -t ${TRITON_DOCKER_IMAGE} \
+    -f docker/Dockerfile \
+    .
+```
+
+### Create model definition files
+
+TODO
+
+### Launch Triton
+
+```bash
+docker run -it --rm --runtime=nvidia --shm-size=1g --ulimit memlock=-1 -v ${WORKSPACE}:${WORKSPACE} -w ${WORKSPACE} ${TRITON_DOCKER_IMAGE} bash
+
+# Now inside Docker, start Triton
+
+export WORKSPACE=$(pwd)
+export SRC_MODELS_DIR=${WORKSPACE}/models
+
+CUDA_VISIBLE_DEVICES=0,1 mpirun -n 1 --allow-run-as-root /opt/tritonserver/bin/tritonserver  --model-repository=${WORKSPACE}/all_models/gptneox/
+```
+
+### Run client test
+
+```bash
+TODO
+```
+
+

--- a/TRITON.md
+++ b/TRITON.md
@@ -110,6 +110,12 @@ python3 ${WORKSPACE}/tools/gpt/identity_test.py
 ```
 
 And now the end-to-end test:
+
+We first have to fix a bug in the inputs for postprocessing:
+```bash
+sed -i -e 's@prepare_tensor("RESPONSE_INPUT_LENGTHS", output2, FLAGS.protocol)@prepare_tensor("sequence_length", output1, FLAGS.protocol)@' ${WORKSPACE}/tools/gpt/end_to_end_test.py
+```
+
 ```bash
 python3 ${WORKSPACE}/tools/gpt/end_to_end_test.py
 ```

--- a/TRITON.md
+++ b/TRITON.md
@@ -80,7 +80,7 @@ sed -i -e "s@/workspace/ft/models/ft/gptneox/@${WORKSPACE}/FT-${MODEL}/1-gpu@" a
 ```bash
 CUDA_VISIBLE_DEVICES=0 mpirun -n 1 \
         --allow-run-as-root /opt/tritonserver/bin/tritonserver  \
-        --model-repository=${WORKSPACE}/all_models/gptneox/fastertransformer
+        --model-repository=${WORKSPACE}/all_models/gptneox/fastertransformer &
 ```
 
 Now, you should see something like this:
@@ -98,8 +98,14 @@ which means the pipeline is ready to make predictions!
 
 ### Run client test
 
+Let's test the endpoint:
 ```bash
-TODO
+python3 ${WORKSPACE}/tools/gpt/identity_test.py
+```
+
+And now the end-to-end test:
+```bash
+python3 ${WORKSPACE}/tools/gpt/end_to_end_test.py
 ```
 
 

--- a/TRITON.md
+++ b/TRITON.md
@@ -8,8 +8,8 @@ To build in Docker, we follow the [instructions](https://github.com/triton-infer
 
 ```bash
 git clone https://github.com/triton-inference-server/fastertransformer_backend.git
-git clone https://github.com/NVIDIA/FasterTransformer.git
 cd fastertransformer_backend
+git clone https://github.com/NVIDIA/FasterTransformer.git
 export WORKSPACE=$(pwd)
 export CONTAINER_VERSION=22.12
 export TRITON_DOCKER_IMAGE=triton_with_ft:${CONTAINER_VERSION}
@@ -36,12 +36,12 @@ fi
 
 ```bash
 export WORKSPACE=$(pwd)
-export SRC_MODELS_DIR=${WORKSPACE}/models
+export TRITON_DOCKER_IMAGE=triton_with_ft:${CONTAINER_VERSION}
 # Go into Docker
 docker run -it --rm --runtime=nvidia --shm-size=1g \
        --ulimit memlock=-1 -v ${WORKSPACE}:${WORKSPACE} \
        -w ${WORKSPACE} ${TRITON_DOCKER_IMAGE} bash
-export PYTHONPATH=$PWD/FasterTransformer/:$PYTHONPATH
+export PYTHONPATH=${WORKSPACE}/FasterTransformer/:$PYTHONPATH
 python3 ${WORKSPACE}/FasterTransformer/examples/pytorch/gptneox/utils/huggingface_gptneox_convert.py \
         -i_g 1 \
         -m_n gptneox \
@@ -64,8 +64,6 @@ python3 ${WORKSPACE}/FasterTransformer/examples/pytorch/gptneox/gptneox_example.
 ### Launch Triton
 
 ```bash
-export WORKSPACE=$(pwd)
-export SRC_MODELS_DIR=${WORKSPACE}/models
 CUDA_VISIBLE_DEVICES=0,1 mpirun -n 1 \
         --allow-run-as-root /opt/tritonserver/bin/tritonserver  \
         --model-repository=${WORKSPACE}/all_models/gptneox/fastertransformer/

--- a/TRITON.md
+++ b/TRITON.md
@@ -2,7 +2,7 @@
 
 To get optimal performance for inference for h2oGPT models, we will be using the [FastTransformer Backend for Triton](https://github.com/triton-inference-server/fastertransformer_backend/).
 
-To build in Docker, we follow the [instructions](https://github.com/triton-inference-server/fastertransformer_backend/blob/main/README.md#setup):
+Make sure to [install Docker](INSTALL-DOCKER.md) first.
 
 ### Build Docker image for Triton with FasterTransformer backend:
 
@@ -30,6 +30,10 @@ export MODEL=h2ogpt-oig-oasst1-512-6.9b
 if [ ! -d ${MODEL} ]; then
     git lfs clone https://huggingface.co/h2oai/${MODEL}
 fi
+```
+If `git lfs` fails, make sure to install it first. For Ubuntu:
+```bash
+sudo apt-get install git-lfs
 ```
 
 ####  Convert to FasterTransformer format


### PR DESCRIPTION
For https://github.com/h2oai/h2ogpt/issues/87

- [x] show that a 20B model can be deployed in Triton as pipeline of tokenization/model/post-processing - ensemble.
- [ ] write nice Python wrapper to use Triton-hosted model from Gradio app (Later PR)