### PR TITLE
Make API easier, and add prompt_dict for custom control over prompt as example of new API parameter don't need to pass

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -15,7 +15,8 @@ def run_cli(  # for local function:
         gpu_id=None, local_files_only=None, resume_download=None, use_auth_token=None,
         trust_remote_code=None, offload_folder=None, compile_model=None,
         # for some evaluate args
-        stream_output=None, prompt_type=None, temperature=None, top_p=None, top_k=None, num_beams=None,
+        stream_output=None, prompt_type=None, prompt_dict=None,
+        temperature=None, top_p=None, top_k=None, num_beams=None,
         max_new_tokens=None, min_new_tokens=None, early_stopping=None, max_time=None, repetition_penalty=None,
         num_return_sequences=None, do_sample=None, chat=None,
         langchain_mode=None, document_choice=None, top_k_docs=None,

--- a/client_test.py
+++ b/client_test.py
@@ -71,6 +71,7 @@ def get_args(prompt, prompt_type, chat=False, stream_output=False, max_new_token
                          # but leave stream_output=False for simple input/output mode
                          stream_output=stream_output,
                          prompt_type=prompt_type,
+                         prompt_dict='',
                          temperature=0.1,
                          top_p=0.75,
                          top_k=40,
@@ -108,6 +109,28 @@ def run_client_nochat(prompt, prompt_type, max_new_tokens):
     client = get_client(serialize=True)
     res = client.predict(
         *tuple(args),
+        api_name=api_name,
+    )
+    print("Raw client result: %s" % res, flush=True)
+    res_dict = dict(prompt=kwargs['instruction_nochat'], iinput=kwargs['iinput_nochat'],
+                    response=md_to_text(ast.literal_eval(res)['response']),
+                    sources=ast.literal_eval(res)['sources'])
+    print(res_dict)
+    return res_dict
+
+
+@pytest.mark.skip(reason="For manual use against some server, no server launched")
+def test_client_basic_api():
+    return run_client_nochat_api(prompt='Who are you?', prompt_type='human_bot', max_new_tokens=50)
+
+
+def run_client_nochat_api(prompt, prompt_type, max_new_tokens):
+    kwargs, args = get_args(prompt, prompt_type, chat=False, max_new_tokens=max_new_tokens)
+
+    api_name = '/submit_nochat_api'  # NOTE: like submit_nochat but stable API for string dict passing
+    client = get_client(serialize=True)
+    res = client.predict(
+        str(dict(kwargs)),
         api_name=api_name,
     )
     print("Raw client result: %s" % res, flush=True)

--- a/create_data.py
+++ b/create_data.py
@@ -567,7 +567,7 @@ def test_show_prompts():
     from prompter import generate_prompt
     for data_points in file_points:
         for data_point in data_points:
-            print(generate_prompt(data_point, 'plain', False, False)[0])
+            print(generate_prompt(data_point, 'plain', '', False, False)[0])
 
 
 def test_get_open_datasets():

--- a/eval.py
+++ b/eval.py
@@ -14,7 +14,8 @@ from utils import clear_torch_cache, NullContext, get_kwargs
 
 def run_eval(  # for local function:
         base_model=None, lora_weights=None,
-        prompt_type=None, debug=None, chat=False, chat_context=None, stream_output=None,
+        prompt_type=None, prompt_dict=None,
+        debug=None, chat=False, chat_context=None, stream_output=None,
         eval_filename=None, eval_prompts_only_num=None, eval_prompts_only_seed=None, eval_as_output=None,
         examples=None, memory_restriction_level=None,
         # for get_model:
@@ -165,7 +166,8 @@ def run_eval(  # for local function:
                     score_with_prompt = False
                     if score_with_prompt:
                         data_point = dict(instruction=instruction, input=iinput, context=context)
-                        prompter = Prompter(prompt_type, debug=debug, chat=chat, stream_output=stream_output)
+                        prompter = Prompter(prompt_type, prompt_dict,
+                                            debug=debug, chat=chat, stream_output=stream_output)
                         prompt = prompter.generate_prompt(data_point)
                     else:
                         # just raw input and output

--- a/stopping.py
+++ b/stopping.py
@@ -25,7 +25,8 @@ class StoppingCriteriaSub(StoppingCriteria):
         return False
 
 
-def get_stopping(prompt_type, tokenizer, device, human='<human>:', bot="<bot>:"):
+def get_stopping(prompt_type, prompt_dict, tokenizer, device, human='<human>:', bot="<bot>:"):
+    # FIXME: prompt_dict unused currently
     if prompt_type in [PromptType.human_bot.name, PromptType.instruct_vicuna.name, PromptType.instruct_with_end.name]:
         if prompt_type == PromptType.human_bot.name:
             # encounters = [prompt.count(human) + 1, prompt.count(bot) + 1]

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -74,7 +74,7 @@ def run_eval1(cpu=False, bits=None, base_model='h2oai/h2ogpt-oig-oasst1-512-6_9b
     from generate import eval_func_param_names, eval_extra_columns
     from generate import main
     kwargs = dict(
-        stream_output=False, prompt_type=prompt_type,
+        stream_output=False, prompt_type=prompt_type, prompt_dict='',
         temperature=0.4, top_p=0.85, top_k=70, num_beams=1, max_new_tokens=256,
         min_new_tokens=0, early_stopping=False, max_time=180, repetition_penalty=1.07,
         num_return_sequences=1, do_sample=True, chat=False, langchain_mode='Disabled',

--- a/tests/test_prompter.py
+++ b/tests/test_prompter.py
@@ -17,13 +17,11 @@ example_data_points = [example_data_point0, example_data_point1, example_data_po
 @wrap_test_forked
 def test_train_prompt(prompt_type='instruct', data_point=0):
     example_data_point = example_data_points[data_point]
-    return generate_prompt(example_data_point, prompt_type, False, False)
+    return generate_prompt(example_data_point, prompt_type, '', False, False)
 
 
 @wrap_test_forked
 def test_test_prompt(prompt_type='instruct', data_point=0):
     example_data_point = example_data_points[data_point]
     example_data_point.pop('output', None)
-    return generate_prompt(example_data_point, prompt_type, False, False)
-
-
+    return generate_prompt(example_data_point, prompt_type, '', False, False)


### PR DESCRIPTION
Gradio uses positional args, and so constantly breaking API when add new parameters to pass to server from client.  Already made it so returned object is string of dict.  Now made input string of dict too, i.e.:
```
from gradio_client import Client
client = Client(os.getenv('HOST', "http://localhost:7860"))

# string of dict for input
kwargs = dict(instruction_nochat='Who are you?')
res = client.predict(str(dict(kwargs)), api_name='/submit_nochat_api')

# string of dict for output
response = ast.literal_eval(res)['response']
assert 'I am h2oGPT' in response or "I'm h2oGPT" in response or 'I’m h2oGPT' in response
```


```
=========================== short test summary info ============================
FAILED tests/test_manual_test.py::test_chat_context - NotImplementedError: MA...
FAILED tests/test_manual_test.py::test_upload_one_file - NotImplementedError:...
FAILED tests/test_manual_test.py::test_upload_multiple_file - NotImplementedE...
FAILED tests/test_manual_test.py::test_upload_url - NotImplementedError: MANU...
FAILED tests/test_manual_test.py::test_upload_arxiv - NotImplementedError: MA...
FAILED tests/test_manual_test.py::test_upload_pasted_text - NotImplementedErr...
FAILED tests/test_manual_test.py::test_no_db_dirs - NotImplementedError: MANU...
FAILED tests/test_manual_test.py::test_upload_unsupported_file - NotImplement...
FAILED tests/test_manual_test.py::test_upload_to_UserData_and_MyData - NotImp...
FAILED tests/test_manual_test.py::test_chat_control - NotImplementedError: MA...
FAILED tests/test_manual_test.py::test_subset_only - NotImplementedError: MAN...
FAILED tests/test_manual_test.py::test_add_new_doc - NotImplementedError: MAN...
= 8 failed, 94 passed, 27 skipped, 1 xfailed, 1 xpassed, 9 warnings in 1638.52s (0:27:18) =
```