### PR TITLE
Generalize h2oai_pipeline so works for any instruct model we have prompt_type for, so run_db_qa will stream and stop just like non-db code path

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -708,8 +708,7 @@ def get_model(
 
     if hasattr(config, 'max_position_embeddings') and isinstance(config.max_position_embeddings, int):
         # help automatically limit inputs to generate
-        tokenizer.model_max_length = \
-            config.max_position_embeddings
+        tokenizer.model_max_length = config.max_position_embeddings
     else:
         tokenizer.model_max_length = 2048
 

--- a/gpt_langchain.py
+++ b/gpt_langchain.py
@@ -153,6 +153,7 @@ def get_llm(use_openai_model=False, model_name=None, model=None,
             # only used if didn't pass model in
             assert model_name is None
             assert tokenizer is None
+            prompt_type = 'human_bot'
             model_name = 'h2oai/h2ogpt-oasst1-512-12b'
             # model_name = 'h2oai/h2ogpt-oig-oasst1-512-6_9b'
             # model_name = 'h2oai/h2ogpt-oasst1-512-20b'
@@ -894,10 +895,11 @@ def _run_qa_db(query=None,
     :return:
     """
     assert query is not None
-
-    assert prompter is not None
-    prompt_type = prompter.prompt_type
-    assert prompt_type is not None
+    assert prompter is not None or prompt_type is not None or model is None  # if model is None, then will generate
+    if prompter is not None:
+        prompt_type = prompter.prompt_type
+    if model is not None:
+        assert prompt_type is not None
     llm, model_name, streamer, prompt_type_out = get_llm(use_openai_model=use_openai_model, model_name=model_name,
                                                          model=model, tokenizer=tokenizer,
                                                          stream_output=stream_output,

--- a/gpt_langchain.py
+++ b/gpt_langchain.py
@@ -128,12 +128,14 @@ def get_llm(use_openai_model=False, model_name=None, model=None,
             top_k=40,
             top_p=0.7,
             prompt_type=None,
+            prompter=None,
             ):
     if use_openai_model:
         from langchain.llms import OpenAI
         llm = OpenAI(temperature=0)
         model_name = 'openai'
         streamer = None
+        prompt_type = 'plain'
     elif model_name in ['gptj', 'llama']:
         from gpt4all_llm import get_llm_gpt4all
         llm = get_llm_gpt4all(model_name, model=model, max_new_tokens=max_new_tokens,
@@ -169,7 +171,9 @@ def get_llm(use_openai_model=False, model_name=None, model=None,
 
         max_max_tokens = tokenizer.model_max_length
         gen_kwargs = dict(max_new_tokens=max_new_tokens,
-                          return_full_text=True, early_stopping=False)
+                          return_full_text=True,
+                          early_stopping=False,
+                          handle_long_generation='hole')
 
         if stream_output:
             skip_prompt = False
@@ -180,18 +184,19 @@ def get_llm(use_openai_model=False, model_name=None, model=None,
         else:
             streamer = None
 
-        if 'h2ogpt' in model_name or prompt_type == 'human_bot':
-            from h2oai_pipeline import H2OTextGenerationPipeline
-            gen_kwargs.update(dict(max_input_tokens=max_max_tokens - max_new_tokens))
-            pipe = H2OTextGenerationPipeline(model=model, tokenizer=tokenizer, **gen_kwargs)
-            # pipe.task = "text-generation"
-            # below makes it listen only to our prompt removal, not built in prompt removal that is less general and not specific for our model
-            pipe.task = "text2text-generation"
-            prompt_type = 'human_bot'
-        else:
-            # only for non-instruct tuned cases when ok with just normal next token prediction
-            from transformers import pipeline
-            pipe = pipeline("text-generation", model=model, tokenizer=tokenizer, **gen_kwargs)
+        from h2oai_pipeline import H2OTextGenerationPipeline
+        pipe = H2OTextGenerationPipeline(model=model, use_prompter=True,
+                                         prompter=prompter,
+                                         prompt_type=prompt_type,
+                                         sanitize_bot_response=True,
+                                         chat=False, stream_output=stream_output,
+                                         tokenizer=tokenizer,
+                                         max_input_tokens=max_max_tokens - max_new_tokens,
+                                         **gen_kwargs)
+        # pipe.task = "text-generation"
+        # below makes it listen only to our prompt removal,
+        # not built in prompt removal that is less general and not specific for our model
+        pipe.task = "text2text-generation"
 
         from langchain.llms import HuggingFacePipeline
         llm = HuggingFacePipeline(pipeline=pipe)
@@ -890,7 +895,9 @@ def _run_qa_db(query=None,
     """
     assert query is not None
 
-    prompt_type = prompter.prompt_type if prompter is not None else prompt_type
+    assert prompter is not None
+    prompt_type = prompter.prompt_type
+    assert prompt_type is not None
     llm, model_name, streamer, prompt_type_out = get_llm(use_openai_model=use_openai_model, model_name=model_name,
                                                          model=model, tokenizer=tokenizer,
                                                          stream_output=stream_output,
@@ -900,6 +907,7 @@ def _run_qa_db(query=None,
                                                          top_k=top_k,
                                                          top_p=top_p,
                                                          prompt_type=prompt_type,
+                                                         prompter=prompter,
                                                          )
 
     if model_name in ['llama', 'gptj']:

--- a/h2oai_pipeline.py
+++ b/h2oai_pipeline.py
@@ -2,36 +2,34 @@ from transformers import TextGenerationPipeline
 from transformers.pipelines.text_generation import ReturnType
 
 from stopping import get_stopping
-
-prompt_type = "human_bot"
-human = "<human>:"
-bot = "<bot>:"
-
-# human-bot interaction like OIG dataset
-prompt = """{human} {instruction}
-{bot}""".format(
-    human=human,
-    instruction="{instruction}",
-    bot=bot,
-)
+from prompter import Prompter
 
 
 class H2OTextGenerationPipeline(TextGenerationPipeline):
-    def __init__(self, *args, use_prompter=False, debug=False, chat=False, stream_output=False,
-                 sanitize_bot_response=True, max_input_tokens=2048 - 256, **kwargs):
+    def __init__(self, *args, debug=False, chat=False, stream_output=False,
+                 sanitize_bot_response=True,
+                 use_prompter=False, prompter=None, prompt_type=None,
+                 max_input_tokens=2048 - 256, **kwargs):
         super().__init__(*args, **kwargs)
-        self.use_prompter = use_prompter
         self.prompt_text = None
+        self.use_prompter = use_prompter
+        self.prompt_type = prompt_type
+        self.prompter = prompter
         if self.use_prompter:
-            from prompter import Prompter
-            self.prompter = Prompter(prompt_type, debug=debug, chat=chat, stream_output=stream_output)
+            if self.prompter is not None:
+                assert self.prompter.prompt_type is not None
+            else:
+                self.prompter = Prompter(self.prompt_type, debug=debug, chat=chat, stream_output=stream_output)
+            self.human = self.prompter.humanstr
+            self.bot = self.prompter.botstr
         else:
             self.prompter = None
         self.sanitize_bot_response = sanitize_bot_response
         self.max_input_tokens = max_input_tokens  # not for generate, so ok that not kwargs
 
     def preprocess(self, prompt_text, prefix="", handle_long_generation=None, **generate_kwargs):
-        prompt_text = prompt.format(instruction=prompt_text)
+        data_point = dict(context='', instruction=prompt_text, input='')
+        prompt_text = self.prompter.generate_prompt(data_point)
         self.prompt_text = prompt_text
         if handle_long_generation is None:
             # forces truncation of inputs to avoid critical failure
@@ -48,12 +46,12 @@ class H2OTextGenerationPipeline(TextGenerationPipeline):
                 outputs = self.prompter.get_response(outputs, prompt=self.prompt_text,
                                                      sanitize_bot_response=self.sanitize_bot_response)
             else:
-                outputs = rec['generated_text'].split(bot)[1].strip().split(human)[0].strip()
+                outputs = rec['generated_text'].split(self.bot)[1].strip().split(self.human)[0].strip()
             rec['generated_text'] = outputs
         return records
 
     def _forward(self, model_inputs, **generate_kwargs):
-        stopping_criteria = get_stopping(prompt_type, self.tokenizer, self.device, human=human, bot=bot)
+        stopping_criteria = get_stopping(self.prompt_type, self.tokenizer, self.device, human=self.human, bot=self.bot)
         generate_kwargs['stopping_criteria'] = stopping_criteria
         # return super()._forward(model_inputs, **generate_kwargs)
         return self.__forward(model_inputs, **generate_kwargs)

--- a/tests/test_langchain_simple.py
+++ b/tests/test_langchain_simple.py
@@ -8,15 +8,17 @@ def test_langchain_simple():
     from h2oai_pipeline import H2OTextGenerationPipeline
 
     model_name = 'h2oai/h2ogpt-oasst1-512-12b'
+    prompt_type = 'human_bot'  # prompt_type required for stopping support and correct handling of instruction prompting
     load_in_8bit = True
     n_gpus = torch.cuda.device_count() if torch.cuda.is_available else 0
     device = 'cpu' if n_gpus == 0 else 'cuda'
     device_map = {"": 0} if device == 'cuda' else "auto"
     tokenizer = AutoTokenizer.from_pretrained(model_name, padding_side="left")
-    model = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype=torch.bfloat16, device_map=device_map, load_in_8bit=load_in_8bit)
+    model = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype=torch.bfloat16, device_map=device_map,
+                                                 load_in_8bit=load_in_8bit)
 
     gen_kwargs = dict(max_new_tokens=512, return_full_text=True, early_stopping=False)
-    pipe = H2OTextGenerationPipeline(model=model, tokenizer=tokenizer, **gen_kwargs)
+    pipe = H2OTextGenerationPipeline(model=model, tokenizer=tokenizer, prompt_type=prompt_type, **gen_kwargs)
     # below makes it listen only to our prompt removal, not built in prompt removal that is less general and not specific for our model
     pipe.task = "text2text-generation"
 
@@ -44,4 +46,3 @@ def test_langchain_simple():
     answer = chain(chain_kwargs)
     print(answer)
     assert 'Einstein' in answer['output_text'] and "Newton" in answer['output_text']
-


### PR DESCRIPTION
- [x] Have prompt_type and even stopping for instruct_vicuna, but junelee/wizard-vicuna-13b was using normal HF pipeline, that only works for plain case.  Now streams and stops and everything else properly for db case too.
- [x] Avoid specialized pipeline code, just pass in prompter if have one, or generate from prompt_type.

This now works properly (human-bot like stuff put in) and also streams properly (before was only showing up at end with sources and unstopped LLM response):
```
python generate.py --base_model=junelee/wizard-vicuna-13b --load_8bit=True --debug=True --h2ocolors=False
```

![image](https://github.com/h2oai/h2ogpt/assets/2249614/3f31bdac-6cc2-4d1c-bc67-77262ae940e7)



```
============================================================================================================ short test summary info ============================================================================================================
FAILED tests/test_manual_test.py::test_chat_context - NotImplementedError: MANUAL TEST FOR NOW
FAILED tests/test_manual_test.py::test_upload_one_file - NotImplementedError: MANUAL TEST FOR NOW -- do and ask query of file
FAILED tests/test_manual_test.py::test_upload_multiple_file - NotImplementedError: MANUAL TEST FOR NOW -- do and ask query of files
FAILED tests/test_manual_test.py::test_upload_url - NotImplementedError: MANUAL TEST FOR NOW -- put in URL box https://github.com/h2oai/h2ogpt/ (and ask what is h2ogpt?). Ensure can go to source links
FAILED tests/test_manual_test.py::test_upload_arxiv - NotImplementedError: MANUAL TEST FOR NOW -- paste in arxiv:1706.03762 and ask who wrote attention paper. Ensure can go to source links
FAILED tests/test_manual_test.py::test_upload_pasted_text - NotImplementedError: MANUAL TEST FOR NOW -- do and see test code for what to try
FAILED tests/test_manual_test.py::test_no_db_dirs - NotImplementedError: MANUAL TEST FOR NOW -- Remove db_dirs, ensure can still start up and use in MyData Mode.
FAILED tests/test_manual_test.py::test_upload_unsupported_file - NotImplementedError: MANUAL TEST FOR NOW -- e.g. json, ensure error correct and reasonable, no cascades
FAILED tests/test_manual_test.py::test_upload_to_UserData_and_MyData - NotImplementedError: MANUAL TEST FOR NOW Upload to each when enabled, ensure no failures
FAILED tests/test_manual_test.py::test_chat_control - NotImplementedError: MANUAL TEST FOR NOW save chat, select chats, clear chat, export, import, etc.
FAILED tests/test_manual_test.py::test_subset_only - NotImplementedError: MANUAL TEST FOR NOW UserData, Select Only for subset, then put in whisper.  Ensure get back only chunks of data with url links to data sources.
=========================================================================== 11 failed, 57 passed, 25 skipped, 1 xfailed, 1 xpassed, 2 warnings in 1007.15s (0:16:47) ============================================================================
(h2ollm) jon@pseudotensor:~/h2o-llm$ 

```