### PR TITLE
ArXiv support via URL in chatbot UI

### DIFF
--- a/README_LangChain.md
+++ b/README_LangChain.md
@@ -64,8 +64,14 @@ sudo apt-get install libreoffice
 ### Supported Datatypes in UI
 
    - `Files` : All Native and Meta DataTypes as file(s),
-   - `URL` : Any URL,
+   - `URL` : Any URL (i.e. `http://` or `https://`) or ArXiv name (e.g. `arXiv:1706.03762`),
    - `Text` : Paste Text into UI.
+
+To support ArXiv API, run:
+```bash
+pip install arxiv pymupdf
+```
+but this is GNU Affero General Public License (AGPL), requiring any source code be made available, which is not an issue directly for h2oGPT, but its like GPL and too strong a constraint for commercial use
 
 ## Database creation
 

--- a/README_LangChain.md
+++ b/README_LangChain.md
@@ -12,6 +12,16 @@ Live hosted instances:
 
 For questions, discussing, or just hanging out, come and join our <a href="https://discord.gg/WKhYMWcVbq"><b>Discord</b></a>!
 
+## Getting Started
+
+To get started quickly to upload from Chatbot any docs, urls, etc. do:
+```bash
+grep -v '#\|peft' requirements.txt > req_constraints.txt
+pip install -r requirements_optional_langchain.txt -c req_constraints.txt
+python generate.py --base_model=h2oai/h2ogpt-oasst1-512-12b --load_8bit=True --langchain_mode=MyData
+```
+See below for additional instructions to add support for some file types.
+
 ## Supported Datatypes
 
 Open-source data types are supported, .msg is not supported due to GPL-3 requirement.  Other meta types support other types inside them.  Special support for some behaviors is provided by the UI itself.
@@ -64,14 +74,16 @@ sudo apt-get install libreoffice
 ### Supported Datatypes in UI
 
    - `Files` : All Native and Meta DataTypes as file(s),
-   - `URL` : Any URL (i.e. `http://` or `https://`) or ArXiv name (e.g. `arXiv:1706.03762`),
+   - `URL` : Any URL (i.e. `http://` or `https://`),
+   - `ArXiv` : Any ArXiv name (e.g. `arXiv:1706.03762`),
    - `Text` : Paste Text into UI.
 
-To support ArXiv API, run:
+To support ArXiv API, do:
 ```bash
-pip install arxiv pymupdf
+grep -v '#\|peft' requirements.txt > req_constraints.txt
+pip install -r requirements_optional_langchain.gpllike.txt -c req_constraints.txt
 ```
-but this is GNU Affero General Public License (AGPL), requiring any source code be made available, which is not an issue directly for h2oGPT, but its like GPL and too strong a constraint for commercial use
+but pymupdf is AGPL, requiring any source code be made available, which is not an issue directly for h2oGPT, but it's like GPL and too strong a constraint for general commercial use.
 
 ## Database creation
 

--- a/gradio_runner.py
+++ b/gradio_runner.py
@@ -264,8 +264,9 @@ def go_gradio(**kwargs):
                     upload_row = gr.Row(visible=kwargs['langchain_mode'] != 'Disabled' and allow_upload)
                     # import control
                     if kwargs['langchain_mode'] != 'Disabled':
-                        from gpt_langchain import file_types
+                        from gpt_langchain import file_types, have_arxiv
                     else:
+                        have_arxiv = False
                         file_types = []
                     with upload_row:
                         fileup_output = gr.File(label='Upload File (Drop-Drop or Select File(s)',
@@ -284,7 +285,8 @@ def go_gradio(**kwargs):
                                                          visible=allow_upload_to_my_data)  # and False)
                     url_row = gr.Row(visible=kwargs['langchain_mode'] != 'Disabled' and allow_upload and enable_url_upload)
                     with url_row:
