### PR TITLE
Improve use of ctx vs. max_new_tokens for non-HF models, and if no docs, don't insert == since no docs, just confuses model

### DIFF
--- a/.env_gpt4all
+++ b/.env_gpt4all
@@ -5,6 +5,8 @@ model_name_gptj=ggml-gpt4all-j-v1.3-groovy.bin
 
 # llama-cpp-python type, supporting version 3 quantization, here from locally built llama.cpp q4 v3 quantization
 model_path_llama=./models/7B/ggml-model-q4_0.bin
+# below assumes max_new_tokens=256
+n_ctx=1792
 
 # GPT4ALl LLaMa type, supporting version 2 quantization, here from model explorer choice so downloads
 model_name_gpt4all_llama=ggml-wizardLM-7B.q4_2.bin


### PR DESCRIPTION
```
============================================================================================================ short test summary info ============================================================================================================
FAILED tests/test_manual_test.py::test_chat_context - NotImplementedError: MANUAL TEST FOR NOW
FAILED tests/test_manual_test.py::test_upload_one_file - NotImplementedError: MANUAL TEST FOR NOW -- do and ask query of file
FAILED tests/test_manual_test.py::test_upload_multiple_file - NotImplementedError: MANUAL TEST FOR NOW -- do and ask query of files
FAILED tests/test_manual_test.py::test_upload_url - NotImplementedError: MANUAL TEST FOR NOW -- put in URL box https://github.com/h2oai/h2ogpt/ (and ask what is h2ogpt?). Ensure can go to source links
FAILED tests/test_manual_test.py::test_upload_arxiv - NotImplementedError: MANUAL TEST FOR NOW -- paste in arxiv:1706.03762 and ask who wrote attention paper. Ensure can go to source links
FAILED tests/test_manual_test.py::test_upload_pasted_text - NotImplementedError: MANUAL TEST FOR NOW -- do and see test code for what to try
FAILED tests/test_manual_test.py::test_no_db_dirs - NotImplementedError: MANUAL TEST FOR NOW -- Remove db_dirs, ensure can still start up and use in MyData Mode.
FAILED tests/test_manual_test.py::test_upload_unsupported_file - NotImplementedError: MANUAL TEST FOR NOW -- e.g. json, ensure error correct and reasonable, no cascades
FAILED tests/test_manual_test.py::test_upload_to_UserData_and_MyData - NotImplementedError: MANUAL TEST FOR NOW Upload to each when enabled, ensure no failures
FAILED tests/test_manual_test.py::test_chat_control - NotImplementedError: MANUAL TEST FOR NOW save chat, select chats, clear chat, export, import, etc.
FAILED tests/test_manual_test.py::test_subset_only - NotImplementedError: MANUAL TEST FOR NOW UserData, Select Only for subset, then put in whisper.  Ensure get back only chunks of data with url links to data sources.
=========================================================================== 11 failed, 61 passed, 25 skipped, 1 xfailed, 1 xpassed, 2 warnings in 1238.19s (0:20:38) ============================================================================
(h2ollm) jon@pseudotensor:~/h2o-llm$ 

```