### PR TITLE
Pass actual eos id to generate, else doesn't know how to stop early if using non-standard eos id (normally=0, falcon GM was 11)

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -1208,7 +1208,7 @@ def evaluate(
         tgt_lang = languages_covered()[tgt_lang]
         gen_kwargs.update(dict(forced_bos_token_id=tokenizer.lang_code_to_id[tgt_lang]))
     else:
-        token_ids = ['eos_token_id', 'bos_token_id']
+        token_ids = ['eos_token_id', 'bos_token_id', 'pad_token_id']
         for token_id in token_ids:
             if hasattr(tokenizer, token_id) and getattr(tokenizer, token_id) is not None:
                 gen_kwargs.update({token_id: getattr(tokenizer, token_id)})

--- a/generate.py
+++ b/generate.py
@@ -656,6 +656,7 @@ def get_model(
                                                      use_auth_token=use_auth_token,
                                                      trust_remote_code=trust_remote_code,
                                                      offload_folder=offload_folder,
+                                                     padding_side='left',
                                                      )
     else:
         tokenizer = tokenizer_loader
@@ -1174,17 +1175,21 @@ def evaluate(
     max_max_tokens = tokenizer.model_max_length
     max_input_tokens = max_max_tokens - max_new_tokens
     input_ids = input_ids[:, -max_input_tokens:]
-    generation_config = GenerationConfig(
-        temperature=float(temperature),
-        top_p=float(top_p),
-        top_k=top_k,
-        num_beams=num_beams,
-        do_sample=do_sample,
-        repetition_penalty=float(repetition_penalty),
-        num_return_sequences=num_return_sequences,
-        renormalize_logits=True,
-        remove_invalid_values=True,
-    )
+    gen_config_kwargs = dict(temperature=float(temperature),
+                             top_p=float(top_p),
+                             top_k=top_k,
+                             num_beams=num_beams,
+                             do_sample=do_sample,
+                             repetition_penalty=float(repetition_penalty),
+                             num_return_sequences=num_return_sequences,
+                             renormalize_logits=True,
+                             remove_invalid_values=True,
+                             )
+    token_ids = ['eos_token_id', 'pad_token_id', 'bos_token_id', 'cls_token_id', 'sep_token_id']
+    for token_id in token_ids:
+        if hasattr(tokenizer, token_id) and getattr(tokenizer, token_id) is not None:
+            gen_config_kwargs.update({token_id: getattr(tokenizer, token_id)})
+    generation_config = GenerationConfig(**gen_config_kwargs)
 
     gen_kwargs = dict(input_ids=input_ids,
                       generation_config=generation_config,
@@ -1203,7 +1208,10 @@ def evaluate(
         tgt_lang = languages_covered()[tgt_lang]
         gen_kwargs.update(dict(forced_bos_token_id=tokenizer.lang_code_to_id[tgt_lang]))
     else:
-        gen_kwargs.update(dict(pad_token_id=tokenizer.eos_token_id))
+        token_ids = ['eos_token_id', 'bos_token_id']
+        for token_id in token_ids:
+            if hasattr(tokenizer, token_id) and getattr(tokenizer, token_id) is not None:
+                gen_kwargs.update({token_id: getattr(tokenizer, token_id)})
 
     decoder_kwargs = dict(skip_special_tokens=True,
                           clean_up_tokenization_spaces=True)

--- a/loaders.py
+++ b/loaders.py
@@ -39,7 +39,8 @@ def get_tokenizer(tokenizer_loader, tokenizer_base_model, local_files_only, resu
     tokenizer = tokenizer_loader.from_pretrained(tokenizer_base_model,
                                                  local_files_only=local_files_only,
                                                  resume_download=resume_download,
-                                                 use_auth_token=use_auth_token)
+                                                 use_auth_token=use_auth_token,
+                                                 padding_side='left')
 
     tokenizer.pad_token_id = 0  # different from the eos token
     # when generating, we will use the logits of right-most token to predict the next token


### PR DESCRIPTION
Fixes #280 -- but response changed

```
=========================== short test summary info ============================
FAILED tests/test_manual_test.py::test_chat_context - NotImplementedError: MA...
FAILED tests/test_manual_test.py::test_upload_one_file - NotImplementedError:...
FAILED tests/test_manual_test.py::test_upload_multiple_file - NotImplementedE...
FAILED tests/test_manual_test.py::test_upload_url - NotImplementedError: MANU...
FAILED tests/test_manual_test.py::test_upload_arxiv - NotImplementedError: MA...
FAILED tests/test_manual_test.py::test_upload_pasted_text - NotImplementedErr...
FAILED tests/test_manual_test.py::test_no_db_dirs - NotImplementedError: MANU...
FAILED tests/test_manual_test.py::test_upload_unsupported_file - NotImplement...
FAILED tests/test_manual_test.py::test_upload_to_UserData_and_MyData - NotImp...
FAILED tests/test_manual_test.py::test_chat_control - NotImplementedError: MA...
FAILED tests/test_manual_test.py::test_subset_only - NotImplementedError: MAN...
FAILED tests/test_manual_test.py::test_add_new_doc - NotImplementedError: MAN...
= 12 failed, 103 passed, 37 skipped, 1 xfailed, 1 xpassed, 11 warnings in 3871.55s (1:04:31) =
```

Before on exact same dependencies but no fix as in this PR:

![image](https://github.com/h2oai/h2ogpt/assets/2249614/10a60c8b-e5f1-41f5-a590-cfb684866c77)


With PR:

![image](https://github.com/h2oai/h2ogpt/assets/2249614/9b0402e7-6372-4aa1-8ff9-43217b03d545)
