### PR TITLE
Handle exceptions better when doing multi-view model lock, and don't block good endpoints

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -739,6 +739,7 @@ def get_client_from_inference_server(inference_server, raise_connection_exceptio
             gr_client = GradioClient(inference_server)
             print("GR Client End: %s" % inference_server)
         except (OSError, ValueError):
+            # Occurs when wrong endpoint and should have been HF client, so don't hard raise, just move to HF
             gr_client = None
         except (ConnectTimeoutError, ConnectTimeout, MaxRetryError, ConnectionError, ConnectionError2,
                 JSONDecodeError) as e:

--- a/gradio_runner.py
+++ b/gradio_runner.py
@@ -1185,18 +1185,28 @@ def go_gradio(**kwargs):
                     # so consistent with prep_bot()
                     # with model_state1 at -3, my_db_state1 at -2, and history(chatbot) at -1
                     gen1 = get_response(*tuple(args_list1), retry=retry)
-                    gen1 = TimeoutIterator(gen1, timeout=0.01, sentinel=None)
+                    gen1 = TimeoutIterator(gen1, timeout=0.01, sentinel=None, raise_on_exception=False)
                     gen_list.append(gen1)
 
                 bots_old = chatbots.copy()
+                exceptions_old = [''] * len(bots_old)
                 for res1 in itertools.zip_longest(*gen_list):
-                    bots = [x[0] if x is not None else y for x, y in zip(res1, bots_old)]
+                    bots = [x[0] if x is not None and not isinstance(x, BaseException) else y for x, y in
+                            zip(res1, bots_old)]
                     bots_old = bots.copy()
-                    exceptions = '\n'.join([x[1] for x in res1 if x and x[1]])
+
+                    def larger_str(x, y):
+                        return x if len(x) > len(y) else y
+
+                    exceptions = [x[1] if x is not None and not isinstance(x, BaseException) else larger_str(str(x), y)
+                                  for x, y in zip(res1, exceptions_old)]
+                    exceptions_old = exceptions.copy()
+                    exceptions_str = '\n'.join(
+                        ['Model %s: %s' % (iix, x) for iix, x in enumerate(exceptions) if x not in [None, '', 'None']])
                     if len(bots) > 1:
-                        yield tuple(bots + [exceptions])
+                        yield tuple(bots + [exceptions_str])
                     else:
-                        yield bots[0], exceptions
+                        yield bots[0], exceptions_str
             finally:
                 clear_torch_cache()
 

--- a/iterators/timeout_iterator.py
+++ b/iterators/timeout_iterator.py
@@ -19,11 +19,12 @@ class TimeoutIterator:
     """
     ZERO_TIMEOUT = 0.0
 
-    def __init__(self, iterator, timeout=0.0, sentinel=object(), reset_on_next=False):
+    def __init__(self, iterator, timeout=0.0, sentinel=object(), reset_on_next=False, raise_on_exception=True):
         self._iterator = iterator
         self._timeout = timeout
         self._sentinel = sentinel
         self._reset_on_next = reset_on_next
+        self._raise_on_exception = raise_on_exception
 
         self._interrupt = False
         self._done = False
@@ -80,7 +81,10 @@ class TimeoutIterator:
         # propagate any exceptions including StopIteration
         if isinstance(data, BaseException):
             self._done = True
-            raise data
+            if self._raise_on_exception:
+                raise data
+            else:
+                return data
 
         return data
 


### PR DESCRIPTION
Handle exceptions better when doing multi-view model lock, so don't hang (quickly check if real connection there) and don't block or fail good endpoints in chat view.  Show exceptions for bad models in chat exceptions