-                        url_text = gr.Textbox(label='URL (http/https) or ArXiv:', interactive=True)
+                        url_label = 'URL (http/https) or ArXiv:' if have_arxiv else 'URL (http/https)'
+                        url_text = gr.Textbox(label=url_label, interactive=True)
                         url_user_btn = gr.Button(value='Add URL content to Shared UserData DB',
                                                  visible=allow_upload_to_user_data)
                         url_my_btn = gr.Button(value='Add URL content to Scratch MyData DB',

--- a/gradio_runner.py
+++ b/gradio_runner.py
@@ -284,7 +284,7 @@ def go_gradio(**kwargs):
                                                          visible=allow_upload_to_my_data)  # and False)
                     url_row = gr.Row(visible=kwargs['langchain_mode'] != 'Disabled' and allow_upload and enable_url_upload)
                     with url_row:
-                        url_text = gr.Textbox(label='URL', interactive=True)
+                        url_text = gr.Textbox(label='URL (http/https) or ArXiv:', interactive=True)
                         url_user_btn = gr.Button(value='Add URL content to Shared UserData DB',
                                                  visible=allow_upload_to_user_data)
                         url_my_btn = gr.Button(value='Add URL content to Scratch MyData DB',

--- a/requirements_optional_langchain.gpllike.txt
+++ b/requirements_optional_langchain.gpllike.txt
@@ -1,0 +1,3 @@
+arxiv==1.4.7
+pymupdf==1.22.3 # AGPL license
+# extract-msg==0.41.1  # GPL3

--- a/requirements_optional_langchain.txt
+++ b/requirements_optional_langchain.txt
@@ -33,7 +33,6 @@ unstructured[local-inference]==0.6.6
 pdfminer.six==20221105
 urllib3==1.26.6
 requests_file==1.5.1
-# extract-msg==0.41.1  # GPL3
 
 #pdf2image==1.16.3
 #pytesseract==0.3.10

--- a/tests/test_manual_test.py
+++ b/tests/test_manual_test.py
@@ -26,7 +26,11 @@ def test_upload_multiple_file():
 
 
 def test_upload_url():
-    raise NotImplementedError("MANUAL TEST FOR NOW -- do and ask query of content of url")
+    raise NotImplementedError("MANUAL TEST FOR NOW -- put in URL box arxiv:1706.03762, ensure can go to source link")
+
+
+def test_upload_arxiv():
+    raise NotImplementedError("MANUAL TEST FOR NOW -- ")
 
 
 def test_upload_pasted_text():


### PR DESCRIPTION
put in URL box arxiv:1706.03762

![image](https://github.com/h2oai/h2ogpt/assets/2249614/db163421-92d1-464c-ad90-26166b591d16)

```
============================================================================================= short test summary info =============================================================================================
FAILED tests/test_manual_test.py::test_chat_context - NotImplementedError: MANUAL TEST FOR NOW
FAILED tests/test_manual_test.py::test_upload_one_file - NotImplementedError: MANUAL TEST FOR NOW -- do and ask query of file
FAILED tests/test_manual_test.py::test_upload_multiple_file - NotImplementedError: MANUAL TEST FOR NOW -- do and ask query of files
FAILED tests/test_manual_test.py::test_upload_url - NotImplementedError: MANUAL TEST FOR NOW -- put in URL box arxiv:1706.03762, ensure can go to source link
FAILED tests/test_manual_test.py::test_upload_arxiv - NotImplementedError: MANUAL TEST FOR NOW --
FAILED tests/test_manual_test.py::test_upload_pasted_text - NotImplementedError: MANUAL TEST FOR NOW -- do and see test code for what to try
FAILED tests/test_manual_test.py::test_no_db_dirs - NotImplementedError: MANUAL TEST FOR NOW -- Remove db_dirs, ensure can still start up and use in MyData Mode.
=================================================================== 7 failed, 30 passed, 8 skipped, 1 xpassed, 11 warnings in 443.47s (0:07:23) ===================================================================
(h2ollm) jon@pseudotensor:~/h2o-llm$ 
```