### PR TITLE
Add weaviate support

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -222,7 +222,7 @@ def main(
     :param document_choice: Default document choice when taking subset of collection
     :param load_db_if_exists: Whether to load chroma db if exists or re-generate db
     :param keep_sources_in_context: Whether to keep url sources in context, not helpful usually
-    :param db_type: 'faiss' for in-memory or 'chroma' for persisted on disk
+    :param db_type: 'faiss' for in-memory or 'chroma' or 'weaviate' for persisted on disk
     :param use_openai_embedding: Whether to use OpenAI embeddings for vector db
     :param use_openai_model: Whether to use OpenAI model for use with vector db
     :param hf_embedding_model: Which HF embedding model to use for vector db

--- a/gpt_langchain.py
+++ b/gpt_langchain.py
@@ -65,7 +65,8 @@ def get_db(sources, use_openai_embedding=False, db_type='faiss', persist_directo
         client = weaviate.Client(
             embedded_options=EmbeddedOptions()
             )
-        db = Weaviate.from_documents(documents=sources, embedding=embedding, client=client, by_text=False)
+        index_name = langchain_mode.replace(' ', '_').capitalize()
+        db = Weaviate.from_documents(documents=sources, embedding=embedding, client=client, by_text=False, index_name=index_name)
 
     elif db_type == 'chroma':
         collection_name = langchain_mode.replace(' ', '_')

--- a/gpt_langchain.py
+++ b/gpt_langchain.py
@@ -951,7 +951,7 @@ def _run_qa_db(query=None,
     :param chunk:
     :param chunk_size:
     :param user_path: user path to glob recursively from
-    :param db_type: 'faiss' for in-memory db or 'chroma' for persistent db
+    :param db_type: 'faiss' for in-memory db or 'chroma' or 'weaviate' for persistent db
     :param model_name: model name, used to switch behaviors
     :param model: pre-initialized model, else will make new one
     :param tokenizer: pre-initialized tokenizer, else will make new one.  Required not None if model is not None

--- a/gpt_langchain.py
+++ b/gpt_langchain.py
@@ -55,6 +55,18 @@ def get_db(sources, use_openai_embedding=False, db_type='faiss', persist_directo
     if db_type == 'faiss':
         from langchain.vectorstores import FAISS
         db = FAISS.from_documents(sources, embedding)
+
+    elif db_type == 'weaviate':
+        import weaviate
+        from weaviate.embedded import EmbeddedOptions
+        from langchain.vectorstores import Weaviate
+
+        # TODO: add support for connecting via docker compose
+        client = weaviate.Client(
+            embedded_options=EmbeddedOptions()
+            )
+        db = Weaviate.from_documents(documents=sources, embedding=embedding, client=client, by_text=False)
+
     elif db_type == 'chroma':
         collection_name = langchain_mode.replace(' ', '_')
         os.makedirs(persist_directory, exist_ok=True)

--- a/reqs_optional/requirements_optional_langchain.txt
+++ b/reqs_optional/requirements_optional_langchain.txt
@@ -40,3 +40,6 @@ tabulate==0.9.0
 # to check licenses
 # Run: pip-licenses|grep -v 'BSD\|Apache\|MIT'
 pip-licenses==4.3.0
+
+# weaviate vector db
+weaviate-client==3.19.2

--- a/tests/test_langchain_units.py
+++ b/tests/test_langchain_units.py
@@ -162,6 +162,24 @@ def test_qa_daidocs_db_chunk_hf_chroma():
                      )
     check_ret(ret)
 
+@wrap_test_forked
+def test_qa_wiki_db_chunk_hf_weaviate():
+
+    from gpt4all_llm import get_model_tokenizer_gpt4all
+    model_name = 'llama'
+    model, tokenizer, device = get_model_tokenizer_gpt4all(model_name)
+
+    from gpt_langchain import _run_qa_db
+    query = "What are the main differences between Linux and Windows?"
+    # chunk_size is chars for each of k=4 chunks
+    ret = _run_qa_db(query=query, use_openai_model=False, use_openai_embedding=False, text_limit=None, chunk=True,
+                     chunk_size=128 * 1,  # characters, and if k=4, then 4*4*128 = 2048 chars ~ 512 tokens
+                     langchain_mode='wiki',
+                     db_type='weaviate',
+                     prompt_type='wizard2',
+                     model_name=model_name, model=model, tokenizer=tokenizer,
+                     )
+    check_ret(ret)
 
 @pytest.mark.skipif(not have_openai_key, reason="requires OpenAI key to run")
 @wrap_test_forked


### PR DESCRIPTION
Fixes #145

Output of running `pytest -s -v tests/test_langchain_units.py::test_qa_wiki_db_chunk_hf_weaviate`:

> ================================================================================= test session starts =================================================================================
> platform linux -- Python 3.10.11, pytest-7.3.1, pluggy-1.0.0 -- /usr/local/py-utils/venvs/pytest/bin/python
> cachedir: .pytest_cache
> rootdir: /workspaces/h2ogpt
> plugins: xdist-3.2.1, anyio-3.7.0
> collected 1 item                                                                                                                                                                      
> 
> tests/test_langchain_units.py::test_qa_wiki_db_chunk_hf_weaviate llama.cpp: loading model from WizardLM-7B-uncensored.ggmlv3.q8_0.bin
> llama_model_load_internal: format     = ggjt v3 (latest)
> llama_model_load_internal: n_vocab    = 32001
> llama_model_load_internal: n_ctx      = 1792
> llama_model_load_internal: n_embd     = 4096
> llama_model_load_internal: n_mult     = 256
> llama_model_load_internal: n_head     = 32
> llama_model_load_internal: n_layer    = 32
> llama_model_load_internal: n_rot      = 128
> llama_model_load_internal: ftype      = 7 (mostly Q8_0)
> llama_model_load_internal: n_ff       = 11008
> llama_model_load_internal: n_parts    = 1
> llama_model_load_internal: model size = 7B
> llama_model_load_internal: ggml ctx size =    0.07 MB
> llama_model_load_internal: mem required  = 8620.72 MB (+ 1026.00 MB per state)
> .
> llama_init_from_file: kv self size  =  896.00 MB
> AVX = 1 | AVX2 = 1 | AVX512 = 1 | AVX512_VBMI = 0 | AVX512_VNNI = 0 | FMA = 1 | NEON = 0 | ARM_FMA = 0 | F16C = 1 | FP16_VA = 0 | WASM_SIMD = 0 | BLAS = 0 | SSE3 = 1 | VSX = 0 | 
> Downloading (…)e9125/.gitattributes: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████| 1.18k/1.18k [00:00<00:00, 5.09MB/s]
> Downloading (…)_Pooling/config.json: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 190/190 [00:00<00:00, 1.04MB/s]
> Downloading (…)7e55de9125/README.md: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████| 10.6k/10.6k [00:00<00:00, 26.3MB/s]
> Downloading (…)55de9125/config.json: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 612/612 [00:00<00:00, 4.07MB/s]
> Downloading (…)ce_transformers.json: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 116/116 [00:00<00:00, 743kB/s]
> Downloading (…)125/data_config.json: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████| 39.3k/39.3k [00:00<00:00, 87.5MB/s]
> Downloading pytorch_model.bin: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████| 90.9M/90.9M [00:00<00:00, 376MB/s]
> Downloading (…)nce_bert_config.json: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████| 53.0/53.0 [00:00<00:00, 341kB/s]
> Downloading (…)cial_tokens_map.json: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 112/112 [00:00<00:00, 854kB/s]
> Downloading (…)e9125/tokenizer.json: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████| 466k/466k [00:00<00:00, 64.4MB/s]
> Downloading (…)okenizer_config.json: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 350/350 [00:00<00:00, 2.45MB/s]
> Downloading (…)9125/train_script.py: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████| 13.2k/13.2k [00:00<00:00, 57.2MB/s]
> Downloading (…)7e55de9125/vocab.txt: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████| 232k/232k [00:00<00:00, 71.1MB/s]
> Downloading (…)5de9125/modules.json: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 349/349 [00:00<00:00, 2.52MB/s]
> Binary /home/vscode/.cache/weaviate-embedded did not exist. Downloading binary from https://github.com/weaviate/weaviate/releases/download/v1.19.3/weaviate-v1.19.3-linux-amd64.tar.gz
> Started /home/vscode/.cache/weaviate-embedded: process ID 4442
> {"action":"startup","default_vectorizer_module":"none","level":"info","msg":"the default vectorizer modules is set to \"none\", as a result all new schema classes without an explicit vectorizer setting, will use this vectorizer","time":"2023-06-02T10:21:13Z"}
> {"action":"startup","auto_schema_enabled":true,"level":"info","msg":"auto schema enabled setting is set to \"true\"","time":"2023-06-02T10:21:13Z"}
> {"level":"warning","msg":"Multiple vector spaces are present, GraphQL Explore and REST API list objects endpoint module include params has been disabled as a result.","time":"2023-06-02T10:21:13Z"}
> {"action":"grpc_startup","level":"info","msg":"grpc server listening at [::]:50051","time":"2023-06-02T10:21:13Z"}
> {"action":"restapi_management","level":"info","msg":"Serving weaviate at http://127.0.0.1:6666","time":"2023-06-02T10:21:13Z"}
> {"action":"hnsw_vector_cache_prefill","count":1000,"index_id":"langchain_cb113cea4c3246fc9584cb8f01423ca2_JyjC68qeAYYp","level":"info","limit":1000000000000,"msg":"prefilled vector cache","time":"2023-06-02T10:21:18Z","took":81193}
> ('\n\nLinux is an open-source operating system that is free to use and modify, while Windows is a proprietary operating system that is owned by Microsoft Corporation.\n\nLinux is based on the Unix operating system, which is known for its stability and security, while Windows is based on the MS-DOS operating system, which is known for its ease of use.\n\nLinux is typically used for servers and other high-performance computing environments, while Windows is more commonly used for personal computers and laptops.\n\nLinux is also known for its flexibility and customizability, as users can modify the operating system to suit their needs, while Windows is more locked down and requires more user input to customize.\n\nOverall, the main differences between Linux and Windows are their licensing models, design principles, and target audience.\n\nSources [Score | Link]:<p><ul><li>0.61 | <a href="https://en.wikipedia.org/wiki/Linux" target="_blank"  rel="noopener noreferrer">https://en.wikipedia.org/wiki/Linux</a></li></ul></p>End Sources<p>', '\nSources [Score | Link]:<p><ul><li>0.61 | <a href="https://en.wikipedia.org/wiki/Linux" target="_blank"  rel="noopener noreferrer">https://en.wikipedia.org/wiki/Linux</a></li></ul></p>End Sources<p>')
> PASSED
> 
> ================================================================================== warnings summary ===================================================================================
> ../../usr/local/py-utils/shared/lib/python3.10/site-packages/pkg_resources/__init__.py:121
>   /usr/local/py-utils/shared/lib/python3.10/site-packages/pkg_resources/__init__.py:121: DeprecationWarning: pkg_resources is deprecated as an API
>     warnings.warn("pkg_resources is deprecated as an API", DeprecationWarning)
> 
> ../../usr/local/py-utils/shared/lib/python3.10/site-packages/pkg_resources/__init__.py:2870
>   /usr/local/py-utils/shared/lib/python3.10/site-packages/pkg_resources/__init__.py:2870: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('google')`.
>   Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
>     declare_namespace(pkg)
> 
> ../../usr/local/py-utils/shared/lib/python3.10/site-packages/pkg_resources/__init__.py:2870
>   /usr/local/py-utils/shared/lib/python3.10/site-packages/pkg_resources/__init__.py:2870: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('mpl_toolkits')`.
>   Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
>     declare_namespace(pkg)
> 
> -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
> ====================================================================== 1 passed, 3 warnings in 205.00s (0:03:24) ======================================================================
> 