### PR TITLE
Move loaders out of finetune, which is only for training, while loader used for generation too

### DIFF
--- a/create_data.py
+++ b/create_data.py
@@ -1576,7 +1576,8 @@ def test_check_stats_data():
     plt.close()
 
     # get tokenize stats for random sample of 1000 rows
-    from finetune import get_loaders, get_tokenizer, generate_and_tokenize_prompt
+    from finetune import generate_and_tokenize_prompt
+    from loaders import get_loaders, get_tokenizer
     from functools import partial
 
     llama_type = False

--- a/export_hf_checkpoint.py
+++ b/export_hf_checkpoint.py
@@ -5,7 +5,7 @@ import shutil
 import torch
 from peft import PeftModel
 from transformers import PreTrainedModel
-from finetune import get_loaders
+from loaders import get_loaders
 
 BASE_MODEL = 'h2oai/h2ogpt-oasst1-512-12b'
 LORA_WEIGHTS = 'h2ogpt-oasst1-512-12b.h2oaih2ogpt-oig-oasst1-instruct-cleaned-v3.1_epochs.805b8e8eff369207340a5a6f90f3c833f9731254.2'

--- a/generate.py
+++ b/generate.py
@@ -13,6 +13,7 @@ from datetime import datetime
 import filelock
 import psutil
 
+from loaders import get_loaders
 from utils import set_seed, clear_torch_cache, save_generate_output, NullContext, wrapped_partial, EThread, get_githash, \
     import_matplotlib, get_device, makedirs
 
@@ -33,8 +34,7 @@ from peft import PeftModel
 from transformers import GenerationConfig, AutoModel, TextIteratorStreamer
 from accelerate import init_empty_weights, infer_auto_device_map
 
-from prompter import Prompter, inv_prompt_type_to_model_lower, generate_prompt
-from finetune import get_loaders, example_data_points
+from prompter import Prompter, inv_prompt_type_to_model_lower
 from stopping import get_stopping
 
 eval_extra_columns = ['prompt', 'response', 'score']
@@ -1484,12 +1484,6 @@ def get_context(chat_context, prompt_type):
     else:
         context0 = ''
     return context0
-
-
-def test_test_prompt(prompt_type='instruct', data_point=0):
-    example_data_point = example_data_points[data_point]
-    example_data_point.pop('output', None)
-    return generate_prompt(example_data_point, prompt_type, False, False)
 
 
 def score_qa(smodel, stokenizer, max_length_tokenize, question, answer, cutoff_len):

--- a/gradio_runner.py
+++ b/gradio_runner.py
@@ -13,10 +13,9 @@ import tabulate
 
 from gradio_themes import H2oTheme, SoftTheme, get_h2o_title, get_simple_title, get_dark_js
 from prompter import Prompter, \
-    prompt_type_to_model_name, prompt_types_strings, inv_prompt_type_to_model_lower
+    prompt_type_to_model_name, prompt_types_strings, inv_prompt_type_to_model_lower, generate_prompt
 from utils import get_githash, flatten_list, zip_data, s3up, clear_torch_cache, get_torch_allocated, system_info_print, \
     ping, get_short_name, get_url, makedirs
-from finetune import generate_prompt
 from generate import get_model, languages_covered, evaluate, eval_func_param_names, score_qa, langchain_modes, \
     inputs_kwargs_list, get_cutoffs, scratch_base_dir
 

