### PR TITLE
Fix and test llamacpp

### DIFF
--- a/.env_gpt4all
+++ b/.env_gpt4all
@@ -2,11 +2,9 @@
 
 # GPT4ALl GPT-J type, from model explorer choice, so downloads
 model_name_gptj=ggml-gpt4all-j-v1.3-groovy.bin
-model_path_gptj=.
 
 # llama-cpp-python type, supporting version 3 quantization, here from locally built llama.cpp q4 v3 quantization
 model_path_llama=./models/7B/ggml-model-q4_0.bin
 
 # GPT4ALl LLaMa type, supporting version 2 quantization, here from model explorer choice so downloads
 model_name_gpt4all_llama=ggml-wizardLM-7B.q4_2.bin
-model_path_gpt4all_llama=.

--- a/.env_gpt4all
+++ b/.env_gpt4all
@@ -1,2 +1,10 @@
-# GPT4ALL model_kwargs
+# GPT4ALL or llama-cpp-python model_kwargs
+
+# GPT4ALl GPT-J type
 model_path_gptj=ggml-gpt4all-j-v1.3-groovy.bin
+
+# llama-cpp-python type, supporting version 3 quantization
+model_path_llama=./models/7B/ggml-model-q4_0.bin
+
+# GPT4ALl LLaMa type, supporting version 2 quantization
+model_path_gpt4all_llama=./models/7B/ggml-model-q4_0.bin

--- a/.env_gpt4all
+++ b/.env_gpt4all
@@ -1,10 +1,12 @@
 # GPT4ALL or llama-cpp-python model_kwargs
 
-# GPT4ALl GPT-J type
-model_path_gptj=ggml-gpt4all-j-v1.3-groovy.bin
+# GPT4ALl GPT-J type, from model explorer choice, so downloads
+model_name_gptj=ggml-gpt4all-j-v1.3-groovy.bin
+model_path_gptj=.
 
-# llama-cpp-python type, supporting version 3 quantization
+# llama-cpp-python type, supporting version 3 quantization, here from locally built llama.cpp q4 v3 quantization
 model_path_llama=./models/7B/ggml-model-q4_0.bin
 
-# GPT4ALl LLaMa type, supporting version 2 quantization
-model_path_gpt4all_llama=./models/7B/ggml-model-q4_0.bin
+# GPT4ALl LLaMa type, supporting version 2 quantization, here from model explorer choice so downloads
+model_name_gpt4all_llama=ggml-wizardLM-7B.q4_2.bin
+model_path_gpt4all_llama=.

--- a/FAQ.md
+++ b/FAQ.md
@@ -295,7 +295,7 @@ python convert.py models/7B/
 # test by running the inference
 ./main -m ./models/7B/ggml-model-q4_0.bin -n 128
 ```
-then adding an entry in the .env file like
+then adding an entry in the .env file like (assumes version 3 quantization)
 ```.env_gpt4all
 # model path and model_kwargs
 model_path_llama=./models/7B/ggml-model-q4_0.bin
@@ -310,7 +310,7 @@ then run h2oGPT like:
 python generate.py --base_model='llama' --langchain_mode=UserData --user_path=user_path
 ```
 
-### is this really a GGML file?
+### is this really a GGML file? Or Using version 2 quantization files from GPT4All that are LLaMa based
 
 If hit error:
 ```text
@@ -320,14 +320,15 @@ error loading model: unknown (magic, version) combination: 67676a74, 00000003; i
 llama_init_from_file: failed to load model
 LLAMA ERROR: failed to load model from ./models/7B/ggml-model-q4_0.bin
 ```
-then note that llama.cpp upgraded to version 3, and we use llama-cpp-python version that supports only that latest version 3.  GPT4All does not support version 3 yet.  If you want to support older version 2 llama quantized models, then
-
-If hit:
-then try:
+then note that llama.cpp upgraded to version 3, and we use llama-cpp-python version that supports only that latest version 3.  GPT4All does not support version 3 yet.  If you want to support older version 2 llama quantized models, then do:
 ```bash
-ip install --force-reinstall --ignore-installed --no-cache-dir llama-cpp-python==0.1.48
+pip install --force-reinstall --ignore-installed --no-cache-dir llama-cpp-python==0.1.48
 ```
-to go back to the prior version
+to go back to the prior version.  Or specify the model using GPT4All as `--base_model='gpt4all_llama` and ensure entry exists like:
+```.env_gpt4all
+model_path_gpt4all_llama=./models/7B/ggml-model-q4_0.bin
+```
+assuming that file is from version 2 quantization.
 
 ### I get the error: `The model 'OptimizedModule' is not supported for . Supported models are ...`
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,7 +14,7 @@ conda create -n h2ogpt -y
 conda activate h2ogpt
 conda install mamba -n base -c conda-forge
 conda install python=3.10 -y
