### PR TITLE
Fix nochat API

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ which will build the database first time.  One can also use any other models, li
 python generate.py --base_model=h2oai/h2ogpt-oig-oasst1-512-6_9b --cli=True
 ```
 or
-```
+```bash
 python generate.py --base_model='llama' --prompt_type=wizard2 --cli=True
 ```
 No streaming is currently supported for llama in CLI chat, but that will be fixed soon.

--- a/cli.py
+++ b/cli.py
@@ -72,7 +72,9 @@ def run_cli(  # for local function:
             gener = fun(*tuple(eval_vars))
             outr = ''
             res_old = ''
-            for res, extra in gener:
+            for gen_output in gener:
+                res = gen_output['response']
+                extra = gen_output['sources']
                 if base_model not in non_hf_types:
                     if not stream_output:
                         print(res)

--- a/client_test.py
+++ b/client_test.py
@@ -36,6 +36,7 @@ Loaded as API: https://gpt.h2o.ai ✔
 {'instruction_nochat': 'Who are you?', 'iinput_nochat': '', 'response': 'I am h2oGPT, a chatbot created by LAION.'}
 
 """
+import ast
 import time
 import os
 import markdown  # pip install markdown
@@ -105,7 +106,8 @@ def run_client_nochat(prompt, prompt_type, max_new_tokens):
         api_name=api_name,
     )
     res_dict = dict(prompt=kwargs['instruction_nochat'], iinput=kwargs['iinput_nochat'],
-                    response=md_to_text(res))
+                    response=md_to_text(ast.literal_eval(res)['response']),
+                    sources=ast.literal_eval(res)['sources'])
     print(res_dict)
     return res_dict
 

--- a/client_test.py
+++ b/client_test.py
@@ -23,7 +23,7 @@ HOST="https://h2oai-h2ogpt-chatbot.hf.space" python client_test.py
 Result:
 
 Loaded as API: https://h2oai-h2ogpt-chatbot.hf.space ✔
-{'instruction_nochat': 'Who are you?', 'iinput_nochat': '', 'response': 'I am h2oGPT, a large language model developed by LAION.'}
+{'instruction_nochat': 'Who are you?', 'iinput_nochat': '', 'response': 'I am h2oGPT, a large language model developed by LAION.', 'sources': ''}
 
 
 For demo:
@@ -33,7 +33,12 @@ HOST="https://gpt.h2o.ai" python client_test.py
 Result:
 
 Loaded as API: https://gpt.h2o.ai ✔
-{'instruction_nochat': 'Who are you?', 'iinput_nochat': '', 'response': 'I am h2oGPT, a chatbot created by LAION.'}
+{'instruction_nochat': 'Who are you?', 'iinput_nochat': '', 'response': 'I am h2oGPT, a chatbot created by LAION.', 'sources': ''}
+
+NOTE: Raw output from API for nochat case is a string of a python dict and will remain so if other entries are added to dict:
+
+{'response': "I'm h2oGPT, a large language model by H2O.ai, the visionary leader in democratizing AI.", 'sources': ''}
+
 
 """
 import ast
@@ -105,6 +110,7 @@ def run_client_nochat(prompt, prompt_type, max_new_tokens):
         *tuple(args),
         api_name=api_name,
     )
+    print("Raw client result: %s" % res, flush=True)
     res_dict = dict(prompt=kwargs['instruction_nochat'], iinput=kwargs['iinput_nochat'],
                     response=md_to_text(ast.literal_eval(res)['response']),
                     sources=ast.literal_eval(res)['sources'])

