### PR TITLE
More control over max_max_new_tokens and memory behavior from generate args

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9,7 +9,7 @@ from utils import clear_torch_cache, NullContext, get_kwargs
 def run_cli(  # for local function:
         base_model=None, lora_weights=None,
         debug=None, chat_context=None,
-        examples=None, is_low_mem=None,
+        examples=None, memory_restriction_level=None,
         # for get_model:
         score_model=None, load_8bit=None, load_4bit=None, load_half=None, infer_devices=None, tokenizer_base_model=None,
         gpu_id=None, local_files_only=None, resume_download=None, use_auth_token=None,

--- a/eval.py
+++ b/eval.py
@@ -16,7 +16,7 @@ def run_eval(  # for local function:
         base_model=None, lora_weights=None,
         prompt_type=None, debug=None, chat=False, chat_context=None, stream_output=None,
         eval_filename=None, eval_prompts_only_num=None, eval_prompts_only_seed=None, eval_as_output=None,
-        examples=None, is_low_mem=None,
+        examples=None, memory_restriction_level=None,
         # for get_model:
         score_model=None, load_8bit=None, load_4bit=None, load_half=None, infer_devices=None, tokenizer_base_model=None,
         gpu_id=None, local_files_only=None, resume_download=None, use_auth_token=None,
@@ -175,7 +175,10 @@ def run_eval(  # for local function:
                         if not (chat_context and prompt_type == 'human_bot'):
                             assert context in [None, ''], context  # should be no context
                         prompt = instruction
-                    cutoff_len = 768 if is_low_mem else tokenizer.model_max_length
+                    if memory_restriction_level > 0:
+                        cutoff_len = 768 if memory_restriction_level <= 2 else 512
+                    else:
+                        cutoff_len = tokenizer.model_max_length
                     inputs = stokenizer(prompt, res,
                                         return_tensors="pt",
                                         truncation=True,

--- a/gpt_langchain.py
+++ b/gpt_langchain.py
@@ -139,7 +139,8 @@ def add_to_db(db, sources, db_type='faiss',
             dup_metadata_files = set([x.metadata['source'] for x in sources if x.metadata['source'] in metadata_files])
             print("Removing %s duplicate files from db because ingesting those as new documents" % len(
                 dup_metadata_files), flush=True)
-            client_collection = db._client.get_collection(name=db._collection.name)
+            client_collection = db._client.get_collection(name=db._collection.name,
+                                                          embedding_function=db._collection._embedding_function)
             for dup_file in dup_metadata_files:
                 dup_file_meta = dict(source=dup_file)
                 try:
@@ -866,7 +867,7 @@ def prep_langchain(persist_directory,
     else:
         if db_dir_exists and user_path is not None:
             print("Prep: persist_directory=%s exists, user_path=%s passed, adding any changed or new documents" % (
-            persist_directory, user_path), flush=True)
+                persist_directory, user_path), flush=True)
         elif not db_dir_exists:
             print("Prep: persist_directory=%s does not exist, regenerating" % persist_directory, flush=True)
         db = None
@@ -968,6 +969,7 @@ def _make_db(use_openai_embedding=False,
         db = Chroma(persist_directory=persist_directory, embedding_function=embedding,
                     collection_name=langchain_mode.replace(' ', '_'),
                     client_settings=client_settings)
+        db.persist()
     sources = []
     if not db and langchain_mode not in ['MyData'] or \
             user_path is not None and \


### PR DESCRIPTION
```
============================================================================================================ short test summary info ============================================================================================================
FAILED tests/test_manual_test.py::test_chat_context - NotImplementedError: MANUAL TEST FOR NOW
FAILED tests/test_manual_test.py::test_upload_one_file - NotImplementedError: MANUAL TEST FOR NOW -- do and ask query of file
FAILED tests/test_manual_test.py::test_upload_multiple_file - NotImplementedError: MANUAL TEST FOR NOW -- do and ask query of files
FAILED tests/test_manual_test.py::test_upload_url - NotImplementedError: MANUAL TEST FOR NOW -- put in URL box https://github.com/h2oai/h2ogpt/ (and ask what is h2ogpt?). Ensure can go to source links
FAILED tests/test_manual_test.py::test_upload_arxiv - NotImplementedError: MANUAL TEST FOR NOW -- paste in arxiv:1706.03762 and ask who wrote attention paper. Ensure can go to source links
FAILED tests/test_manual_test.py::test_upload_pasted_text - NotImplementedError: MANUAL TEST FOR NOW -- do and see test code for what to try
FAILED tests/test_manual_test.py::test_no_db_dirs - NotImplementedError: MANUAL TEST FOR NOW -- Remove db_dirs, ensure can still start up and use in MyData Mode.
FAILED tests/test_manual_test.py::test_upload_unsupported_file - NotImplementedError: MANUAL TEST FOR NOW -- e.g. json, ensure error correct and reasonable, no cascades
FAILED tests/test_manual_test.py::test_upload_to_UserData_and_MyData - NotImplementedError: MANUAL TEST FOR NOW Upload to each when enabled, ensure no failures
FAILED tests/test_manual_test.py::test_chat_control - NotImplementedError: MANUAL TEST FOR NOW save chat, select chats, clear chat, export, import, etc.
FAILED tests/test_manual_test.py::test_subset_only - NotImplementedError: MANUAL TEST FOR NOW UserData, Select Only for subset, then put in whisper.  Ensure get back only chunks of data with url links to data sources.
FAILED tests/test_manual_test.py::test_add_new_doc - NotImplementedError: MANUAL TEST FOR NOW UserData, add new pdf or file to user_path and see if pushing refresh sources updates and shows new file in list, then ask question about that new doc
=========================================================================== 12 failed, 88 passed, 27 skipped, 1 xfailed, 1 xpassed, 9 warnings in 1636.51s (0:27:16) ============================================================================
(h2ollm) jon@pseudotensor:~/h2ogpt$ 

```