### PR TITLE
Ensure can use offline

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -178,6 +178,8 @@ See models that are currently supported in this automatic way, and the same dict
 
 Note, when running `generate.py` and asking your first question, it will download the model(s), which for the 6.9B model takes about 15 minutes per 3 pytorch bin files if have 10MB/s download.
 
+If all data has been put into `~/.cache` by HF transformers, then these following steps (those related to downloading HF models) are not required.
+
 1) Download model and tokenizer of choice
 
 ```python
@@ -208,29 +210,20 @@ from langchain.embeddings import HuggingFaceEmbeddings
 embedding = HuggingFaceEmbeddings(model_name=hf_embedding_model, model_kwargs=model_kwargs)
 ```
 
-4) Gradio uses Cloudfare scripts, download from Cloudfare:
-```
-iframeResizer.contentWindow.min.js
-index-8bb1e421.js
-``` 
-place them into python environment at:
-```
-site-packages/gradio/templates/cdn/assets
-site-packages/gradio/templates/frontend/assets
-```
-
-5) For jupyterhub dashboard,  modify `index-8bb1e421.js` to remove or hardcode port number into urls where `/port/7860` is located.  One may have to modify:
-```
-templates/cdn/index.html
-templates/frontend/index.html
-templates/frontend/share.html
-```
- 
-6) Run generate with transformers in [Offline Mode](https://huggingface.co/docs/transformers/installation#offline-mode)
+4) Run generate with transformers in [Offline Mode](https://huggingface.co/docs/transformers/installation#offline-mode)
 
 ```bash
-HF_DATASETS_OFFLINE=1 TRANSFORMERS_OFFLINE=1 python generate.py --base_model='h2oai/h2ogpt-oasst1-512-12b'
+HF_DATASETS_OFFLINE=1 TRANSFORMERS_OFFLINE=1 python generate.py --base_model='h2oai/h2ogpt-oasst1-512-12b' --gradio_offline_level=2
 ```
+
+Some code is always disabled that involves uploads out of user control: Huggingface telemetry, gradio telemetry, chromadb posthog.
+
+The additional option `--gradio_offline_level=2` changes fonts to avoid download of google fonts. This option disables google fonts for downloading, which is less intrusive than uploading, but still required in air-gapped case.  The fonts don't look as nice as google fonts, but ensure full offline behavior.
+
+If the front-end can still access internet, but just backend should not, then one can use `--gradio_offline_level=1` for slightly better-looking fonts.
+
+Note that gradio attempts to download [iframeResizer.contentWindow.min.js](https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.1/iframeResizer.contentWindow.min.js),
+but nothing prevents gradio from working without this.  So a simple firewall block is sufficient.  For more details, see: https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/10324.
 
 ### Isolated LangChain Usage:
 

--- a/generate.py
+++ b/generate.py
@@ -9,9 +9,14 @@ import os
 import time
 import traceback
 import typing
+import warnings
 from datetime import datetime
 import filelock
 import psutil
+
+os.environ['HF_HUB_DISABLE_TELEMETRY'] = '1'
+os.environ['BITSANDBYTES_NOWELCOME'] = '1'
+warnings.filterwarnings('ignore', category=UserWarning, message='TypedStorage is deprecated')
 
 from loaders import get_loaders
 from utils import set_seed, clear_torch_cache, save_generate_output, NullContext, wrapped_partial, EThread, get_githash, \
@@ -22,7 +27,6 @@ import_matplotlib()
 SEED = 1236
 set_seed(SEED)
 
-os.environ['HF_HUB_DISABLE_TELEMETRY'] = '1'
 from typing import Union
 
 import fire
@@ -83,6 +87,7 @@ def main(
         cli_loop: bool = True,
         gradio: bool = True,
         gradio_avoid_processing_markdown: bool = False,
+        gradio_offline_level: int = 0,
         chat: bool = True,
         chat_context: bool = False,
         stream_output: bool = True,
@@ -174,6 +179,12 @@ def main(
     :param cli_loop: whether to loop for CLI (False usually only for testing)
     :param gradio: whether to enable gradio, or to enable benchmark mode
     :param gradio_avoid_processing_markdown:
+    :param gradio_offline_level: > 0, then change fonts so full offline
+           == 1 means backend won't need internet for fonts, but front-end UI might if font not cached
+           == 2 means backend and frontend don't need internet to download any fonts.
+           Note: Some things always disabled include HF telemetry, gradio telemetry, chromadb posthog that involve uploading.
+           This option further disables google fonts for downloading, which is less intrusive than uploading,
+           but still required in air-gapped case.  The fonts don't look as nice as google fonts, but ensure full offline behavior.
     :param chat: whether to enable chat mode with chat history
     :param chat_context: whether to use extra helpful context if human_bot
     :param stream_output: whether to stream output from generate

--- a/gpt_langchain.py
+++ b/gpt_langchain.py
@@ -727,6 +727,10 @@ def prep_langchain(persist_directory, load_db_if_exists, db_type, use_openai_emb
     return db
 
 
+import posthog
+posthog.disabled = True
+
+
 def get_existing_db(persist_directory, load_db_if_exists, db_type, use_openai_embedding, langchain_mode,
                     hf_embedding_model):
     if load_db_if_exists and db_type == 'chroma' and os.path.isdir(persist_directory) and os.path.isdir(

--- a/gradio_themes.py
+++ b/gradio_themes.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
+
+from typing import Iterable
+
 from gradio.themes.soft import Soft
 from gradio.themes import Color
-from gradio.themes.utils import colors, sizes
+from gradio.themes.utils import colors, sizes, fonts
 
 h2o_yellow = Color(
     name="yellow",
@@ -43,6 +46,22 @@ class H2oTheme(Soft):
             spacing_size: sizes.Size | str = sizes.spacing_md,
             radius_size: sizes.Size | str = sizes.radius_md,
             text_size: sizes.Size | str = sizes.text_lg,
+            font: fonts.Font
+            | str
+            | Iterable[fonts.Font | str] = (
+                fonts.GoogleFont("Montserrat"),
+                "ui-sans-serif",
+                "system-ui",
+                "sans-serif",
+            ),
+            font_mono: fonts.Font
+            | str
+            | Iterable[fonts.Font | str] = (
+                fonts.GoogleFont("IBM Plex Mono"),
+                "ui-monospace",
+                "Consolas",
+                "monospace",
+            ),
     ):
         super().__init__(
             primary_hue=primary_hue,
@@ -51,6 +70,8 @@ class H2oTheme(Soft):
             spacing_size=spacing_size,
             radius_size=radius_size,
             text_size=text_size,
+            font=font,
+            font_mono=font_mono,
         )
         super().set(
             link_text_color="#3344DD",
@@ -89,6 +110,22 @@ class SoftTheme(Soft):
             spacing_size: sizes.Size | str = sizes.spacing_md,
             radius_size: sizes.Size | str = sizes.radius_md,
             text_size: sizes.Size | str = sizes.text_md,
+            font: fonts.Font
+            | str
+            | Iterable[fonts.Font | str] = (
+                fonts.GoogleFont("Montserrat"),
+                "ui-sans-serif",
+                "system-ui",
+                "sans-serif",
+            ),
+            font_mono: fonts.Font
+            | str
+            | Iterable[fonts.Font | str] = (
+                fonts.GoogleFont("IBM Plex Mono"),
+                "ui-monospace",
+                "Consolas",
+                "monospace",
+            ),
     ):
         super().__init__(
             primary_hue=primary_hue,
@@ -97,6 +134,8 @@ class SoftTheme(Soft):
             spacing_size=spacing_size,
             radius_size=radius_size,
             text_size=text_size,
+            font=font,
+            font_mono=font_mono,
         )
 
 


### PR DESCRIPTION
```
============================================================================================================ short test summary info ============================================================================================================
FAILED tests/test_manual_test.py::test_chat_context - NotImplementedError: MANUAL TEST FOR NOW
FAILED tests/test_manual_test.py::test_upload_one_file - NotImplementedError: MANUAL TEST FOR NOW -- do and ask query of file
FAILED tests/test_manual_test.py::test_upload_multiple_file - NotImplementedError: MANUAL TEST FOR NOW -- do and ask query of files
FAILED tests/test_manual_test.py::test_upload_url - NotImplementedError: MANUAL TEST FOR NOW -- put in URL box https://github.com/h2oai/h2ogpt/ (and ask what is h2ogpt?). Ensure can go to source links
FAILED tests/test_manual_test.py::test_upload_arxiv - NotImplementedError: MANUAL TEST FOR NOW -- paste in arxiv:1706.03762 and ask who wrote attention paper. Ensure can go to source links
FAILED tests/test_manual_test.py::test_upload_pasted_text - NotImplementedError: MANUAL TEST FOR NOW -- do and see test code for what to try
FAILED tests/test_manual_test.py::test_no_db_dirs - NotImplementedError: MANUAL TEST FOR NOW -- Remove db_dirs, ensure can still start up and use in MyData Mode.
FAILED tests/test_manual_test.py::test_upload_unsupported_file - NotImplementedError: MANUAL TEST FOR NOW -- e.g. json, ensure error correct and reasonable, no cascades
FAILED tests/test_manual_test.py::test_upload_to_UserData_and_MyData - NotImplementedError: MANUAL TEST FOR NOW Upload to each when enabled, ensure no failures
FAILED tests/test_manual_test.py::test_chat_control - NotImplementedError: MANUAL TEST FOR NOW save chat, select chats, clear chat, export, import, etc.
FAILED tests/test_manual_test.py::test_subset_only - NotImplementedError: MANUAL TEST FOR NOW UserData, Select Only for subset, then put in whisper.  Ensure get back only chunks of data with url links to data sources.
=========================================================================== 11 failed, 58 passed, 25 skipped, 1 xfailed, 1 xpassed, 2 warnings in 1143.81s (0:19:03) ============================================================================
(h2ollm) jon@pseudotensor:~/h2o-llm$ 

```

See also:

https://github.com/gradio-app/gradio/issues/1450#issuecomment-1504353760
https://github.com/oobabooga/text-generation-webui/commit/649e4017a5646403f86c813a8471286cb5f98da2
https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/10024