### PR TITLE
Submit button is now primary + more spacing between prompt area and action buttons

### DIFF
--- a/gradio_ui/css.py
+++ b/gradio_ui/css.py
@@ -35,4 +35,17 @@ def make_css_base() -> str:
     #prompt-form textarea {
         border: 1px solid rgb(209, 213, 219);
     }
+    
+    #prompt-form label > div {
+        margin-top: 4px;
+    }
+    
+    button.primary:hover {
+        background-color: var(--primary-600) !important;
+        transition: .2s;
+    }
+    
+    #prompt-form-area {
+        margin-bottom: 2.5rem;
+    }
     """

--- a/gradio_ui/prompt_form.py
+++ b/gradio_ui/prompt_form.py
@@ -7,7 +7,7 @@ def make_prompt_form(kwargs):
     else:
         instruction_label = "press Enter or click Submit to send message, press Shift-Enter for more lines"
 
-    with gr.Row():
+    with gr.Row(elem_id='prompt-form-area'):
         with gr.Column(scale=50):
             instruction = gr.Textbox(
                 lines=kwargs['input_lines'],
@@ -18,7 +18,7 @@ def make_prompt_form(kwargs):
             )
             instruction.style(container=True)
         with gr.Row():
-            submit = gr.Button(value='Submit').style(full_width=False, size='sm')
-            stop_btn = gr.Button(value="Stop").style(full_width=False, size='sm')
+            submit = gr.Button(value='Submit', variant='primary').style(full_width=False, size='sm')
+            stop_btn = gr.Button(value="Stop", variant='secondary').style(full_width=False, size='sm')
 
     return instruction, submit, stop_btn


### PR DESCRIPTION
continuation of https://github.com/h2oai/h2ogpt/pull/259

- the Submit button is now primary button
- there is more spacing between the prompt input area and the action buttons below
  - the proximity of prompt area with the chat area should make it more obvious they are closely linked

## h2ocolors=True
<img width="1088" alt="image" src="https://github.com/h2oai/h2ogpt/assets/18228330/7a8db097-6404-4a34-b6b1-25442fe9627b">

<img width="1098" alt="image" src="https://github.com/h2oai/h2ogpt/assets/18228330/c2aaae54-7e9f-4b9a-a64e-d6f56d5f01d2">

## h2ocolors=False

<img width="1075" alt="image" src="https://github.com/h2oai/h2ogpt/assets/18228330/2e68283d-a107-441a-b632-5bf895ace8a3">

<img width="1070" alt="image" src="https://github.com/h2oai/h2ogpt/assets/18228330/fd14c823-c9b8-48f3-9701-44f499be5f0c">