--- a/loaders.py
+++ b/loaders.py
@@ -1,0 +1,50 @@
+def get_loaders(llama_type, model_name, reward_type):
+    # NOTE: Some models need specific new prompt_type
+    # E.g. t5_xxl_true_nli_mixture has input format: "premise: PREMISE_TEXT hypothesis: HYPOTHESIS_TEXT".)
+    if llama_type:
+        from transformers import LlamaForCausalLM, LlamaTokenizer
+        model_loader = LlamaForCausalLM
+        tokenizer_loader = LlamaTokenizer
+    elif 'distilgpt2' in model_name.lower():
+        from transformers import AutoModelForCausalLM, AutoTokenizer
+        return AutoModelForCausalLM, AutoTokenizer
+    elif 'gpt2' in model_name.lower():
+        from transformers import GPT2LMHeadModel, GPT2Tokenizer
+        return GPT2LMHeadModel, GPT2Tokenizer
+    elif 'mbart-' in model_name.lower():
+        from transformers import MBartForConditionalGeneration, MBart50TokenizerFast
+        return MBartForConditionalGeneration, MBart50TokenizerFast
+    elif 't5' == model_name.lower() or \
+         't5-' in model_name.lower() or \
+         'flan-' in model_name.lower():
+        from transformers import AutoTokenizer, T5ForConditionalGeneration
+        return T5ForConditionalGeneration, AutoTokenizer
+    elif 'bigbird' in model_name:
+        from transformers import BigBirdPegasusForConditionalGeneration, AutoTokenizer
+        return BigBirdPegasusForConditionalGeneration, AutoTokenizer
+    elif 'bart-large-cnn-samsum' in model_name or 'flan-t5-base-samsum' in model_name:
+        from transformers import pipeline
+        return pipeline, "summarization"
+    elif reward_type or 'OpenAssistant/reward-model'.lower() in model_name.lower():
+        from transformers import AutoModelForSequenceClassification, AutoTokenizer
+        return AutoModelForSequenceClassification, AutoTokenizer
+    else:
+        from transformers import AutoTokenizer, AutoModelForCausalLM
+        model_loader = AutoModelForCausalLM
+        tokenizer_loader = AutoTokenizer
+    return model_loader, tokenizer_loader
+
+
+def get_tokenizer(tokenizer_loader, tokenizer_base_model, local_files_only, resume_download, use_auth_token):
+    tokenizer = tokenizer_loader.from_pretrained(tokenizer_base_model,
+                                                 local_files_only=local_files_only,
+                                                 resume_download=resume_download,
+                                                 use_auth_token=use_auth_token)
+
+    tokenizer.pad_token_id = 0  # different from the eos token
+    # when generating, we will use the logits of right-most token to predict the next token
+    # so the padding should be on the left,
+    # e.g. see: https://huggingface.co/transformers/v4.11.3/model_doc/t5.html#inference
+    tokenizer.padding_side = "left"  # Allow batched inference
+
+    return tokenizer

--- a/tests/test_prompter.py
+++ b/tests/test_prompter.py
@@ -1,0 +1,26 @@
+from prompter import generate_prompt
+
+example_data_point0 = dict(instruction="Summarize",
+                           input="Ducks eat seeds by the lake, then swim in the lake where fish eat small animals.",
+                           output="Ducks eat and swim at the lake.")
+
+example_data_point1 = dict(instruction="Who is smarter, Einstein or Newton?",
+                           output="Einstein.")
+
+example_data_point2 = dict(input="Who is smarter, Einstein or Newton?",
+                           output="Einstein.")
+
+example_data_points = [example_data_point0, example_data_point1, example_data_point2]
+
+
+def test_train_prompt(prompt_type='instruct', data_point=0):
+    example_data_point = example_data_points[data_point]
+    return generate_prompt(example_data_point, prompt_type, False, False)
+
+
+def test_test_prompt(prompt_type='instruct', data_point=0):
+    example_data_point = example_data_points[data_point]
+    example_data_point.pop('output', None)
+    return generate_prompt(example_data_point, prompt_type, False, False)
+
+


### PR DESCRIPTION
```
============================================================================================= short test summary info =============================================================================================
FAILED tests/test_manual_test.py::test_chat_context - NotImplementedError: MANUAL TEST FOR NOW
FAILED tests/test_manual_test.py::test_upload_one_file - NotImplementedError: MANUAL TEST FOR NOW -- do and ask query of file
FAILED tests/test_manual_test.py::test_upload_multiple_file - NotImplementedError: MANUAL TEST FOR NOW -- do and ask query of files
FAILED tests/test_manual_test.py::test_upload_url - NotImplementedError: MANUAL TEST FOR NOW -- put in URL box https://github.com/h2oai/h2ogpt/ (and ask what is h2ogpt?). Ensure can go to source links
FAILED tests/test_manual_test.py::test_upload_arxiv - NotImplementedError: MANUAL TEST FOR NOW -- paste in arxiv:1706.03762 and ask who wrote attention paper. Ensure can go to source links
FAILED tests/test_manual_test.py::test_upload_pasted_text - NotImplementedError: MANUAL TEST FOR NOW -- do and see test code for what to try
FAILED tests/test_manual_test.py::test_no_db_dirs - NotImplementedError: MANUAL TEST FOR NOW -- Remove db_dirs, ensure can still start up and use in MyData Mode.
FAILED tests/test_manual_test.py::test_upload_unsupported_file - NotImplementedError: MANUAL TEST FOR NOW -- e.g. json, ensure error correct and reasonable, no cascades
FAILED tests/test_manual_test.py::test_upload_to_UserData_and_MyData - NotImplementedError: MANUAL TEST FOR NOW Upload to each when enabled, ensure no failures
FAILED tests/test_manual_test.py::test_chat_control - NotImplementedError: MANUAL TEST FOR NOW save chat, select chats, clear chat, export, import, etc.
================================================================== 10 failed, 37 passed, 25 skipped, 1 xpassed, 2 warnings in 706.87s (0:11:46) ===================================================================
(h2ollm) jon@pseudotensor:~/h2o-llm$ 

```