### PR TITLE
Add CLI mode with tests

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -367,3 +367,30 @@ Ignore this warning.
    - `CUDA_VISIBLE_DEVICES`: Standard list of CUDA devices to make visible.
 
 These can be usful on HuggingFace spaces, where one sets secret tokens because CLI options cannot be used.
+
+### GPT4All not producing output.
+
+Please contact GPT4All team.  Even a basic test can give empty result.
+```python
+>>> from gpt4all import GPT4All as GPT4AllModel
+>>> m = GPT4AllModel('ggml-gpt4all-j-v1.3-groovy.bin')
+Found model file.
+gptj_model_load: loading model from '/home/jon/.cache/gpt4all/ggml-gpt4all-j-v1.3-groovy.bin' - please wait ...
+gptj_model_load: n_vocab = 50400
+gptj_model_load: n_ctx   = 2048
+gptj_model_load: n_embd  = 4096
+gptj_model_load: n_head  = 16
+gptj_model_load: n_layer = 28
+gptj_model_load: n_rot   = 64
+gptj_model_load: f16     = 2
+gptj_model_load: ggml ctx size = 5401.45 MB
+gptj_model_load: kv self size  =  896.00 MB
+gptj_model_load: ................................... done
+gptj_model_load: model size =  3609.38 MB / num tensors = 285
+>>> m.generate('Was Avogadro a  professor at the University of Turin?')
+
+''
+>>>
+```
+Also, the model tends to not do well when input has new lines, spaces or `<br>` work better.
+This does not seem to be an issue with h2oGPT.

--- a/FAQ.md
+++ b/FAQ.md
@@ -394,3 +394,13 @@ gptj_model_load: model size =  3609.38 MB / num tensors = 285
 ```
 Also, the model tends to not do well when input has new lines, spaces or `<br>` work better.
 This does not seem to be an issue with h2oGPT.
+
+### Commercial viability
+
+Open-source means the models are not proprietary and are available to download.  In addition, the license for all of our non-research models is Apache V2, which is a fully permissive license.  Some licenses for other open-source models are not fully permissive, such as StabilityAI's models that are CC-BY-SA that require derivatives to be shared too.
+
+We post models and license and data origin details on our huggingface page: https://huggingface.co/h2oai (all models, except research ones, are fully permissive).  The foundational models we fine-tuned on, e.g. Pythia 6.9B, Pythia 12B, NeoX 20B, or Open-LLaMa checkpoints are fully commercially viable.  These foundational models are also listed on the huggingface page for each fine-tuned model.  Full training logs, source data, etc. are all provided for all models.  [GPT4All](https://github.com/nomic-ai/gpt4all) GPT_J is commercially viable, but other models may not be.  Any Meta based [LLaMa](https://github.com/facebookresearch/llama) based models are not commercially viable.
+
+Data used to fine-tune are provided on the huggingface pages for each model.  Data for foundational models are provided on their huggingface pages.  Any models trained on GPT3.5 data like ShareGPT, Vicuna, Alpaca, etc. are not commercially viable due to ToS violations w.r.t. building competitive models.  Any research-based h2oGPT models based upon Meta's weights for LLaMa are not commercially viable.
+
+Overall, we have done a significant amount of due diligence regarding data and model licenses to carefully select only fully permissive data and models for our models we license as Apache V2.  Outside our models, some "open-source" models like Vicuna, Koala, WizardLM, etc. are based upon Meta's weights for LLaMa, which is not commercially usable due to ToS violations w.r.t. non-competitive clauses well as research-only clauses.  Such models tend to also use data from GPT3.5 (ChatGPT), which is also not commercially usable due to ToS violations w.r.t. non-competitive clauses.  E.g. Alpaca data, ShareGPT data, WizardLM data, etc. all fall under that category. All open-source foundational models consume data from the internet, including the Pile or C4 (web crawl) that may contain objectionable material.  Future licenses w.r.t. new web crawls may change, but it is our understanding that existing data crawls would not be affected by any new licenses.  However, some web crawl data may contain pirated books.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,28 @@ For no langchain support (still uses LangChain package as model wrapper), run as
 python generate.py --base_model=gptj --score_model=None
 ```
 
+### CLI chat
+
+The CLI can be used instead of gradio by running for some base model, e.g.:
+```bash
+python generate.py --base_model=gptj --cli=True
+```
+and for LangChain run:
+```bash
+python make_db.py --user_path=user_path --collection_name=UserData
+python generate.py --base_model=gptj --cli=True --langchain_mode=UserData
+```
+with documents in `user_path` folder, or directly run:
+or
+```bash
+python generate.py --base_model=gptj --cli=True --langchain_mode=UserData --user_path=user_path
+```
+which will build the database first time.
+One can also use any other models, like:
+```bash
+python generate.py --base_model=h2oai/h2ogpt-oig-oasst1-512-6_9b --cli=True
+```
+
 ### Development
 
 - To create a development environment for training and generation, follow the [installation instructions](INSTALL.md).