--- a/eval.py
+++ b/eval.py
@@ -119,7 +119,8 @@ def run_eval(  # for local function:
             # Also means likely do NOT want --stream_output=True, else would show all generations
             gener = fun(*tuple(ex), exi=exi) if eval_sharegpt_as_output else fun(*tuple(ex))
             for res_fun in gener:
-                res, extra = res_fun
+                res = res_fun['response']
+                extra = res_fun['sources']
                 print(res)
                 if smodel:
                     score_with_prompt = False

--- a/generate.py
+++ b/generate.py
@@ -959,7 +959,7 @@ def evaluate(
                            cli=cli,
                            ):
             outr, extra = r  # doesn't accumulate, new answer every yield, so only save that full answer
-            yield r
+            yield dict(response=outr, sources=extra)
         if save_dir:
             save_generate_output(output=outr, base_model=base_model, save_dir=save_dir)
             if verbose:
@@ -979,7 +979,7 @@ def evaluate(
         else:
             raise RuntimeError("No such task type %s" % tokenizer)
         # NOTE: uses max_length only
-        yield model(prompt, max_length=max_new_tokens)[0][key], ''
+        yield dict(response=model(prompt, max_length=max_new_tokens)[0][key], sources='')
 
     if 'mbart-' in base_model.lower():
         assert src_lang is not None
@@ -1103,8 +1103,9 @@ def evaluate(
                             if bucket.qsize() > 0 or thread.exc:
                                 thread.join()
                             outputs += new_text
-                            yield prompter.get_response(outputs, prompt=inputs_decoded,
-                                                        sanitize_bot_response=sanitize_bot_response), ''
+                            yield dict(response=prompter.get_response(outputs, prompt=inputs_decoded,
+                                                                      sanitize_bot_response=sanitize_bot_response),
+                                       sources='')
                     except BaseException:
                         # if any exception, raise that exception if was from thread, first
                         if thread.exc:
@@ -1121,8 +1122,8 @@ def evaluate(
                 else:
                     outputs = model.generate(**gen_kwargs)
                     outputs = [decoder(s) for s in outputs.sequences]
-                    yield prompter.get_response(outputs, prompt=inputs_decoded,
-                                                sanitize_bot_response=sanitize_bot_response), ''
+                    yield dict(response=prompter.get_response(outputs, prompt=inputs_decoded,
+                                                              sanitize_bot_response=sanitize_bot_response), sources='')
                     if outputs and len(outputs) >= 1:
                         decoded_output = prompt + outputs[0]
                 if save_dir and decoded_output:

--- a/gradio_runner.py
+++ b/gradio_runner.py
@@ -957,7 +957,8 @@ body.dark{#warning {background-color: #555555};}
                            **kwargs_evaluate)
             try:
                 for output_fun in fun1(*tuple(args_list)):
-                    output, extra = output_fun
+                    output = output_fun['response']
+                    extra = output_fun['sources']  # FIXME: can show sources in separate text box etc.
                     # ensure good visually, else markdown ignores multiple \n
                     bot_message = output.replace('\n', '<br>')
                     history[-1][1] = bot_message

--- a/tests/test_langchain_units.py
+++ b/tests/test_langchain_units.py
@@ -330,7 +330,7 @@ def test_md_add():
             assert db is not None
             docs = db.similarity_search("What is h2oGPT?")
             assert len(docs) == 4
-            assert 'h2oGPT is a large language model' in docs[0].page_content
+            assert 'h2oGPT is a large language model' in docs[1].page_content
             assert os.path.normpath(docs[0].metadata['source']) == os.path.normpath(test_file1)
 
 


### PR DESCRIPTION
```
============================================================================================================ short test summary info ============================================================================================================
FAILED tests/test_langchain_units.py::test_md_add - AssertionError: assert 'h2oGPT is a large language model' in 'bash\ngit clone https://github.com/h2oai/h2ogpt.git\ncd h2ogpt\npip install -r requirements.txt\npython generate.py --base_model=h2oai/h2ogpt-oig-oasst1-512-6_9b --load_8bit=...
FAILED tests/test_manual_test.py::test_chat_context - NotImplementedError: MANUAL TEST FOR NOW
FAILED tests/test_manual_test.py::test_upload_one_file - NotImplementedError: MANUAL TEST FOR NOW -- do and ask query of file
FAILED tests/test_manual_test.py::test_upload_multiple_file - NotImplementedError: MANUAL TEST FOR NOW -- do and ask query of files
FAILED tests/test_manual_test.py::test_upload_url - NotImplementedError: MANUAL TEST FOR NOW -- put in URL box https://github.com/h2oai/h2ogpt/ (and ask what is h2ogpt?). Ensure can go to source links
FAILED tests/test_manual_test.py::test_upload_arxiv - NotImplementedError: MANUAL TEST FOR NOW -- paste in arxiv:1706.03762 and ask who wrote attention paper. Ensure can go to source links
FAILED tests/test_manual_test.py::test_upload_pasted_text - NotImplementedError: MANUAL TEST FOR NOW -- do and see test code for what to try
FAILED tests/test_manual_test.py::test_no_db_dirs - NotImplementedError: MANUAL TEST FOR NOW -- Remove db_dirs, ensure can still start up and use in MyData Mode.
FAILED tests/test_manual_test.py::test_upload_unsupported_file - NotImplementedError: MANUAL TEST FOR NOW -- e.g. json, ensure error correct and reasonable, no cascades
FAILED tests/test_manual_test.py::test_upload_to_UserData_and_MyData - NotImplementedError: MANUAL TEST FOR NOW Upload to each when enabled, ensure no failures
FAILED tests/test_manual_test.py::test_chat_control - NotImplementedError: MANUAL TEST FOR NOW save chat, select chats, clear chat, export, import, etc.
FAILED tests/test_manual_test.py::test_subset_only - NotImplementedError: MANUAL TEST FOR NOW UserData, Select Only for subset, then put in whisper.  Ensure get back only chunks of data with url links to data sources.
=========================================================================== 12 failed, 61 passed, 25 skipped, 1 xfailed, 1 xpassed, 2 warnings in 1239.61s (0:20:39) ============================================================================
(h2ollm) jon@pseudotensor:~/h2o-llm$ 

```