### PR TITLE
venv support in gitignore&Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ flagged_data_points
 .pytest_cache
 user_path
 user_path_test
+
+# Environments
+venv/
+.venv

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,21 @@
+PYTHON_VERSION ?= 3.10
+PYTHON ?= python$(PYTHON_VERSION)
+VENV?=venv
+
 all: reqs_optional/req_constraints.txt
 
 .PHONY: reqs_optional/req_constraints.txt
 reqs_optional/req_constraints.txt:
 	grep -v '#\|peft\|transformers\|accelerate' requirements.txt > $@
+
+.PHONY: venv
+venv: ## Create VENV
+	$(PYTHON) -m venv $(VENV)
+
+.PHONY: setup
+setup: venv ## Setup VENV with the requirements.txt
+	./$(VENV)/bin/python -m pip install -r requirements.txt
+
+.PHONY: clean
+clean: ## Clean VENV
+	rm -rf $(VENV)


### PR DESCRIPTION
As someone actively using the h2ogpt repo, I create my Python venv in the project folder before running the models. However, at every git pull, I need to delete venv because can not pull without stashing changes for the venv.

I think there could be many others running into the same issue, so thought this can be a nice slight improvement :)

(Also added helpers in Makefile, but your call)