--- a/README_LangChain.md
+++ b/README_LangChain.md
@@ -115,7 +115,18 @@ For links to direct to the document and download to your local machine, the orig
 
 #### What is h2oGPT's LangChain integration like?
 
-* [PrivateGPT](https://github.com/imartinez/privateGPT) but h2oGPT is fully commercially viable by not using [GPT4All](https://github.com/nomic-ai/gpt4all) based upon [LLaMa](https://github.com/facebookresearch/llama) and used data from GPT3.5 (violation of ToS).
+* [PrivateGPT](https://github.com/imartinez/privateGPT) .  By comparison, h2oGPT has:
+  * UI with chats export, import, selection, regeneration, and undo
+  * UI and document Q/A, upload, download, and list
+  * Choose which specific collection
+  * Choose to get response regarding all documents or specific selected document(s) out of a collection
+  * Choose to chat with LLM, get one-off LLM response to a query, or talk to a collection
+  * GPU support from any hugging face model for highest performance
+  * Upload a many types of docs, from PDFs to images (caption or OCR), URLs, ArXiv queries, or just plain text inputs
+  * Server-Client API through gradio client
+  * RLHF score evaluation for every response
+  * UI with side-by-side model comparisons against two models at a time with independent chat streams
+  * Fine-tuning framework with QLORA 4-bit, 8-bit, 16-bit GPU fine-tuning or CPU fine-tuning
 
 * [Vault-AI](https://github.com/pashpashpash/vault-ai) but h2oGPT is fully private and open-source by not using OpenAI or [pinecone](https://www.pinecone.io/).
 

--- a/README_LangChain.md
+++ b/README_LangChain.md
@@ -118,6 +118,7 @@ For links to direct to the document and download to your local machine, the orig
 * [PrivateGPT](https://github.com/imartinez/privateGPT) .  By comparison, h2oGPT has:
   * UI with chats export, import, selection, regeneration, and undo
   * UI and document Q/A, upload, download, and list
+  * Parallel ingest of documents, using GPUs if present for vector embeddings, with progress bar in stdout
   * Choose which specific collection
   * Choose to get response regarding all documents or specific selected document(s) out of a collection
   * Choose to chat with LLM, get one-off LLM response to a query, or talk to a collection

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,92 @@
+import copy
+import torch
+
+from generate import eval_func_param_names, get_score_model, get_model, evaluate
+from utils import clear_torch_cache, NullContext, get_kwargs
+
+
+def run_cli(  # for local function:
+        base_model=None, lora_weights=None,
+        debug=None, chat_context=None,
+        examples=None, is_low_mem=None,
+        # for get_model:
+        score_model=None, load_8bit=None, load_4bit=None, load_half=None, infer_devices=None, tokenizer_base_model=None,
+        gpu_id=None, local_files_only=None, resume_download=None, use_auth_token=None,
+        trust_remote_code=None, offload_folder=None, compile_model=None,
+        # for some evaluate args
+        stream_output=None, prompt_type=None, temperature=None, top_p=None, top_k=None, num_beams=None,
+        max_new_tokens=None, min_new_tokens=None, early_stopping=None, max_time=None, repetition_penalty=None,
+        num_return_sequences=None, do_sample=None, chat=None,
+        langchain_mode=None, document_choice=None, top_k_docs=None,
+        # for evaluate kwargs
+        src_lang=None, tgt_lang=None, concurrency_count=None, save_dir=None, sanitize_bot_response=None,
+        model_state0=None, raise_generate_gpu_exceptions=None, load_db_if_exists=None, dbs=None, user_path=None,
+        use_openai_embedding=None, use_openai_model=None, hf_embedding_model=None, chunk=None, chunk_size=None,
+        db_type=None, n_jobs=None, first_para=None, text_limit=None, verbose=None, cli=None,
+        # unique to this function:
+        cli_loop=None,
+):
+    score_model = ""  # FIXME: For now, so user doesn't have to pass
+    n_gpus = torch.cuda.device_count() if torch.cuda.is_available else 0
+    device = 'cpu' if n_gpus == 0 else 'cuda'
+    context_class = NullContext if n_gpus > 1 or n_gpus == 0 else torch.device
+
+    with context_class(device):
+        from functools import partial
+
+        # get score model
+        smodel, stokenizer, sdevice = get_score_model(reward_type=True,
+                                                      **get_kwargs(get_score_model, exclude_names=['reward_type'],
+                                                                   **locals()))
+
+        model, tokenizer, device = get_model(reward_type=False,
+                                             **get_kwargs(get_model, exclude_names=['reward_type'], **locals()))
+        model_state = [model, tokenizer, device, base_model]
+        my_db_state = [None]
+        fun = partial(evaluate, model_state, my_db_state,
+                      **get_kwargs(evaluate, exclude_names=['model_state', 'my_db_state'] + eval_func_param_names,
+                                   **locals()))
+
+        clear_torch_cache()
+
+        example1 = examples[-1]  # pick reference example
+        all_generations = []
+        while True:
+            instruction = input("\nEnter an instruction: ")
+            if instruction == "exit":
+                break
+
+            eval_vars = copy.deepcopy(example1)
+            eval_vars[eval_func_param_names.index('instruction')] = \
+                eval_vars[eval_func_param_names.index('instruction_nochat')] = instruction
+            eval_vars[eval_func_param_names.index('iinput')] = \
+                eval_vars[eval_func_param_names.index('iinput_nochat')] = ''  # no input yet
+            eval_vars[eval_func_param_names.index('context')] = ''  # no context yet
+
+            # grab other parameters, like langchain_mode
+            for k in eval_func_param_names:
+                if k in locals():
+                    eval_vars[eval_func_param_names.index(k)] = locals()[k]
+
+            gener = fun(*tuple(eval_vars))
+            outr = ''
+            res_old = ''
+            for res, extra in gener:
+                if base_model not in ['gptj', 'llama']:
+                    if not stream_output:
+                        print(res)
+                    else:
+                        # then stream output for gradio that has full output each generation, so need here to show only new chars
+                        diff = res[len(res_old):]
+                        print(diff, end='', flush=True)
+                        res_old = res
+                    outr = res  # don't accumulate
+                else:
+                    outr += res  # just is one thing
+                    if extra:
+                        # show sources at end after model itself had streamed to std rest of response
+                        print(extra, flush=True)
+            all_generations.append(outr + '\n')
+            if not cli_loop:
+                break
+    return all_generations

--- a/eval.py
+++ b/eval.py
@@ -1,15 +1,11 @@
-import inspect
 import os
 import traceback
-from typing import Union
-
 import numpy as np
 import pandas as pd
 import torch
 from matplotlib import pyplot as plt
 
-from generate import eval_func_param_names, eval_extra_columns, get_context, get_score_model, get_model, \
-    inputs_kwargs_list, evaluate
+from generate import eval_func_param_names, eval_extra_columns, get_context, get_score_model, get_model, evaluate
 from prompter import Prompter
 from utils import clear_torch_cache, NullContext, get_kwargs
 
@@ -27,7 +23,7 @@ def run_eval(  # for local function:
         src_lang=None, tgt_lang=None, concurrency_count=None, save_dir=None, sanitize_bot_response=None,
         model_state0=None, raise_generate_gpu_exceptions=None, load_db_if_exists=None, dbs=None, user_path=None,
         use_openai_embedding=None, use_openai_model=None, hf_embedding_model=None, chunk=None, chunk_size=None,
-        db_type=None, n_jobs=None, first_para=None, text_limit=None,
+        db_type=None, n_jobs=None, first_para=None, text_limit=None, verbose=None, cli=None,
 ):
     if eval_sharegpt_prompts_only > 0:
         # override default examples with shareGPT ones for human-level eval purposes only
@@ -122,7 +118,8 @@ def run_eval(  # for local function:
             # fun yields as generator, so have to iterate over it
             # Also means likely do NOT want --stream_output=True, else would show all generations
             gener = fun(*tuple(ex), exi=exi) if eval_sharegpt_as_output else fun(*tuple(ex))
-            for res in gener:
+            for res_fun in gener:
+                res, extra = res_fun
                 print(res)
                 if smodel:
                     score_with_prompt = False

--- a/gpt4all_llm.py
+++ b/gpt4all_llm.py
@@ -1,5 +1,6 @@
 import inspect
 import os
+import sys
 from typing import Dict, Any, Optional, List
 from langchain.callbacks.manager import CallbackManagerForLLMRun
 from pydantic import root_validator
@@ -47,6 +48,19 @@ def get_model_tokenizer_gpt4all(base_model, **kwargs):
     return model, FakeTokenizer(), 'cpu'
 
 
+from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
+
+
+class H2OStreamingStdOutCallbackHandler(StreamingStdOutCallbackHandler):
+
+    def on_llm_new_token(self, token: str, **kwargs: Any) -> None:
+        """Run on new LLM token. Only available when streaming is enabled."""
+        # streaming to std already occurs without this
+        # sys.stdout.write(token)
+        # sys.stdout.flush()
+        pass
+
+
 def get_llm_gpt4all(model_name, model=None,
                     max_new_tokens=256,
                     temperature=0.1,
@@ -55,8 +69,7 @@ def get_llm_gpt4all(model_name, model=None,
                     top_p=0.7):
     env_gpt4all_file = ".env_gpt4all"
     model_kwargs = dotenv_values(env_gpt4all_file)
-    from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
-    callbacks = [StreamingStdOutCallbackHandler()]
+    callbacks = [H2OStreamingStdOutCallbackHandler()]
     n_ctx = model_kwargs.pop('n_ctx', 1024)
     default_params = {'context_erase': 0.5, 'n_batch': 1, 'n_ctx': n_ctx, 'n_predict': max_new_tokens,
                       'repeat_last_n': 64 if repetition_penalty != 1.0 else 0, 'repeat_penalty': repetition_penalty,

--- a/gradio_runner.py
+++ b/gradio_runner.py
@@ -174,7 +174,7 @@ body.dark{#warning {background-color: #555555};}
         my_db_state = gr.State([None, None])
         chat_state = gr.State({})
         # make user default first and default choice, dedup
-        docs_state00 = [kwargs['document_choice'], 'All', 'Only', 'None']
+        docs_state00 = kwargs['document_choice'] + ['All', 'Only', 'None']
         docs_state0 = []
         [docs_state0.append(x) for x in docs_state00 if x not in docs_state0]
         docs_state = gr.State(docs_state0)  # first is chosen as default

--- a/gradio_runner.py
+++ b/gradio_runner.py
@@ -173,7 +173,10 @@ body.dark{#warning {background-color: #555555};}
         lora_options_state = gr.State([lora_options])
         my_db_state = gr.State([None, None])
         chat_state = gr.State({})
-        docs_state0 = ['All', 'Only', 'None']
+        # make user default first and default choice, dedup
+        docs_state00 = [kwargs['document_choice'], 'All', 'Only', 'None']
+        docs_state0 = []
+        [docs_state0.append(x) for x in docs_state00 if x not in docs_state0]
         docs_state = gr.State(docs_state0)  # first is chosen as default
         gr.Markdown(f"""
             {get_h2o_title(title) if kwargs['h2ocolors'] else get_simple_title(title)}
@@ -924,7 +927,8 @@ body.dark{#warning {background-color: #555555};}
                            my_db_state1,
                            **kwargs_evaluate)
             try:
-                for output in fun1(*tuple(args_list)):
+                for output_fun in fun1(*tuple(args_list)):
+                    output, extra = output_fun
                     # ensure good visually, else markdown ignores multiple \n
                     bot_message = output.replace('\n', '<br>')
                     history[-1][1] = bot_message

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,70 @@
+from tests.utils import wrap_test_forked
+
+
+@wrap_test_forked
+def test_cli(monkeypatch):
+    query = "What is the Earth?"
+    monkeypatch.setattr('builtins.input', lambda _: query)
+
+    from generate import main
+    all_generations = main(base_model='gptj', cli=True, cli_loop=False, score_model='None')
+
+    assert len(all_generations) == 1
+    assert "The Earth is a planet in our solar system that orbits around the Sun." in all_generations[0]
+
+
+@wrap_test_forked
+def test_cli_langchain(monkeypatch):
+    from tests.utils import make_user_path_test
+    user_path = make_user_path_test()
+
+    query = "What is the cat doing?"
+    monkeypatch.setattr('builtins.input', lambda _: query)
+
+    from generate import main
+    all_generations = main(base_model='gptj', cli=True, cli_loop=False, score_model='None',
+                           langchain_mode='UserData',
+                           user_path=user_path,
+                           visible_langchain_modes=['UserData', 'MyData'],
+                           document_choice=['All'],
+                           verbose=True)
+
+    print(all_generations)
+    assert len(all_generations) == 1
+    assert "pexels-evg-kowalievska-1170986_small.jpg" in all_generations[0]
+    assert "looking out the window" in all_generations[0]
+
+
+@wrap_test_forked
+def test_cli_h2ogpt(monkeypatch):
+    query = "What is the Earth?"
+    monkeypatch.setattr('builtins.input', lambda _: query)
+
+    from generate import main
+    all_generations = main(base_model='h2oai/h2ogpt-oig-oasst1-512-6_9b', cli=True, cli_loop=False, score_model='None')
+
+    assert len(all_generations) == 1
+    assert "The Earth is a planet in the Solar System." in all_generations[0]
+
+
+@wrap_test_forked
+def test_cli_langchain_h2ogpt(monkeypatch):
+    from tests.utils import make_user_path_test
+    user_path = make_user_path_test()
+
+    query = "What is the cat doing?"
+    monkeypatch.setattr('builtins.input', lambda _: query)
+
+    from generate import main
+    all_generations = main(base_model='h2oai/h2ogpt-oig-oasst1-512-6_9b',
+                           cli=True, cli_loop=False, score_model='None',
+                           langchain_mode='UserData',
+                           user_path=user_path,
+                           visible_langchain_modes=['UserData', 'MyData'],
+                           document_choice=['All'],
+                           verbose=True)
+
+    print(all_generations)
+    assert len(all_generations) == 1
+    assert "pexels-evg-kowalievska-1170986_small.jpg" in all_generations[0]
+    assert "looking out the window" in all_generations[0]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+import pytest
+
 from tests.utils import wrap_test_forked
 
 
@@ -13,6 +15,8 @@ def test_cli(monkeypatch):
     assert "The Earth is a planet in our solar system that orbits around the Sun." in all_generations[0]
 
 
+@pytest.mark.xfail(strict=False, reason="GPT4All produces no output if input has new lines etc."
+                                        "  See FAQ.md, outside h2oGPT same thing even for single line inputs.")
 @wrap_test_forked
 def test_cli_langchain(monkeypatch):
     from tests.utils import make_user_path_test

--- a/tests/test_client_calls.py
+++ b/tests/test_client_calls.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tests.utils import wrap_test_forked
+from tests.utils import wrap_test_forked, make_user_path_test
 
 
 @wrap_test_forked
@@ -67,19 +67,7 @@ def test_client_chat_stream():
 
 @wrap_test_forked
 def test_client_chat_stream_langchain():
-    import os
-    import shutil
-
-    user_path = 'user_path_test'
-    if os.path.isdir(user_path):
-        shutil.rmtree(user_path)
-    os.makedirs(user_path)
-    db_dir = "db_dir_UserData"
-    if os.path.isdir(db_dir):
-        shutil.rmtree(db_dir)
-    shutil.copy('data/pexels-evg-kowalievska-1170986_small.jpg', user_path)
-    shutil.copy('README.md', user_path)
-    shutil.copy('FAQ.md', user_path)
+    user_path = make_user_path_test()
     prompt = "What is h2oGPT?"
     res_dict = run_client_chat(prompt=prompt, stream_output=True, langchain_mode="UserData", user_path=user_path,
                                visible_langchain_modes=['UserData', 'MyData'])

--- a/tests/test_client_calls.py
+++ b/tests/test_client_calls.py
@@ -24,21 +24,21 @@ def test_client1():
 
 @wrap_test_forked
 def test_client_chat_nostream():
-    res_dict = run_client_chat(stream_output=False)
+    res_dict, client = run_client_chat_with_server(stream_output=False)
     assert 'I am h2oGPT' in res_dict['response'] or "I'm h2oGPT" in res_dict['response'] or 'I’m h2oGPT' in res_dict[
         'response']
 
 
 @wrap_test_forked
 def test_client_chat_nostream_gpt4all():
-    res_dict = run_client_chat(stream_output=False, base_model='gptj', prompt_type='plain')
+    res_dict, client = run_client_chat_with_server(stream_output=False, base_model='gptj', prompt_type='plain')
     assert 'I am a computer program designed to assist' in res_dict['response']
 
 
-def run_client_chat(prompt='Who are you?', stream_output=False, max_new_tokens=256,
-                    base_model='h2oai/h2ogpt-oig-oasst1-512-6_9b', prompt_type='human_bot',
-                    langchain_mode='Disabled', user_path=None,
-                    visible_langchain_modes=['UserData', 'MyData']):
+def run_client_chat_with_server(prompt='Who are you?', stream_output=False, max_new_tokens=256,
+                                base_model='h2oai/h2ogpt-oig-oasst1-512-6_9b', prompt_type='human_bot',
+                                langchain_mode='Disabled', user_path=None,
+                                visible_langchain_modes=['UserData', 'MyData']):
     import os, sys
     if langchain_mode == 'Disabled':
         os.environ['TEST_LANGCHAIN_IMPORT'] = "1"
@@ -53,33 +53,129 @@ def run_client_chat(prompt='Who are you?', stream_output=False, max_new_tokens=2
          visible_langchain_modes=visible_langchain_modes)
 
     from client_test import run_client_chat
-    res_dict = run_client_chat(prompt=prompt, prompt_type='human_bot', stream_output=stream_output,
-                               max_new_tokens=max_new_tokens, langchain_mode=langchain_mode)
+    res_dict, client = run_client_chat(prompt=prompt, prompt_type='human_bot', stream_output=stream_output,
+                                       max_new_tokens=max_new_tokens, langchain_mode=langchain_mode)
     assert res_dict['prompt'] == prompt
     assert res_dict['iinput'] == ''
-    return res_dict
+    return res_dict, client
 
 
 @wrap_test_forked
 def test_client_chat_stream():
-    run_client_chat(stream_output=True)
+    run_client_chat_with_server(stream_output=True)
 
 
 @wrap_test_forked
 def test_client_chat_stream_langchain():
     user_path = make_user_path_test()
     prompt = "What is h2oGPT?"
-    res_dict = run_client_chat(prompt=prompt, stream_output=True, langchain_mode="UserData", user_path=user_path,
-                               visible_langchain_modes=['UserData', 'MyData'])
+    res_dict, client = run_client_chat_with_server(prompt=prompt, stream_output=True, langchain_mode="UserData",
+                                                   user_path=user_path,
+                                                   visible_langchain_modes=['UserData', 'MyData'])
     # below wouldn't occur if didn't use LangChain with README.md,
     # raw LLM tends to ramble about H2O.ai and what it does regardless of question.
     assert 'h2oGPT is a large language model' in res_dict['response']
 
 
 @wrap_test_forked
+def test_client_chat_stream_langchain_steps():
+    user_path = make_user_path_test()
+
+    stream_output = True
+    max_new_tokens = 256
+    base_model = 'h2oai/h2ogpt-oig-oasst1-512-6_9b'
+    prompt_type = 'human_bot'
+    langchain_mode = 'UserData'
+    visible_langchain_modes = ['UserData', 'MyData']
+
+    from generate import main
+    main(base_model=base_model, prompt_type=prompt_type, chat=True,
+         stream_output=stream_output, gradio=True, num_beams=1, block_gradio_exit=False,
+         max_new_tokens=max_new_tokens,
+         langchain_mode=langchain_mode, user_path=user_path,
+         visible_langchain_modes=visible_langchain_modes)
+
+    from client_test import get_client, get_args, run_client
+    client = get_client(serialize=False)
+
+    # QUERY1
+    prompt = "What is h2oGPT?"
+    langchain_mode = 'UserData'
+    kwargs, args = get_args(prompt, prompt_type, chat=True, stream_output=stream_output,
+                            max_new_tokens=max_new_tokens, langchain_mode=langchain_mode)
+
+    res_dict, client = run_client(client, prompt, args, kwargs)
+    assert 'a large language model' in res_dict['response'] and 'FAQ.md' in res_dict['response']
+
+    # QUERY2
+    prompt = "What is h2oGPT?"
+    langchain_mode = 'ChatLLM'
+    kwargs, args = get_args(prompt, prompt_type, chat=True, stream_output=stream_output,
+                            max_new_tokens=max_new_tokens, langchain_mode=langchain_mode)
+
+    res_dict, client = run_client(client, prompt, args, kwargs)
+    # i.e. answers wrongly without data, dumb model, but also no docs at all since cutoff entirely
+    assert 'H2O.ai is a technology company' in res_dict['response'] and '.md' not in res_dict['response']
+
+    # QUERY3
+    prompt = "What is whisper?"
+    langchain_mode = 'UserData'
+    kwargs, args = get_args(prompt, prompt_type, chat=True, stream_output=stream_output,
+                            max_new_tokens=max_new_tokens, langchain_mode=langchain_mode)
+
+    res_dict, client = run_client(client, prompt, args, kwargs)
+    # odd answer since no whisper docs, but still shows some docs at very low score
+    assert 'Whisper is a secure messaging app' in res_dict['response'] and '.md' in res_dict['response']
+
+
+@wrap_test_forked
+def test_client_chat_stream_langchain_steps2():
+    # full user data
+    from make_db import make_db_main
+    make_db_main(download_some=True)
+    user_path = None  # shouldn't be necessary, db already made
+
+    stream_output = True
+    max_new_tokens = 256
+    base_model = 'h2oai/h2ogpt-oig-oasst1-512-6_9b'
+    prompt_type = 'human_bot'
+    langchain_mode = 'UserData'
+    visible_langchain_modes = ['UserData', 'MyData']
+
+    from generate import main
+    main(base_model=base_model, prompt_type=prompt_type, chat=True,
+         stream_output=stream_output, gradio=True, num_beams=1, block_gradio_exit=False,
+         max_new_tokens=max_new_tokens,
+         langchain_mode=langchain_mode, user_path=user_path,
+         visible_langchain_modes=visible_langchain_modes,
+         verbose=True)
+
+    from client_test import get_client, get_args, run_client
+    client = get_client(serialize=False)
+
+    # QUERY1
+    prompt = "Who are you?"
+    langchain_mode = 'ChatLLM'
+    kwargs, args = get_args(prompt, prompt_type, chat=True, stream_output=stream_output,
+                            max_new_tokens=max_new_tokens, langchain_mode=langchain_mode)
+
+    res_dict, client = run_client(client, prompt, args, kwargs)
+    assert 'a large language model' in res_dict['response'] and 'FAQ.md' not in res_dict['response']
+
+    # QUERY2
+    prompt = "What is whisper?"
+    langchain_mode = 'UserData'
+    kwargs, args = get_args(prompt, prompt_type, chat=True, stream_output=stream_output,
+                            max_new_tokens=max_new_tokens, langchain_mode=langchain_mode)
+
+    res_dict, client = run_client(client, prompt, args, kwargs)
+    assert 'speech recognition system' in res_dict['response'] and 'whisper.pdf' in res_dict['response']
+
+
+@wrap_test_forked
 def test_client_chat_stream_long():
     prompt = 'Tell a very long story about cute birds for kids.'
-    res_dict = run_client_chat(prompt=prompt, stream_output=True, max_new_tokens=1024)
+    res_dict, client = run_client_chat_with_server(prompt=prompt, stream_output=True, max_new_tokens=1024)
     assert 'Once upon a time' in res_dict['response']
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,3 +16,19 @@ def wrap_test_forked(func):
 
 def run_test(func, *args, **kwargs):
     return func(*args, **kwargs)
+
+
+def make_user_path_test():
+    import os
+    import shutil
+    user_path = 'user_path_test'
+    if os.path.isdir(user_path):
+        shutil.rmtree(user_path)
+    os.makedirs(user_path)
+    db_dir = "db_dir_UserData"
+    if os.path.isdir(db_dir):
+        shutil.rmtree(db_dir)
+    shutil.copy('data/pexels-evg-kowalievska-1170986_small.jpg', user_path)
+    shutil.copy('README.md', user_path)
+    shutil.copy('FAQ.md', user_path)
+    return user_path


### PR DESCRIPTION
```
(h2ollm) jon@pseudotensor:~/h2o-llm$ python generate.py --base_model=h2oai/h2ogpt-oig-oasst1-512-6_9b --cli=True

===================================BUG REPORT===================================
Welcome to bitsandbytes. For bug reports, please run

python -m bitsandbytes

 and submit this information together with your error trace to: https://github.com/TimDettmers/bitsandbytes/issues
================================================================================
bin /home/jon/miniconda3/envs/h2ollm/lib/python3.10/site-packages/bitsandbytes/libbitsandbytes_cuda121.so
/home/jon/miniconda3/envs/h2ollm/lib/python3.10/site-packages/bitsandbytes/cuda_setup/main.py:149: UserWarning: /home/jon/miniconda3/envs/h2ollm did not contain ['libcudart.so', 'libcudart.so.11.0', 'libcudart.so.12.0'] as expected! Searching further paths...
  warn(msg)
/home/jon/miniconda3/envs/h2ollm/lib/python3.10/site-packages/bitsandbytes/cuda_setup/main.py:149: UserWarning: WARNING: The following directories listed in your path were found to be non-existent: {PosixPath('/opt/clang+llvm-4.0.0-x86_64-linux-gnu-ubuntu-16.04/lib'), PosixPath('/opt/rstudio-1.0.136/bin'), PosixPath('/usr/local/cuda/extras/CUPTI/lib64'), PosixPath('/usr/lib/jvm/default-java/jre/lib/amd64/server'), PosixPath('/home/jon/lib')}
  warn(msg)
CUDA SETUP: CUDA runtime path found: /usr/local/cuda/lib64/libcudart.so
CUDA SETUP: Highest compute capability among GPUs detected: 7.5
CUDA SETUP: Detected CUDA version 121
CUDA SETUP: Loading binary /home/jon/miniconda3/envs/h2ollm/lib/python3.10/site-packages/bitsandbytes/libbitsandbytes_cuda121.so...
Using Model h2oai/h2ogpt-oig-oasst1-512-6_9b
device_map: {'': 0}
Loading checkpoint shards: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:06<00:00,  2.10s/it]

Enter an instruction: Who are you?
Using pad_token, but it is not set yet.
Pre-Generate: 2023-05-26 18:49:36.334195
Generate: 2023-05-26 18:49:36.334220
Hi! I'm h2oGPT, a large language model by H2O.ai, the visionary leader in democratizing AI. How can I help you?Post-Generate: 2023-05-26 18:49:38.308654 decoded_output: 149

Enter an instruction: 
```


```
(h2ollm) jon@pseudotensor:~/h2o-llm$ python generate.py --base_model=gptj --cli=True --score_model=None

===================================BUG REPORT===================================
Welcome to bitsandbytes. For bug reports, please run

python -m bitsandbytes

 and submit this information together with your error trace to: https://github.com/TimDettmers/bitsandbytes/issues
================================================================================
bin /home/jon/miniconda3/envs/h2ollm/lib/python3.10/site-packages/bitsandbytes/libbitsandbytes_cuda121.so
/home/jon/miniconda3/envs/h2ollm/lib/python3.10/site-packages/bitsandbytes/cuda_setup/main.py:149: UserWarning: /home/jon/miniconda3/envs/h2ollm did not contain ['libcudart.so', 'libcudart.so.11.0', 'libcudart.so.12.0'] as expected! Searching further paths...
  warn(msg)
/home/jon/miniconda3/envs/h2ollm/lib/python3.10/site-packages/bitsandbytes/cuda_setup/main.py:149: UserWarning: WARNING: The following directories listed in your path were found to be non-existent: {PosixPath('/usr/local/cuda/extras/CUPTI/lib64'), PosixPath('/opt/rstudio-1.0.136/bin'), PosixPath('/usr/lib/jvm/default-java/jre/lib/amd64/server'), PosixPath('/opt/clang+llvm-4.0.0-x86_64-linux-gnu-ubuntu-16.04/lib'), PosixPath('/home/jon/lib')}
  warn(msg)
CUDA SETUP: CUDA runtime path found: /usr/local/cuda/lib64/libcudart.so
CUDA SETUP: Highest compute capability among GPUs detected: 7.5
CUDA SETUP: Detected CUDA version 121
CUDA SETUP: Loading binary /home/jon/miniconda3/envs/h2ollm/lib/python3.10/site-packages/bitsandbytes/libbitsandbytes_cuda121.so...
Using Model gptj
Found model file.
gptj_model_load: loading model from '/home/jon/.cache/gpt4all/ggml-gpt4all-j-v1.3-groovy.bin' - please wait ...
gptj_model_load: n_vocab = 50400
gptj_model_load: n_ctx   = 2048
gptj_model_load: n_embd  = 4096
gptj_model_load: n_head  = 16
gptj_model_load: n_layer = 28
gptj_model_load: n_rot   = 64
gptj_model_load: f16     = 2
gptj_model_load: ggml ctx size = 5401.45 MB
gptj_model_load: kv self size  =  896.00 MB
gptj_model_load: ................................... done
gptj_model_load: model size =  3609.38 MB / num tensors = 285

Enter an instruction: Who are you?
I am a computer program designed to assist users with various tasks. I can help them find information, answer questions, and perform calculations.

Enter an instruction: 

```



```
================================================================================================================ short test summary info ================================================================================================================
FAILED tests/test_eval.py::test_eval1[False-4] - TypeError: GPTNeoXForCausalLM.__init__() got an unexpected keyword argument 'load_in_4bit'
FAILED tests/test_manual_test.py::test_chat_context - NotImplementedError: MANUAL TEST FOR NOW
FAILED tests/test_manual_test.py::test_upload_one_file - NotImplementedError: MANUAL TEST FOR NOW -- do and ask query of file
FAILED tests/test_manual_test.py::test_upload_multiple_file - NotImplementedError: MANUAL TEST FOR NOW -- do and ask query of files
FAILED tests/test_manual_test.py::test_upload_url - NotImplementedError: MANUAL TEST FOR NOW -- put in URL box https://github.com/h2oai/h2ogpt/ (and ask what is h2ogpt?). Ensure can go to source links
FAILED tests/test_manual_test.py::test_upload_arxiv - NotImplementedError: MANUAL TEST FOR NOW -- paste in arxiv:1706.03762 and ask who wrote attention paper. Ensure can go to source links
FAILED tests/test_manual_test.py::test_upload_pasted_text - NotImplementedError: MANUAL TEST FOR NOW -- do and see test code for what to try
FAILED tests/test_manual_test.py::test_no_db_dirs - NotImplementedError: MANUAL TEST FOR NOW -- Remove db_dirs, ensure can still start up and use in MyData Mode.
FAILED tests/test_manual_test.py::test_upload_unsupported_file - NotImplementedError: MANUAL TEST FOR NOW -- e.g. json, ensure error correct and reasonable, no cascades
FAILED tests/test_manual_test.py::test_upload_to_UserData_and_MyData - NotImplementedError: MANUAL TEST FOR NOW Upload to each when enabled, ensure no failures
FAILED tests/test_manual_test.py::test_chat_control - NotImplementedError: MANUAL TEST FOR NOW save chat, select chats, clear chat, export, import, etc.
FAILED tests/test_manual_test.py::test_subset_only - NotImplementedError: MANUAL TEST FOR NOW UserData, Select Only for subset, then put in whisper.  Ensure get back only chunks of data with url links to data sources.
================================================================================ 12 failed, 48 passed, 25 skipped, 1 xfailed, 1 xpassed, 2 warnings in 906.22s (0:15:06) ================================================================================
(h2ollm) jon@pseudotensor:~/h2o-llm$ 

```