### PR TITLE
Allow update db from UI if files changed, since normally not constantly checking for new files

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -280,20 +280,21 @@ To Chat with your docs, choose, e.g. UserData.  To avoid including docs, and jus
 * None: Similar to choosing ChatLLM instead of the chosen collection
 * ... Or choose one or more documents to chat with (then do not select All, Only, or None)
 
-| Button                       | Purpose                                                                                              |
-------------------------------|------------------------------------------------------------------------------------------------------|
-| Get Sources                  | For chosen collection, get all sources and place list into drop-down for choosing subset             |
-| Show Sources                 | For chosen collection, get and show (in HTML with links to source docs if present) at bottom of page |
-| Upload Box                   | Drag-n-drop or select from user's system one or more files                                           |
-| Add File(s) to UserData      | After using Upload box and seeing files listed there, add those files to UserData collection         |
-| Add File(s) to MyData        | After using Upload box and seeing files listed there, add those files to MyData collection           |
-| Download File w/Sources      | After clicking Get Sources, downloadable file will appear here that lists all sources in text file   |
-| URL                          | Enter text URL link or arxiv:<paper id> to download text content of web page or download             |
-| Add URL Content to UserData  | After entering text into URL box, download into UserData collection                                  |
-| Add URL Content to MyData    | After entering text into URL box, download into MyData collection                                    |
-| Paste Text                   | Enter raw text for adding to collection                                                              |
-| Add Text Content to UserData | After entering text Text box, add into UserData collection                                           |
-| Add Text Content to MyData   | After entering text Text box, add into MyData collection                                             |
+| Button                       | Purpose                                                                                            |
+-------------------------------|----------------------------------------------------------------------------------------------------|
+| Get Sources                  | For chosen collection, get all sources and place list into drop-down for choosing subset           |
+| Show Sources                 | For chosen collection, get and show (in HTML with links to source docs) at bottom of page          |
+| Refresh Sources              | For chosen collection, updaet any changed or new files and show new sources at bottom of page      |
+| Upload Box                   | Drag-n-drop or select from user's system one or more files                                         |
+| Add File(s) to UserData      | After using Upload box and seeing files listed there, add those files to UserData collection       |
+| Add File(s) to MyData        | After using Upload box and seeing files listed there, add those files to MyData collection         |
+| Download File w/Sources      | After clicking Get Sources, downloadable file will appear here that lists all sources in text file |
+| URL                          | Enter text URL link or arxiv:<paper id> to download text content of web page or download           |
+| Add URL Content to UserData  | After entering text into URL box, download into UserData collection                                |
+| Add URL Content to MyData    | After entering text into URL box, download into MyData collection                                  |
+| Paste Text                   | Enter raw text for adding to collection                                                            |
+| Add Text Content to UserData | After entering text Text box, add into UserData collection                                         |
+| Add Text Content to MyData   | After entering text Text box, add into MyData collection                                           |
 
 #### Expert Tab
 

--- a/tests/test_manual_test.py
+++ b/tests/test_manual_test.py
@@ -62,3 +62,7 @@ def test_chat_control():
 
 def test_subset_only():
     raise NotImplementedError("""MANUAL TEST FOR NOW UserData, Select Only for subset, then put in whisper.  Ensure get back only chunks of data with url links to data sources.""")
+
+
+def test_add_new_doc():
+    raise NotImplementedError("""MANUAL TEST FOR NOW UserData, add new pdf or file to user_path and see if pushing refresh sources updates and shows new file in list, then ask question about that new doc""")


### PR DESCRIPTION
```
============================================================================================================ short test summary info ============================================================================================================
FAILED tests/test_manual_test.py::test_chat_context - NotImplementedError: MANUAL TEST FOR NOW
FAILED tests/test_manual_test.py::test_upload_one_file - NotImplementedError: MANUAL TEST FOR NOW -- do and ask query of file
FAILED tests/test_manual_test.py::test_upload_multiple_file - NotImplementedError: MANUAL TEST FOR NOW -- do and ask query of files
FAILED tests/test_manual_test.py::test_upload_url - NotImplementedError: MANUAL TEST FOR NOW -- put in URL box https://github.com/h2oai/h2ogpt/ (and ask what is h2ogpt?). Ensure can go to source links
FAILED tests/test_manual_test.py::test_upload_arxiv - NotImplementedError: MANUAL TEST FOR NOW -- paste in arxiv:1706.03762 and ask who wrote attention paper. Ensure can go to source links
FAILED tests/test_manual_test.py::test_upload_pasted_text - NotImplementedError: MANUAL TEST FOR NOW -- do and see test code for what to try
FAILED tests/test_manual_test.py::test_no_db_dirs - NotImplementedError: MANUAL TEST FOR NOW -- Remove db_dirs, ensure can still start up and use in MyData Mode.
FAILED tests/test_manual_test.py::test_upload_unsupported_file - NotImplementedError: MANUAL TEST FOR NOW -- e.g. json, ensure error correct and reasonable, no cascades
FAILED tests/test_manual_test.py::test_upload_to_UserData_and_MyData - NotImplementedError: MANUAL TEST FOR NOW Upload to each when enabled, ensure no failures
FAILED tests/test_manual_test.py::test_chat_control - NotImplementedError: MANUAL TEST FOR NOW save chat, select chats, clear chat, export, import, etc.
FAILED tests/test_manual_test.py::test_subset_only - NotImplementedError: MANUAL TEST FOR NOW UserData, Select Only for subset, then put in whisper.  Ensure get back only chunks of data with url links to data sources.
=========================================================================== 11 failed, 88 passed, 27 skipped, 1 xfailed, 1 xpassed, 9 warnings in 1621.63s (0:27:01) ============================================================================
(h2ollm) jon@pseudotensor:~/h2ogpt$ 

```