-conda update -n base -c defaults conda
+conda update -n base -c defaults conda -y 
 ```
 Enter new shell and should also see `(base)` in prompt.  Then, create new env:
 ```bash

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,7 +14,7 @@ conda create -n h2ogpt -y
 conda activate h2ogpt
 conda install mamba -n base -c conda-forge
 conda install python=3.10 -y
-conda update -n base -c defaults conda -y 
+conda update -n base -c defaults conda -y
 ```
 Enter new shell and should also see `(base)` in prompt.  Then, create new env:
 ```bash

--- a/cli.py
+++ b/cli.py
@@ -2,6 +2,7 @@ import copy
 import torch
 
 from generate import eval_func_param_names, get_score_model, get_model, evaluate
+from prompter import non_hf_types
 from utils import clear_torch_cache, NullContext, get_kwargs
 
 
@@ -72,7 +73,7 @@ def run_cli(  # for local function:
             outr = ''
             res_old = ''
             for res, extra in gener:
-                if base_model not in ['gptj', 'llama']:
+                if base_model not in non_hf_types:
                     if not stream_output:
                         print(res)
                     else:

--- a/generate.py
+++ b/generate.py
@@ -35,7 +35,7 @@ from peft import PeftModel
 from transformers import GenerationConfig, AutoModel, TextIteratorStreamer
 from accelerate import init_empty_weights, infer_auto_device_map
 
-from prompter import Prompter, inv_prompt_type_to_model_lower
+from prompter import Prompter, inv_prompt_type_to_model_lower, non_hf_types
 from stopping import get_stopping
 
 eval_extra_columns = ['prompt', 'response', 'score']
@@ -572,7 +572,7 @@ def get_model(
     """
     if verbose:
         print("Get %s model" % base_model, flush=True)
-    if base_model in ['llama', 'gptj']:
+    if base_model in non_hf_types:
         from gpt4all_llm import get_model_tokenizer_gpt4all
         model, tokenizer, device = get_model_tokenizer_gpt4all(base_model)
         return model, tokenizer, device
@@ -924,8 +924,7 @@ def evaluate(
         db1 = dbs[langchain_mode]
     else:
         db1 = None
-    if langchain_mode not in [False, 'Disabled', 'ChatLLM', 'LLM'] and db1 is not None or base_model in ['llama',
-                                                                                                         'gptj']:
+    if langchain_mode not in [False, 'Disabled', 'ChatLLM', 'LLM'] and db1 is not None or base_model in non_hf_types:
         query = instruction if not iinput else "%s\n%s" % (instruction, iinput)
         outr = ""
         # use smaller cut_distanct for wiki_full since so many matches could be obtained, and often irrelevant unless close
@@ -967,7 +966,7 @@ def evaluate(
                 print(
                     'Post-Generate Langchain: %s decoded_output: %s' % (str(datetime.now()), len(outr) if outr else -1),
                     flush=True)
-        if outr or base_model in ['llama', 'gptj']:
+        if outr or base_model in non_hf_types:
             # if got no response (e.g. not showing sources and got no sources,
             # so nothing to give to LLM), then slip through and ask LLM
             # Or if llama/gptj, then just return since they had no response and can't go down below code path

--- a/gpt4all_llm.py
+++ b/gpt4all_llm.py
@@ -82,14 +82,21 @@ def get_llm_gpt4all(model_name, model=None,
     default_params = {'context_erase': 0.5, 'n_batch': 1, 'n_ctx': n_ctx, 'n_predict': max_new_tokens,
                       'repeat_last_n': 64 if repetition_penalty != 1.0 else 0, 'repeat_penalty': repetition_penalty,
                       'temp': temperature, 'top_k': top_k, 'top_p': top_p}
-    if model_name in ['llama', 'gpt4all_llama']:
+    if model_name == 'llama':
         model_path = model_kwargs.pop('model_path_llama') if model is None else model
         llm = H2OLlamaCpp(model_path=model_path, n_ctx=n_ctx, callbacks=callbacks, verbose=False)
-    else:
+    elif model_name == 'gpt4all_llama':
+        model_path = model_kwargs.pop('model_path_gpt4all_llama') if model is None else model
+        llm = H2OGPT4All(model=model_path, backend='llama', callbacks=callbacks,
+                         verbose=False, **default_params,
+                         )
+    elif model_name == 'gptj':
         model_path = model_kwargs.pop('model_path_gptj') if model is None else model
         llm = H2OGPT4All(model=model_path, backend='gptj', callbacks=callbacks,
                          verbose=False, **default_params,
                          )
+    else:
+        raise RuntimeError("No such model_name %s" % model_name)
     return llm
 
 

--- a/gpt4all_llm.py
+++ b/gpt4all_llm.py
@@ -40,19 +40,17 @@ def get_model_tokenizer_gpt4all(base_model, **kwargs):
     elif base_model in "gpt4all_llama":
         if 'model_name_gpt4all_llama' not in model_kwargs and 'model_path_gpt4all_llama' not in model_kwargs:
             raise ValueError("No model_name_gpt4all_llama or model_path_gpt4all_llama in %s" % env_gpt4all_file)
-        model_path = model_kwargs.pop('model_path_gpt4all_llama', './')
-        model_name = model_kwargs.pop('model_name_gpt4all_llama', os.path.basename(model_path))
+        model_name = model_kwargs.pop('model_name_gpt4all_llama')
         model_type = 'llama'
         from gpt4all import GPT4All as GPT4AllModel
-        model = GPT4AllModel(model_name=model_name, model_path=model_path, model_type=model_type)
+        model = GPT4AllModel(model_name=model_name, model_type=model_type)
     elif base_model in "gptj":
         if 'model_name_gptj' not in model_kwargs and 'model_path_gptj' not in model_kwargs:
             raise ValueError("No model_name_gpt4j or model_path_gpt4j in %s" % env_gpt4all_file)
-        model_path = model_kwargs.pop('model_path_gptj', './')
         model_name = model_kwargs.pop('model_name_gptj')
         model_type = 'gptj'
         from gpt4all import GPT4All as GPT4AllModel
-        model = GPT4AllModel(model_name=model_name, model_path=model_path, model_type=model_type)
+        model = GPT4AllModel(model_name=model_name, model_type=model_type)
     else:
         raise ValueError("No such base_model %s" % base_model)
     return model, FakeTokenizer(), 'cpu'

--- a/gpt_langchain.py
+++ b/gpt_langchain.py
@@ -19,6 +19,7 @@ from operator import concat
 from joblib import Parallel, delayed
 from tqdm import tqdm
 
+from prompter import non_hf_types
 from utils import wrapped_partial, EThread, import_matplotlib, sanitize_filename, makedirs, get_url, flatten_list, \
     get_device, ProgressParallel
 
@@ -136,7 +137,7 @@ def get_llm(use_openai_model=False, model_name=None, model=None,
         model_name = 'openai'
         streamer = None
         prompt_type = 'plain'
-    elif model_name in ['gptj', 'llama']:
+    elif model_name in non_hf_types:
         from gpt4all_llm import get_llm_gpt4all
         llm = get_llm_gpt4all(model_name, model=model, max_new_tokens=max_new_tokens,
                               temperature=temperature,
@@ -916,7 +917,7 @@ def _run_qa_db(query=None,
                                                          prompter=prompter,
                                                          )
 
-    if model_name in ['llama', 'gptj']:
+    if model_name in non_hf_types:
         # FIXME: for now, streams to stdout/stderr currently
         stream_output = False
 
@@ -1002,7 +1003,7 @@ def get_similarity_chain(query=None,
                          llm=None,
                          verbose=False,
                          ):
-    if not use_openai_model and prompt_type not in ['plain'] or model_name in ['llama', 'gptj']:
+    if not use_openai_model and prompt_type not in ['plain'] or model_name in non_hf_types:
         # instruct-like, rather than few-shot prompt_type='plain' as default
         # but then sources confuse the model with how inserted among rest of text, so avoid
         prefix = ""

--- a/gradio_runner.py
+++ b/gradio_runner.py
@@ -26,7 +26,7 @@ requests.get = original_get
 
 from gradio_themes import H2oTheme, SoftTheme, get_h2o_title, get_simple_title, get_dark_js
 from prompter import Prompter, \
-    prompt_type_to_model_name, prompt_types_strings, inv_prompt_type_to_model_lower, generate_prompt
+    prompt_type_to_model_name, prompt_types_strings, inv_prompt_type_to_model_lower, generate_prompt, non_hf_types
 from utils import get_githash, flatten_list, zip_data, s3up, clear_torch_cache, get_torch_allocated, system_info_print, \
     ping, get_short_name, get_url, makedirs, get_kwargs
 from generate import get_model, languages_covered, evaluate, eval_func_param_names, score_qa, langchain_modes, \
@@ -1410,7 +1410,7 @@ body.dark{#warning {background-color: #555555};}
     scheduler = BackgroundScheduler()
     scheduler.add_job(func=clear_torch_cache, trigger="interval", seconds=20)
     if is_public and \
-            kwargs['base_model'] not in ['gptj', 'llama']:
+            kwargs['base_model'] not in non_hf_types:
         # FIXME: disable for gptj, langchain or gpt4all modify print itself
         # FIXME: and any multi-threaded/async print will enter model output!
         scheduler.add_job(func=ping, trigger="interval", seconds=60)
@@ -1419,7 +1419,7 @@ body.dark{#warning {background-color: #555555};}
     # import control
     if kwargs['langchain_mode'] == 'Disabled' and \
             os.environ.get("TEST_LANGCHAIN_IMPORT") and \
-            kwargs['base_model'] not in ['gptj', 'llama']:
+            kwargs['base_model'] not in non_hf_types:
         assert 'gpt_langchain' not in sys.modules, "Dev bug, import of langchain when should not have"
         assert 'langchain' not in sys.modules, "Dev bug, import of langchain when should not have"
 

--- a/prompter.py
+++ b/prompter.py
@@ -2,6 +2,9 @@ import time
 from enum import Enum
 
 
+non_hf_types = ['gpt4all_llama', 'llama', 'gptj']
+
+
 class PromptType(Enum):
     plain = 0
     instruct = 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,9 +21,6 @@ bitsandbytes==0.39.0
 accelerate==0.19.0
 git+https://github.com/huggingface/peft.git@3714aa2fff158fdfa637b2b65952580801d890b2
 transformers==4.28.1
-# below can be used for 4-bit training
-# git+https://github.com/huggingface/accelerate.git@0226f750257b3bf2cadc4f189f9eef0c764a0467
-# git+https://github.com/huggingface/transformers.git@f67dac97bdc63874f2288546b3fa87e69d2ea1c8
 tokenizers==0.13.3
 APScheduler==3.10.1
 

--- a/requirements_optional_gpt4all.txt
+++ b/requirements_optional_gpt4all.txt
@@ -1,3 +1,3 @@
 gpt4all==0.2.3
-llama-cpp-python==0.1.54
+llama-cpp-python==0.1.55
 python-dotenv==1.0.0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,6 +40,28 @@ def test_cli_langchain(monkeypatch):
 
 
 @wrap_test_forked
+def test_cli_langchain_llamacpp(monkeypatch):
+    from tests.utils import make_user_path_test
+    user_path = make_user_path_test()
+
+    query = "What is the cat doing?"
+    monkeypatch.setattr('builtins.input', lambda _: query)
+
+    from generate import main
+    all_generations = main(base_model='llama', cli=True, cli_loop=False, score_model='None',
+                           langchain_mode='UserData',
+                           user_path=user_path,
+                           visible_langchain_modes=['UserData', 'MyData'],
+                           document_choice=['All'],
+                           verbose=True)
+
+    print(all_generations)
+    assert len(all_generations) == 1
+    assert "pexels-evg-kowalievska-1170986_small.jpg" in all_generations[0]
+    assert "What is the cat thinking about?" in all_generations[0]
+
+
+@wrap_test_forked
 def test_cli_h2ogpt(monkeypatch):
     query = "What is the Earth?"
     monkeypatch.setattr('builtins.input', lambda _: query)

--- a/tests/test_client_calls.py
+++ b/tests/test_client_calls.py
@@ -40,6 +40,12 @@ def test_client_chat_nostream_gpt4all():
 
 
 @wrap_test_forked
+def test_client_chat_nostream_gpt4all_llama():
+    res_dict, client = run_client_chat_with_server(stream_output=False, base_model='gpt4all_llama', prompt_type='plain')
+    assert 'What do you want? Why are you here?' in res_dict['response']
+
+
+@wrap_test_forked
 def test_client_chat_nostream_llama7b():
     from huggingface_hub import hf_hub_download
 

--- a/tests/test_client_calls.py
+++ b/tests/test_client_calls.py
@@ -58,6 +58,7 @@ def test_client_chat_nostream_llama7b():
         # True for case when locally already logged in with correct token, so don't have to set key
         token = os.getenv('HUGGINGFACE_API_TOKEN', True)
         out_path = hf_hub_download('h2oai/ggml', file, token=token, repo_type='model')
+        # out_path will look like '/home/jon/.cache/huggingface/hub/models--h2oai--ggml/snapshots/57e79c71bb0cee07e3e3ffdea507105cd669fa96/ggml-model-q4_0_7b.bin'
         shutil.copy(out_path, dest)
 
     res_dict, client = run_client_chat_with_server(stream_output=False, base_model='llama', prompt_type='plain')

--- a/tests/test_client_calls.py
+++ b/tests/test_client_calls.py
@@ -1,6 +1,10 @@
+import os
+import shutil
+
 import pytest
 
 from tests.utils import wrap_test_forked, make_user_path_test
+from utils import makedirs
 
 
 @wrap_test_forked
@@ -33,6 +37,25 @@ def test_client_chat_nostream():
 def test_client_chat_nostream_gpt4all():
     res_dict, client = run_client_chat_with_server(stream_output=False, base_model='gptj', prompt_type='plain')
     assert 'I am a computer program designed to assist' in res_dict['response']
+
+
+@wrap_test_forked
+def test_client_chat_nostream_llama7b():
+    from huggingface_hub import hf_hub_download
+
+    file = 'ggml-model-q4_0_7b.bin'
+    dest = 'models/7B/'
+    makedirs(dest, exist_ok=True)
+    full_path = os.path.join(dest, file)
+
+    if not os.path.isfile(full_path):
+        # True for case when locally already logged in with correct token, so don't have to set key
+        token = os.getenv('HUGGINGFACE_API_TOKEN', True)
+        out_path = hf_hub_download('h2oai/ggml', file, token=token, repo_type='model')
+        shutil.copy(out_path, dest)
+
+    res_dict, client = run_client_chat_with_server(stream_output=False, base_model='llama', prompt_type='plain')
+    assert 'Why do you want to know?' in res_dict['response']
 
 
 def run_client_chat_with_server(prompt='Who are you?', stream_output=False, max_new_tokens=256,


### PR DESCRIPTION
Now properly supports:

* GPT4All gptj: downloads to cache, no local file choice
* GPT4All llama (version 2 quant), downloads to cache, no local file choice
* llama-cpp-python's llama (version 3 quant)

Saw odd garbling from model had downloaded myself from  model explorer, so sticking to internal cache downloader for GPT4All.

gptj from GPT4all still has the "no output" issue, even natively.  So best to stick to llama.cpp version IMO, e.g. by downloading a version 3 quantization llama.cpp model, or build one yourself as in FAQ.md, and then doing:

```
python generate.py --base_model='llama' --langchain_mode=UserData --user_path=user_path --score_model=None
```


Tests:
```
============================================================================================================ short test summary info ============================================================================================================
FAILED tests/test_manual_test.py::test_chat_context - NotImplementedError: MANUAL TEST FOR NOW
FAILED tests/test_manual_test.py::test_upload_one_file - NotImplementedError: MANUAL TEST FOR NOW -- do and ask query of file
FAILED tests/test_manual_test.py::test_upload_multiple_file - NotImplementedError: MANUAL TEST FOR NOW -- do and ask query of files
FAILED tests/test_manual_test.py::test_upload_url - NotImplementedError: MANUAL TEST FOR NOW -- put in URL box https://github.com/h2oai/h2ogpt/ (and ask what is h2ogpt?). Ensure can go to source links
FAILED tests/test_manual_test.py::test_upload_arxiv - NotImplementedError: MANUAL TEST FOR NOW -- paste in arxiv:1706.03762 and ask who wrote attention paper. Ensure can go to source links
FAILED tests/test_manual_test.py::test_upload_pasted_text - NotImplementedError: MANUAL TEST FOR NOW -- do and see test code for what to try
FAILED tests/test_manual_test.py::test_no_db_dirs - NotImplementedError: MANUAL TEST FOR NOW -- Remove db_dirs, ensure can still start up and use in MyData Mode.
FAILED tests/test_manual_test.py::test_upload_unsupported_file - NotImplementedError: MANUAL TEST FOR NOW -- e.g. json, ensure error correct and reasonable, no cascades
FAILED tests/test_manual_test.py::test_upload_to_UserData_and_MyData - NotImplementedError: MANUAL TEST FOR NOW Upload to each when enabled, ensure no failures
FAILED tests/test_manual_test.py::test_chat_control - NotImplementedError: MANUAL TEST FOR NOW save chat, select chats, clear chat, export, import, etc.
FAILED tests/test_manual_test.py::test_subset_only - NotImplementedError: MANUAL TEST FOR NOW UserData, Select Only for subset, then put in whisper.  Ensure get back only chunks of data with url links to data sources.
=========================================================================== 11 failed, 60 passed, 25 skipped, 1 xfailed, 1 xpassed, 2 warnings in 1198.21s (0:19:58) ============================================================================
(h2ollm) jon@pseudotensor:~/h2o-llm$ 

```