### PR TITLE
Check data for unhelpful responses

### DIFF
--- a/create_data.py
+++ b/create_data.py
@@ -1572,6 +1572,9 @@ def test_check_unhelpful():
                   "You need to provide more context",
                   "provide more context",
                   ]
+    unhelpful += ["As a large language model",
+                  "cannot provide any information",
+                  ]
     file = '/home/jon/Downloads/openassistant_oasst1_h2ogpt_graded.json'
     data = json.load(open(file, 'rt'))
     bads = {}

--- a/create_data.py
+++ b/create_data.py
@@ -1517,3 +1517,66 @@ def test_check_stats_data():
     plt.title("token_count with cutoff=%s avg: %s median: %s" % (cutoff_len, token_avg, token_median))
     plt.savefig('token_hist_%s.png' % cutoff_len)
     plt.close()
+
+
+def test_check_unhelpful():
+    # base versions
+    unhelpful = ["I'm sorry, I didn't quite understand your question, could you please rephrase it?",
+                 "I'm sorry, but I don't understand your question. Could you please rephrase it?",
+                 "I'm sorry, I didn't quite understand your question",
+                 "I do not understand your question. Can you please try to make it clearer?",
+                 "I'm sorry, but as an AI language model",
+                 "I apologize, but I cannot rephrase text that I cannot understand. Your post is difficult to read and follow.",
+                 "I apologize, but I am not h2oGPT. I am a language model developed by H2O.ai. How may I help you?",
+                 "Sorry, but I am not an actual Linux shell, nor am I capable of emulating one. I am an open source chat assistant and would be glad t",
+                 "I apologize, but I cannot perform the task you have requested.",
+                 "I'm sorry, I cannot perform this task as I am an AI language model and do not have access",
+                 "I'm sorry, I'm not sure what you're asking for here.",
+                 "I'm not sure what you are asking",
+                 "You need to provide more context",
+                 ]
+    # reduced versions, with redundant parts, just to give context for where they came from
+    unhelpful += ["sorry, I didn't quite understand your question",
+                  "I didn't quite understand your question",
+                  "I didn't understand your question",
+                  "I did not understand your question",
+                  "I did not understand the question",
+                  "could you please rephrase"
+                  "could you rephrase"
+                  "I do not understand your question.",
+                  "I do not understand the question.",
+                  "I do not understand that question.",
+                  "Can you please try to make it clearer",
+                  "Can you try to make it clearer",
+                  "sorry, but as an AI language model",
+                  "as an AI language model",
+                  "I apologize, but I cannot",
+                  "I cannot rephrase text",
+                  "I cannot understand. Your post is difficult to read and follow."
+                  "Your post is difficult to read and follow."
+                  "I apologize, but I am",
+                  "Sorry, but I am not ",
+                  "nor am I capable",
+                  "I am not capable of",
+                  "I apologize, but I cannot perform the task you have requested",
+                  "I cannot perform the task",
+                  "I cannot complete the task",
+                  "I'm sorry",
+                  "I am sorry",
+                  "do not have access",
+                  "not sure what you're asking for",
+                  "not sure what you are asking for",
+                  "not sure what is being asked",
+                  "I'm not sure what you are asking",
+                  "not sure what you are asking",
+                  "You need to provide more context",
+                  "provide more context",
+                  ]
+    file = '/home/jon/Downloads/openassistant_oasst1_h2ogpt_graded.json'
+    data = json.load(open(file, 'rt'))
+    bads = []
+    for sub in unhelpful:
+        if sub in str(data):
+            bads.append(sub)
+    print("bad subs: %s" % bads, flush=True)
+    assert len(bads) == 0, bads

--- a/create_data.py
+++ b/create_data.py
@@ -1582,6 +1582,7 @@ def test_check_unhelpful():
                   "As an artificial intelligence I can't",
                   "As an artificial intelligence I cannot",
                   "I am sorry but I do not understand",
+                  "Can you please explain",
                   ]
     data = json.load(open(file, 'rt'))
     bads = {}

--- a/create_data.py
+++ b/create_data.py
@@ -1581,6 +1581,7 @@ def test_check_unhelpful():
                   "As an artificial intelligence I don't have the capability",
                   "As an artificial intelligence I can't",
                   "As an artificial intelligence I cannot",
+                  "I am sorry but I do not understand",
                   ]
     data = json.load(open(file, 'rt'))
     bads = {}

--- a/create_data.py
+++ b/create_data.py
@@ -1574,9 +1574,12 @@ def test_check_unhelpful():
                   ]
     file = '/home/jon/Downloads/openassistant_oasst1_h2ogpt_graded.json'
     data = json.load(open(file, 'rt'))
-    bads = []
+    bads = {}
     for sub in unhelpful:
-        if sub in str(data):
-            bads.append(sub)
-    print("bad subs: %s" % bads, flush=True)
+        string_all = str(data)
+        bads[sub] = string_all.count(sub)
+    bads = {k: v for k, v in bads.items() if v > 0}
+    import pprint
+    pp = pprint.PrettyPrinter(indent=4)
+    pp.pprint(bads)
     assert len(bads) == 0, bads

--- a/create_data.py
+++ b/create_data.py
@@ -1574,15 +1574,36 @@ def test_check_unhelpful():
                   ]
     unhelpful += ["As a large language model",
                   "cannot provide any information",
+                  "As an artificial intelligence I do not have the capability",
+                  "As an artificial intelligence I don't have the capability",
+                  "As an artificial intelligence I can't",
+                  "As an artificial intelligence I cannot",
                   ]
     file = '/home/jon/Downloads/openassistant_oasst1_h2ogpt_graded.json'
     data = json.load(open(file, 'rt'))
     bads = {}
