### PR TITLE
Fix `TypeError: can only concatenate str (not "list") to str` on startup

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -1481,7 +1481,7 @@ Philipp: ok, ok you can find everything here. https://huggingface.co/blog/the-pa
                    early_stopping, max_time, repetition_penalty, num_return_sequences, do_sample]
 
     if use_placeholder_instruction_as_example:
-        examples += [placeholder_instruction, ''] + params_list
+        examples += [[placeholder_instruction, ''] + params_list]
 
     if use_default_examples:
         examples += [


### PR DESCRIPTION
Fixes following error on startup `python generate.py --base_model=distilgpt2 --load_8bit=True`
```
Traceback (most recent call last):
  File "/home/sajith/src/h2ogpt/generate.py", line 1684, in <module>
    fire.Fire(main)
  File "/home/sajith/src/h2ogpt/venv/lib/python3.10/site-packages/fire/core.py", line 141, in Fire
    component_trace = _Fire(component, args, parsed_flag_args, context, name)
  File "/home/sajith/src/h2ogpt/venv/lib/python3.10/site-packages/fire/core.py", line 475, in _Fire
    component, remaining_args = _CallAndUpdateTrace(
  File "/home/sajith/src/h2ogpt/venv/lib/python3.10/site-packages/fire/core.py", line 691, in _CallAndUpdateTrace
    component = fn(*varargs, **kwargs)
  File "/home/sajith/src/h2ogpt/generate.py", line 363, in main
    get_generate_params(model_lower, chat,
  File "/home/sajith/src/h2ogpt/generate.py", line 1533, in get_generate_params
    example += [chat, '', '', 'Disabled', top_k_docs, chunk, chunk_size, ['All']]
TypeError: can only concatenate str (not "list") to str
```