### PR TITLE
ChatAll: stream as fast as one can with short timeout=0.01 to avoid stalling any single endpoint to appear in UI

### DIFF
--- a/finetune.py
+++ b/finetune.py
@@ -617,10 +617,10 @@ def generate_and_tokenize_prompt(data_point, prompt_type=None, train_on_inputs=F
     assert tokenizer is not None
     prompt_dict = ''  # only for custom prompt_type
     assert prompt_type != PromptType.custom.name, "custom not setup for finetune"
-    full_prompt, _, _, _ = generate_prompt(data_point, prompt_type, prompt_dict, False, False, False)
+    full_prompt, _, _, _, _ = generate_prompt(data_point, prompt_type, prompt_dict, False, False, False)
     tokenized_full_prompt = tokenize(full_prompt, tokenizer, cutoff_len, add_eos_token=add_eos_token)
     if not train_on_inputs:
-        user_prompt, _, _, _ = generate_prompt({**data_point, "output": ""}, prompt_type, prompt_dict, False, False, False)
+        user_prompt, _, _, _, _ = generate_prompt({**data_point, "output": ""}, prompt_type, prompt_dict, False, False, False)
         tokenized_user_prompt = tokenize(user_prompt, tokenizer, cutoff_len, add_eos_token=add_eos_token)
         user_prompt_len = len(tokenized_user_prompt["input_ids"])
         if add_eos_token:

--- a/generate.py
+++ b/generate.py
@@ -795,7 +795,7 @@ def get_model(
             try:
                 print("GR Client Begin: %s" % inference_server)
                 # first do sanity check if alive, else gradio client takes too long by default
-                requests.get(inference_server, timeout=30)
+                requests.get(inference_server, timeout=int(os.getenv('REQUEST_TIMEOUT', '30')))
                 client = GradioClient(inference_server)
                 print("GR Client End: %s" % inference_server)
             except (OSError, ValueError):
@@ -812,7 +812,7 @@ def get_model(
             inference_server, headers = get_hf_server(inference_server)
             print("HF Client Begin: %s" % inference_server)
             try:
-                client = HFClient(inference_server, headers=headers, timeout=30)
+                client = HFClient(inference_server, headers=headers, timeout=int(os.getenv('REQUEST_TIMEOUT', '30')))
                 # quick check valid TGI endpoint
                 res = client.generate('What?', max_new_tokens=1)
                 client = HFClient(inference_server, headers=headers, timeout=300)
@@ -1561,7 +1561,7 @@ def evaluate(
             if gr_client is None:
                 inference_server, headers = get_hf_server(inference_server)
                 try:
-                    hf_client = HFClient(inference_server, headers=headers, timeout=30)
+                    hf_client = HFClient(inference_server, headers=headers, timeout=int(os.getenv('REQUEST_TIMEOUT', '30')))
                     # quick check valid TGI endpoint
                     res = hf_client.generate('What?', max_new_tokens=1)
                     hf_client = HFClient(inference_server, headers=headers, timeout=300)

--- a/generate.py
+++ b/generate.py
@@ -17,7 +17,8 @@ import filelock
 import requests
 import psutil
 from requests import ConnectTimeout, JSONDecodeError
-from urllib3.exceptions import ConnectTimeoutError, MaxRetryError
+from urllib3.exceptions import ConnectTimeoutError, MaxRetryError, ConnectionError
+from requests.exceptions import ConnectionError as ConnectionError2
 
 if os.path.dirname(os.path.abspath(__file__)) not in sys.path:
     sys.path.append(os.path.dirname(os.path.abspath(__file__)))
@@ -800,14 +801,16 @@ def get_model(
                 print("GR Client End: %s" % inference_server)
             except (OSError, ValueError):
                 client = None
-            except (ConnectTimeoutError, ConnectTimeout, MaxRetryError, ConnectionError, JSONDecodeError) as e:
+            except (ConnectTimeoutError, ConnectTimeout, MaxRetryError, ConnectionError, ConnectionError2,
+                    JSONDecodeError) as e:
+                client = None
                 t, v, tb = sys.exc_info()
                 ex = ''.join(traceback.format_exception(t, v, tb))
                 print("GR Client Failed: %s" % str(ex))
-                return None, None, None
         else:
             client = None
         if client is None:
+            res = None
             from text_generation import Client as HFClient
             inference_server, headers = get_hf_server(inference_server)
             print("HF Client Begin: %s" % inference_server)
@@ -816,9 +819,12 @@ def get_model(
                 # quick check valid TGI endpoint
                 res = client.generate('What?', max_new_tokens=1)
                 client = HFClient(inference_server, headers=headers, timeout=300)
-            except (ConnectTimeoutError, ConnectTimeout, MaxRetryError, ConnectionError, JSONDecodeError) as e:
+            except (ConnectTimeoutError, ConnectTimeout, MaxRetryError, ConnectionError, ConnectionError2,
+                    JSONDecodeError) as e:
                 client = None
-                res = None
+                t, v, tb = sys.exc_info()
+                ex = ''.join(traceback.format_exception(t, v, tb))
+                print("HF Client Failed: %s" % str(ex))
             print("HF Client End: %s %s" % (inference_server, res))
 
         # Don't return None, None for model, tokenizer so triggers
@@ -1561,7 +1567,8 @@ def evaluate(
             if gr_client is None:
                 inference_server, headers = get_hf_server(inference_server)
                 try:
-                    hf_client = HFClient(inference_server, headers=headers, timeout=int(os.getenv('REQUEST_TIMEOUT', '30')))
+                    hf_client = HFClient(inference_server, headers=headers,
+                                         timeout=int(os.getenv('REQUEST_TIMEOUT', '30')))
                     # quick check valid TGI endpoint
                     res = hf_client.generate('What?', max_new_tokens=1)
                     hf_client = HFClient(inference_server, headers=headers, timeout=300)

--- a/gradio_runner.py
+++ b/gradio_runner.py
@@ -16,6 +16,7 @@ import filelock
 import pandas as pd
 import requests
 import tabulate
+from iterators import TimeoutIterator
 
 from gradio_ui.css import get_css
 from gradio_ui.prompt_form import make_prompt_form, make_chatbots
@@ -1181,9 +1182,11 @@ def go_gradio(**kwargs):
                     args_list1.append(chatbot1)
                     # so consistent with prep_bot()
                     # with model_state1 at -3, my_db_state1 at -2, and history(chatbot) at -1
-                    gen_list.append(get_response(*tuple(args_list1), retry=retry))
+                    gen1 = get_response(*tuple(args_list1), retry=retry)
+                    gen1 = TimeoutIterator(gen1, timeout=0.01, sentinel=None)
+                    gen_list.append(gen1)
 
-                bots_old = [''] * len(gen_list)
+                bots_old = chatbots.copy()
                 for res1 in itertools.zip_longest(*gen_list):
                     bots = [x[0] if x is not None else y for x, y in zip(res1, bots_old)]
                     bots_old = bots.copy()

--- a/iterators/__init__.py
+++ b/iterators/__init__.py
@@ -1,0 +1,4 @@
+from .timeout_iterator import TimeoutIterator, AsyncTimeoutIterator
+from .iterator_pipe import IteratorPipe, AsyncIteratorPipe
+
+__all__ = ["TimeoutIterator", "AsyncTimeoutIterator", "IteratorPipe", "AsyncIteratorPipe"]

--- a/iterators/iterator_pipe.py
+++ b/iterators/iterator_pipe.py
@@ -1,0 +1,93 @@
+import queue
+import asyncio
+
+
+class IteratorPipe:
+    """
+    Iterator Pipe creates an iterator that can be fed in data from another block of code or thread of execution
+    """
+
+    def __init__(self, sentinel=object()):
+        self._q = queue.Queue()
+        self._sentinel = sentinel
+        self._sentinel_pushed = False
+        self._closed = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._closed:
+            raise StopIteration
+
+        data = self._q.get(block=True)
+        if data is self._sentinel:
+            self._closed = True
+            raise StopIteration
+
+        return data
+
+    def put(self, data) -> bool:
+        """
+        Pushes next item to Iterator and returns True
+        If iterator has been closed via close(), doesn't push anything and returns False
+        """
+        if self._sentinel_pushed:
+            return False
+
+        self._q.put(data)
+        return True
+
+    def close(self):
+        """
+        Close is idempotent. Calling close multiple times is safe
+        Iterator will raise StopIteration only after all elements pushed before close have been iterated
+        """
+        # make close idempotent
+        if not self._sentinel_pushed:
+            self._sentinel_pushed = True
+        self._q.put(self._sentinel)
+
+
+class AsyncIteratorPipe:
+
+    def __init__(self, sentinel=object()):
+        self._q = asyncio.Queue()
+        self._sentinel = sentinel
+        self._sentinel_pushed = False
+        self._closed = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._closed:
+            raise StopAsyncIteration
+
+        data = await self._q.get()
+        if data is self._sentinel:
+            self._closed = True
+            raise StopAsyncIteration
+
+        return data
+
+    async def put(self, data) -> bool:
+        """
+        Pushes next item to Iterator and returns True
+        If iterator has been closed via close(), doesn't push anything and returns False
+        """
+        if self._sentinel_pushed:
+            return False
+
+        await self._q.put(data)
+        return True
+
+    async def close(self):
+        """
+        Close is idempotent. Calling close multiple times is safe
+        Iterator will raise StopIteration only after all elements pushed before close have been iterated
+        """
+        # make close idempotent
+        if not self._sentinel_pushed:
+            self._sentinel_pushed = True
+            await self._q.put(self._sentinel)

--- a/iterators/timeout_iterator.py
+++ b/iterators/timeout_iterator.py
@@ -1,0 +1,161 @@
+import queue
+import asyncio
+import threading
+
+
+class TimeoutIterator:
+    """
+    Wrapper class to add timeout feature to synchronous iterators
+    - timeout: timeout for next(). Default=ZERO_TIMEOUT i.e. no timeout or blocking calls to next. Updated using set_timeout() 
+    - sentinel: the object returned by iterator when timeout happens
+    - reset_on_next: if set to True, timeout is reset to the value of ZERO_TIMEOUT on each iteration
+
+    TimeoutIterator uses a thread internally.
+    The thread stops once the iterator exhausts or raises an exception during iteration.
+
+    Any excptions raised within the wrapped iterator are popagated as it is.
+    Exception is raised when all elements geenerated by the actual iterator before exception have been consumed
+    Timeout can be set dynamically before going for iteration
+    """
+    ZERO_TIMEOUT = 0.0
+
+    def __init__(self, iterator, timeout=0.0, sentinel=object(), reset_on_next=False):
+        self._iterator = iterator
+        self._timeout = timeout
+        self._sentinel = sentinel
+        self._reset_on_next = reset_on_next
+
+        self._interrupt = False
+        self._done = False
+        self._buffer = queue.Queue()
+        self._thread = threading.Thread(target=self.__lookahead)
+        self._thread.start()
+
+    def get_sentinel(self):
+        return self._sentinel
+
+    def set_reset_on_next(self, reset_on_next):
+        self._reset_on_next = reset_on_next
+
+    def set_timeout(self, timeout: float):
+        """
+        Set timeout for next iteration
+        """
+        self._timeout = timeout
+
+    def interrupt(self):
+        """
+        interrupt and stop the underlying thread.
+        the thread acutally dies only after interrupt has been set and
+        the underlying iterator yields a value after that.
+        """
+        self._interrupt = True
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        """
+        yield the result from iterator
+        if timeout > 0:
+            yield data if available.
+            otherwise yield sentinal
+        """
+        if self._done:
+            raise StopIteration
+
+        data = self._sentinel
+        try:
+            if self._timeout > self.ZERO_TIMEOUT:
+                data = self._buffer.get(timeout=self._timeout)
+            else:
+                data = self._buffer.get()
+        except queue.Empty:
+            pass
+        finally:
+            # see if timeout needs to be reset
+            if self._reset_on_next:
+                self._timeout = self.ZERO_TIMEOUT
+
+        # propagate any exceptions including StopIteration
+        if isinstance(data, BaseException):
+            self._done = True
+            raise data
+
+        return data
+
+    def __lookahead(self):
+        try:
+            while True:
+                self._buffer.put(next(self._iterator))
+                if self._interrupt:
+                    raise StopIteration()
+        except BaseException as e:
+            self._buffer.put(e)
+
+
+class AsyncTimeoutIterator:
+    """
+    Async version of TimeoutIterator. See method documentation of TimeoutIterator
+    """
+    ZERO_TIMEOUT = 0.0
+
+    def __init__(self, iterator, timeout=0.0, sentinel=object(), reset_on_next=False):
+        self._iterator = iterator
+        self._timeout = timeout
+        self._sentinel = sentinel
+        self._reset_on_next = reset_on_next
+
+        self._interrupt = False
+        self._done = False
+        self._buffer = asyncio.Queue()
+        self._task = asyncio.get_event_loop().create_task(self.__lookahead())
+
+    def get_sentinel(self):
+        return self._sentinel
+
+    def set_reset_on_next(self, reset_on_next):
+        self._reset_on_next = reset_on_next
+
+    def set_timeout(self, timeout: float):
+        self._timeout = timeout
+
+    def interrupt(self):
+        self._interrupt = True
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._done:
+            raise StopAsyncIteration
+
+        data = self._sentinel
+        try:
+            if self._timeout > self.ZERO_TIMEOUT:
+                data = await asyncio.wait_for(self._buffer.get(), self._timeout)
+            else:
+                data = await self._buffer.get()
+        except asyncio.TimeoutError:
+            pass
+        finally:
+            # see if timeout needs to be reset
+            if self._reset_on_next:
+                self._timeout = self.ZERO_TIMEOUT
+
+        # propagate any exceptions including StopIteration
+        if isinstance(data, BaseException):
+            self._done = True
+            raise data
+
+        return data
+
+    async def __lookahead(self):
+        try:
+            while True:
+                data = await self._iterator.__anext__()
+                await self._buffer.put(data)
+                if self._interrupt:
+                    raise StopAsyncIteration()
+        except BaseException as e:
+            await self._buffer.put(e)

--- a/tests/test_async_iterator_pipe.py
+++ b/tests/test_async_iterator_pipe.py
@@ -1,0 +1,112 @@
+import unittest
+import asyncio
+from iterators import AsyncIteratorPipe
+
+
+class TestTimeoutIterator(unittest.TestCase):
+
+    def test_normal_iteration(self):
+
+        async def _(self):
+            it = AsyncIteratorPipe()
+
+            await it.put(1)
+            await it.put(2)
+            await it.put(3)
+            await it.close()  # stop iteration
+
+            self.assertEqual(await it.__anext__(), 1)
+            self.assertEqual(await it.__anext__(), 2)
+            self.assertEqual(await it.__anext__(), 3)
+
+            with self.assertRaises(StopAsyncIteration):
+                await it.__anext__()
+
+        asyncio.get_event_loop().run_until_complete(_(self))
+
+    def test_multiple_next_after_exception(self):
+
+        async def _(self):
+            it = AsyncIteratorPipe()
+
+            await it.put(1)
+            await it.put(2)
+            await it.put(3)
+            await it.close()  # stop iteration
+
+            self.assertEqual(await it.__anext__(), 1)
+            self.assertEqual(await it.__anext__(), 2)
+            self.assertEqual(await it.__anext__(), 3)
+
+            with self.assertRaises(StopAsyncIteration):
+                await it.__anext__()
+
+            with self.assertRaises(StopAsyncIteration):
+                await it.__anext__()
+
+        asyncio.get_event_loop().run_until_complete(_(self))
+
+
+    def test_multiple_close(self):
+
+        async def _(self):
+            it = AsyncIteratorPipe()
+
+            await it.put(1)
+            await it.put(2)
+            await it.put(3)
+            await it.close()  # stop iteration
+            await it.close()  # stop iteration
+            await it.close()  # stop iteration
+
+            self.assertEqual(await it.__anext__(), 1)
+            self.assertEqual(await it.__anext__(), 2)
+            self.assertEqual(await it.__anext__(), 3)
+
+            with self.assertRaises(StopAsyncIteration):
+                await it.__anext__()
+
+        asyncio.get_event_loop().run_until_complete(_(self))
+
+
+    def test_put_after_close(self):
+
+        async def _(self):
+            it = AsyncIteratorPipe()
+
+            self.assertTrue(await it.put(1))
+            await it.close()  # stop iteration
+
+            self.assertFalse(await it.put(2))
+            await it.close()  # stop iteration
+
+            self.assertFalse(await it.put(3))
+            await it.close()  # stop iteration
+
+            self.assertEqual(await it.__anext__(), 1)
+
+            with self.assertRaises(StopAsyncIteration):
+                await it.__anext__()
+
+        asyncio.get_event_loop().run_until_complete(_(self))
+
+    def test_normal_iteration_via_for_loop(self):
+
+        async def _(self):
+            it = AsyncIteratorPipe()
+            await it.put(1)
+            await it.put(2)
+            await it.put(3)
+            await it.close()
+
+            iter_results = []
+            async for x in it:
+                iter_results.append(x)
+            self.assertEqual(iter_results, [1,2,3])
+
+            iter_results = []
+            async for x in it:
+                iter_results.append(x)
+            self.assertEqual(iter_results, [])
+
+        asyncio.get_event_loop().run_until_complete(_(self))

--- a/tests/test_async_timeout_iterator.py
+++ b/tests/test_async_timeout_iterator.py
@@ -1,0 +1,204 @@
+import unittest
+import asyncio
+
+from iterators import AsyncTimeoutIterator
+
+
+async def iter_simple():
+    yield 1
+    yield 2
+
+
+async def iter_with_sleep():
+    yield 1
+    await asyncio.sleep(0.6)
+    yield 2
+    await asyncio.sleep(0.4)
+    yield 3
+
+
+async def iter_with_exception():
+    yield 1
+    yield 2
+    raise Exception
+    yield 3
+
+
+class TestTimeoutIterator(unittest.TestCase):
+
+    def test_normal_iteration(self):
+
+        async def _(self):
+
+            i = iter_simple()
+            it = AsyncTimeoutIterator(i)
+
+            self.assertEqual(await it.__anext__(), 1)
+            self.assertEqual(await it.__anext__(), 2)
+
+            with self.assertRaises(StopAsyncIteration):
+                await it.__anext__()
+            with self.assertRaises(StopAsyncIteration):
+                await it.__anext__()
+
+        asyncio.get_event_loop().run_until_complete(_(self))
+
+    def test_normal_iteration_for_loop(self):
+
+        async def _(self):
+
+            i = iter_simple()
+            it = AsyncTimeoutIterator(i)
+            iterResults = []
+            async for x in it: 
+                iterResults.append(x)        
+            self.assertEqual(iterResults, [1,2])
+
+        asyncio.get_event_loop().run_until_complete(_(self))
+
+    def test_timeout_block(self):
+
+        async def _(self):
+            i = iter_with_sleep()
+            it = AsyncTimeoutIterator(i)
+            self.assertEqual(await it.__anext__(), 1)
+            self.assertEqual(await it.__anext__(), 2)
+            self.assertEqual(await it.__anext__(), 3)
+
+            with self.assertRaises(StopAsyncIteration):
+                await it.__anext__()
+            with self.assertRaises(StopAsyncIteration):
+                            await it.__anext__()
+
+        asyncio.get_event_loop().run_until_complete(_(self))
+
+    def test_timeout_block_for_loop(self):
+
+        async def _(self):
+            i = iter_with_sleep()
+            it = AsyncTimeoutIterator(i)
+            iterResults = []
+            async for x in it: 
+                iterResults.append(x)        
+            self.assertEqual(iterResults, [1,2,3])
+
+        asyncio.get_event_loop().run_until_complete(_(self))
+
+    def test_fixed_timeout(self):
+
+        async def _(self):
+            i = iter_with_sleep()
+            it = AsyncTimeoutIterator(i, timeout=0.5)
+
+            self.assertEqual(await it.__anext__(), 1)
+            self.assertEqual(await it.__anext__(), it.get_sentinel())
+            self.assertEqual(await it.__anext__(), 2)
+            self.assertEqual(await it.__anext__(), 3)
+            with self.assertRaises(StopAsyncIteration):
+                await it.__anext__()
+        asyncio.get_event_loop().run_until_complete(_(self))
+        
+    def test_fixed_timeout(self):
+
+        async def _(self):
+            i = iter_with_sleep()
+            it = AsyncTimeoutIterator(i, timeout=0.5)
+            iterResults = []
+            async for x in it: 
+                iterResults.append(x)        
+            self.assertEqual(iterResults, [1,it.get_sentinel(),2,3])
+                
+        asyncio.get_event_loop().run_until_complete(_(self))
+
+    def test_timeout_update(self):
+        async def _(self):
+            i = iter_with_sleep()
+            it = AsyncTimeoutIterator(i, timeout=0.5)
+
+            self.assertEqual(await it.__anext__(), 1)
+            self.assertEqual(await it.__anext__(), it.get_sentinel())
+
+            it.set_timeout(0.3)
+            self.assertEqual(await it.__anext__(), 2)
+            self.assertEqual(await it.__anext__(), it.get_sentinel())
+
+            self.assertEqual(await it.__anext__(), 3)
+
+            with self.assertRaises(StopAsyncIteration):
+                await it.__anext__()
+
+        asyncio.get_event_loop().run_until_complete(_(self))
+
+    def test_custom_sentinel(self):
+        async def _(self):
+            i = iter_with_sleep()
+            it = AsyncTimeoutIterator(i, timeout=0.5, sentinel="END")
+            self.assertEqual(await it.__anext__(), 1)
+            self.assertEqual(await it.__anext__(), "END")
+
+            self.assertEqual(await it.__anext__(), 2)
+            self.assertEqual(await it.__anext__(), 3)
+
+            with self.assertRaises(StopAsyncIteration):
+                await it.__anext__()
+
+        asyncio.get_event_loop().run_until_complete(_(self))
+
+    def test_feature_timeout_reset(self):
+        async def _(self):
+            i = iter_with_sleep()
+            it = AsyncTimeoutIterator(i, timeout=0.5, reset_on_next=True)
+
+            self.assertEqual(await it.__anext__(), 1) # timeout gets reset after first iteration
+            self.assertEqual(await it.__anext__(), 2)
+            self.assertEqual(await it.__anext__(), 3)
+
+            with self.assertRaises(StopAsyncIteration):
+                await it.__anext__()
+
+        asyncio.get_event_loop().run_until_complete(_(self))
+
+    def test_function_set_reset_on_next(self):
+        async def _(self):
+            i = iter_with_sleep()
+            it = AsyncTimeoutIterator(i, timeout=0.35, reset_on_next=False)
+
+            self.assertEqual(await it.__anext__(), 1)
+            self.assertEqual(await it.__anext__(), it.get_sentinel())
+            it.set_reset_on_next(True)
+            self.assertEqual(await it.__anext__(), 2)
+            self.assertEqual(await it.__anext__(), 3)
+
+            with self.assertRaises(StopAsyncIteration):
+                await it.__anext__()
+
+        asyncio.get_event_loop().run_until_complete(_(self))
+
+    def test_iterator_raises_exception(self):
+        async def _(self):
+            i = iter_with_exception()
+            it = AsyncTimeoutIterator(i, timeout=0.5, sentinel="END")
+            self.assertEqual(await it.__anext__(), 1)
+            self.assertEqual(await it.__anext__(), 2)
+
+            with self.assertRaises(Exception):
+                await it.__anext__()
+            with self.assertRaises(StopAsyncIteration):
+                await it.__anext__()
+
+        asyncio.get_event_loop().run_until_complete(_(self))
+
+
+    def test_interrupt_thread(self):
+        async def _(self):
+            i = iter_with_sleep()
+            it = AsyncTimeoutIterator(i, timeout=0.5, sentinel="END")
+            self.assertEqual(await it.__anext__(), 1)
+            self.assertEqual(await it.__anext__(), it.get_sentinel())
+            it.interrupt()
+            self.assertEqual(await it.__anext__(), 2)
+
+            with self.assertRaises(StopAsyncIteration):
+                await it.__anext__()
+
+        asyncio.get_event_loop().run_until_complete(_(self))

--- a/tests/test_iterator_pipe.py
+++ b/tests/test_iterator_pipe.py
@@ -1,0 +1,81 @@
+import unittest
+from iterators import IteratorPipe
+
+
+class TestQueueToIterator(unittest.TestCase):
+
+    def test_normal_iteration(self):
+        it = IteratorPipe()
+
+        it.put(1)
+        it.put(2)
+        it.put(3)
+        it.close()  # stop iteration
+
+        self.assertEqual(next(it), 1)
+        self.assertEqual(next(it), 2)
+        self.assertEqual(next(it), 3)
+        self.assertRaises(StopIteration, next, it)
+
+    def test_normal_custom_sentinel(self):
+        sentinel = object()
+        it = IteratorPipe(sentinel=sentinel)
+
+        it.put(1)
+        it.put(2)
+        it.put(3)
+        it.put(sentinel)  # stop iteration
+
+        self.assertEqual(next(it), 1)
+        self.assertEqual(next(it), 2)
+        self.assertEqual(next(it), 3)
+        self.assertRaises(StopIteration, next, it)
+
+    def test_multiple_close(self):
+        sentinel = object()
+        it = IteratorPipe(sentinel=sentinel)
+
+        it.put(1)
+        it.put(2)
+        it.put(3)
+        it.close()  # stop iteration
+        it.close()  # stop iteration
+        it.close()  # stop iteration
+
+        self.assertEqual(next(it), 1)
+        self.assertEqual(next(it), 2)
+        self.assertEqual(next(it), 3)
+        self.assertRaises(StopIteration, next, it)
+
+    def test_multiple_next_after_close(self):
+        sentinel = object()
+        it = IteratorPipe(sentinel=sentinel)
+
+        it.put(1)
+        it.put(2)
+        it.put(3)
+        it.close()  # stop iteration
+
+        self.assertEqual(next(it), 1)
+        self.assertEqual(next(it), 2)
+        self.assertEqual(next(it), 3)
+        self.assertRaises(StopIteration, next, it)
+        self.assertRaises(StopIteration, next, it)
+        self.assertRaises(StopIteration, next, it)
+
+    def test_put_after_close(self):
+        sentinel = object()
+        it = IteratorPipe(sentinel=sentinel)
+
+        self.assertTrue(it.put(1))
+        it.close()  # stop iteration
+
+        self.assertFalse(it.put(2))
+        it.close()  # stop iteration
+
+        self.assertFalse(it.put(3))
+        it.close()  # stop iteration
+
+        self.assertEqual(next(it), 1)
+        self.assertRaises(StopIteration, next, it)
+        self.assertRaises(StopIteration, next, it)

--- a/tests/test_timeout_iterator.py
+++ b/tests/test_timeout_iterator.py
@@ -1,0 +1,138 @@
+import unittest
+import time
+
+from iterators import TimeoutIterator
+
+
+def iter_simple():
+    yield 1
+    yield 2
+
+
+def iter_with_sleep():
+    yield 1
+    time.sleep(0.6)
+    yield 2
+    time.sleep(0.4)
+    yield 3
+
+
+def iter_with_exception():
+    yield 1
+    yield 2
+    raise Exception
+    yield 3
+
+
+class TestTimeoutIterator(unittest.TestCase):
+
+    def test_normal_iteration(self):
+        i = iter_simple()
+        it = TimeoutIterator(i)
+
+        self.assertEqual(next(it), 1)
+        self.assertEqual(next(it), 2)
+
+        self.assertRaises(StopIteration, next, it)
+        self.assertRaises(StopIteration, next, it)
+
+    def test_normal_iteration_for_loop(self):
+        i = iter_simple()
+        it = TimeoutIterator(i)
+        iterResults = []
+        for x in it:
+            iterResults.append(x)
+        self.assertEqual(iterResults, [1, 2])
+
+    def test_timeout_block(self):
+        i = iter_with_sleep()
+        it = TimeoutIterator(i)
+        self.assertEqual(next(it), 1)
+        self.assertEqual(next(it), 2)
+        self.assertEqual(next(it), 3)
+        self.assertRaises(StopIteration, next, it)
+        self.assertRaises(StopIteration, next, it)
+
+    def test_timeout_block_for_loop(self):
+        i = iter_with_sleep()
+        it = TimeoutIterator(i)
+        iterResults = []
+        for x in it:
+            iterResults.append(x)
+        self.assertEqual(iterResults, [1, 2, 3])
+
+    def test_fixed_timeout(self):
+        i = iter_with_sleep()
+        it = TimeoutIterator(i, timeout=0.5)
+        self.assertEqual(next(it), 1)
+        self.assertEqual(next(it), it.get_sentinel())
+
+        self.assertEqual(next(it), 2)
+        self.assertEqual(next(it), 3)
+        self.assertRaises(StopIteration, next, it)
+
+    def test_fixed_timeout_for_loop(self):
+        i = iter_with_sleep()
+        it = TimeoutIterator(i, timeout=0.5)
+        iterResults = []
+        for x in it:
+            iterResults.append(x)
+        self.assertEqual(iterResults, [1, it.get_sentinel(), 2, 3])
+
+    def test_timeout_update(self):
+        i = iter_with_sleep()
+        it = TimeoutIterator(i, timeout=0.5)
+        self.assertEqual(next(it), 1)
+        self.assertEqual(next(it), it.get_sentinel())
+
+        it.set_timeout(0.3)
+        self.assertEqual(next(it), 2)
+        self.assertEqual(next(it), it.get_sentinel())
+
+        self.assertEqual(next(it), 3)
+        self.assertRaises(StopIteration, next, it)
+
+    def test_custom_sentinel(self):
+        i = iter_with_sleep()
+        it = TimeoutIterator(i, timeout=0.5, sentinel="END")
+        self.assertEqual(next(it), 1)
+        self.assertEqual(next(it), "END")
+
+        self.assertEqual(next(it), 2)
+        self.assertEqual(next(it), 3)
+        self.assertRaises(StopIteration, next, it)
+
+    def test_feature_timeout_reset(self):
+        i = iter_with_sleep()
+        it = TimeoutIterator(i, timeout=0.5, reset_on_next=True)
+        self.assertEqual(next(it), 1)  # timeout gets reset after first iteration
+        self.assertEqual(next(it), 2)
+        self.assertEqual(next(it), 3)
+        self.assertRaises(StopIteration, next, it)
+
+    def test_function_set_reset_on_next(self):
+        i = iter_with_sleep()
+        it = TimeoutIterator(i, timeout=0.35, reset_on_next=False)
+        self.assertEqual(next(it), 1)
+        self.assertEqual(next(it), it.get_sentinel())
+        it.set_reset_on_next(True)
+        self.assertEqual(next(it), 2)
+        self.assertEqual(next(it), 3)
+        self.assertRaises(StopIteration, next, it)
+
+    def test_iterator_raises_exception(self):
+        i = iter_with_exception()
+        it = TimeoutIterator(i, timeout=0.5, sentinel="END")
+        self.assertEqual(next(it), 1)
+        self.assertEqual(next(it), 2)
+        self.assertRaises(Exception, next, it)
+        self.assertRaises(StopIteration, next, it)
+
+    def test_interrupt_thread(self):
+        i = iter_with_sleep()
+        it = TimeoutIterator(i, timeout=0.5, sentinel="END")
+        self.assertEqual(next(it), 1)
+        self.assertEqual(next(it), it.get_sentinel())
+        it.interrupt()
+        self.assertEqual(next(it), 2)
+        self.assertRaises(StopIteration, next, it)


### PR DESCRIPTION
Fixes #332 by using https://github.com/leangaurav/pypi_iterator, so that stream as fast as one can with short timeout=0.01 to avoid stalling any single endpoint to appear in UI.