+    string_all = str(data)
     for sub in unhelpful:
-        string_all = str(data)
         bads[sub] = string_all.count(sub)
     bads = {k: v for k, v in bads.items() if v > 0}
     import pprint
     pp = pprint.PrettyPrinter(indent=4)
     pp.pprint(bads)
-    assert len(bads) == 0, bads
+
+    # check just bot
+    import re
+    convs = [[x.strip() for x in re.split(r'%s|%s' % (human, bot), y['input']) if x.strip()] for y in data]
+    humans = [[x for i, x in enumerate(y) if i % 2 == 0] for y in convs]
+    bots = [[x for i, x in enumerate(y) if i % 2 == 1] for y in convs]
+
+    bads_bots = {}
+    string_all = str(bots)
+    for sub in unhelpful:
+        bads_bots[sub] = string_all.count(sub)
+    bads_bots = {k: v for k, v in bads_bots.items() if v > 0}
+    import pprint
+    pp = pprint.PrettyPrinter(indent=4)
+    pp.pprint(bads_bots)
+
+    # assert len(bads) == 0, bads
+    assert len(bads_bots) == 0, bads_bots

--- a/create_data.py
+++ b/create_data.py
@@ -1520,6 +1520,9 @@ def test_check_stats_data():
 
 
 def test_check_unhelpful():
+    file = '/home/jon/Downloads/openassistant_oasst1_h2ogpt_graded.json'
+    # file = 'h2ogpt-oig-oasst1-instruct-cleaned-v2.json'
+
     # base versions
     unhelpful = ["I'm sorry, I didn't quite understand your question, could you please rephrase it?",
                  "I'm sorry, but I don't understand your question. Could you please rephrase it?",
@@ -1579,7 +1582,6 @@ def test_check_unhelpful():
                   "As an artificial intelligence I can't",
                   "As an artificial intelligence I cannot",
                   ]
-    file = '/home/jon/Downloads/openassistant_oasst1_h2ogpt_graded.json'
     data = json.load(open(file, 'rt'))
     bads = {}
     string_all = str(data)
@@ -1589,6 +1591,9 @@ def test_check_unhelpful():
     import pprint
     pp = pprint.PrettyPrinter(indent=4)
     pp.pprint(bads)
+
+    total_bads = sum(list(bads.values()))
+    print('total_bads: %s' % total_bads, flush=True)
 
     # check just bot
     import re
@@ -1604,6 +1609,9 @@ def test_check_unhelpful():
     import pprint
     pp = pprint.PrettyPrinter(indent=4)
     pp.pprint(bads_bots)
+
+    total_bads_bots = sum(list(bads_bots.values()))
+    print('total_bads_bots: %s' % total_bads_bots, flush=True)
 
     # assert len(bads) == 0, bads
     assert len(bads_bots) == 0, bads_bots


### PR DESCRIPTION
```
pytest -s -v tests/create_data.test_check_unhelpful
```

gives (for just bot responses) for `openassistant_oasst1_h2ogpt_graded.json`
```
{   'As a large language model': 15,
    'As an artificial intelligence I do not have the capability': 2,
    'I am not capable of': 15,
    'I am sorry': 41,
    "I didn't understand your question": 1,
    "I'm sorry": 279,
    "I'm sorry, I cannot perform this task as I am an AI language model and do not have access": 3,
    "I'm sorry, but as an AI language model": 19,
    'You need to provide more context': 3,
    'as an AI language model': 50,
    'do not have access': 20,
    'nor am I capable': 1,
    'provide more context': 26,
    'sorry, but as an AI language model': 26}
total_bads_bots: 501
```

For `h2ogpt-oig-oasst1-instruct-cleaned-v2.json`:

```
{   'As a large language model': 25,
    'As an artificial intelligence I cannot': 3,
    'As an artificial intelligence I do not have the capability': 2,
    'I am not capable of': 27,
    'I am sorry': 125,
    'I apologize, but I cannot': 1,
    "I didn't quite understand your question": 5,
    "I didn't understand your question": 2,
    "I'm sorry": 518,
    "I'm sorry, I cannot perform this task as I am an AI language model and do not have access": 3,
    "I'm sorry, I didn't quite understand your question": 5,
    "I'm sorry, I didn't quite understand your question, could you please rephrase it?": 5,
    "I'm sorry, but as an AI language model": 22,
    'Sorry, but I am not ': 1,
    'Sorry, but I am not an actual Linux shell, nor am I capable of emulating one. I am an open source chat assistant and would be glad t': 1,
    'You need to provide more context': 3,
    'as an AI language model': 61,
    'do not have access': 80,
    'nor am I capable': 2,
    'not sure what you are asking': 3,
    'provide more context': 66,
    "sorry, I didn't quite understand your question": 5,
    'sorry, but as an AI language model': 29}
total_bads_bots: 994
```


If higher reward model score threshold doesn't help.  It would be cheating to just filter these exact matches out, will leave too many other non-explicit cases in I didn't hard-code.

Could use BLEU etc. for matching response with those example targets perhaps.

Note in some cases OASST has these as "toxic" Q/A pairs, so good it didn't do it.  But it makes the model less smart by too much to have those, randomly will respond in that way for totally safe questions/prompts.

Some other AI moralizing filters could be done, some of those are excessive however: https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered .  The problem is not the need for AI alignment, the problem is these models parrot responses without any real conditions.  Just randomly become unhelpful as proven by just regenerating.  It can just be that a typo in word or grammar mistake can be enough to typically respond back in an unhelpful way, which is a bad bias to have.

