### PR TITLE
Get number of tokens after limited, although before prompt_type is applied, to reduce max_new_tokens for OpenAI

### DIFF
--- a/gpt_langchain.py
+++ b/gpt_langchain.py
@@ -490,7 +490,7 @@ class H2OHuggingFaceTextGenInference(HuggingFaceTextGenInference):
         # HF inference server needs control over input tokens
         assert self.tokenizer is not None
         from h2oai_pipeline import H2OTextGenerationPipeline
-        prompt = H2OTextGenerationPipeline.limit_prompt(prompt, self.tokenizer)
+        prompt, num_prompt_tokens = H2OTextGenerationPipeline.limit_prompt(prompt, self.tokenizer)
 
         # NOTE: TGI server does not add prompting, so must do here
         data_point = dict(context='', instruction=prompt, input='')
@@ -603,6 +603,7 @@ def get_llm(use_openai_model=False,
         callbacks = [StreamingGradioCallbackHandler()]
         llm = cls(model_name=model_name,
                   temperature=temperature if do_sample else 0,
+                  # FIXME: Need to count tokens and reduce max_new_tokens to fit like in generate.py
                   max_tokens=max_new_tokens,
                   top_p=top_p if do_sample else 1,
                   frequency_penalty=0,

--- a/h2oai_pipeline.py
+++ b/h2oai_pipeline.py
@@ -71,8 +71,8 @@ class H2OTextGenerationPipeline(TextGenerationPipeline):
             # unknown
             model_max_length = None
 
+        num_prompt_tokens = None
         if model_max_length is not None:
-            num_prompt_tokens = None
             # can't wait for "hole" if not plain prompt_type, since would lose prefix like <human>:
             # For https://github.com/h2oai/h2ogpt/issues/192
             for trial in range(0, 3):
@@ -108,10 +108,10 @@ class H2OTextGenerationPipeline(TextGenerationPipeline):
                         print("Reduced max_new_tokens from %s -> %s" % (
                         generate_kwargs['max_new_tokens'], max_new_tokens))
                     generate_kwargs['max_new_tokens'] = max_new_tokens
-        return prompt_text
+        return prompt_text, num_prompt_tokens
 
     def preprocess(self, prompt_text, prefix="", handle_long_generation=None, **generate_kwargs):
-        prompt_text = H2OTextGenerationPipeline.limit_prompt(prompt_text, self.tokenizer)
+        prompt_text, num_prompt_tokens = H2OTextGenerationPipeline.limit_prompt(prompt_text, self.tokenizer)
 
         data_point = dict(context='', instruction=prompt_text, input='')
         if self.prompter is not None:


### PR DESCRIPTION
Get number of tokens after limited, although before prompt_type is applied, to reduce max_new_tokens for OpenAI, who interprets max as like a min since fail if input + max > 4096 even if don't need to generate max_new_tokens tokens, only need to generate min_new_tokens


```

Generation Failed: This model's maximum context length is 4097 tokens. However, you requested 4696 tokens (3672 in the messages, 1024 in the completion). Please reduce the length of the messages or completion.   File "/home/ubuntu/h2ogpt/iterators/timeout>
    self._buffer.put(next(self._iterator))
  File "/home/ubuntu/h2ogpt/gradio_runner.py", line 1149, in get_response
    for output_fun in fun1():
  File "/home/ubuntu/h2ogpt/generate.py", line 1622, in evaluate
    response = openai.ChatCompletion.create(
  File "/home/ubuntu/miniconda3/envs/h2ollm/lib/python3.10/site-packages/openai/api_resources/chat_completion.py", line 25, in create
    return super().create(*args, **kwargs)
  File "/home/ubuntu/miniconda3/envs/h2ollm/lib/python3.10/site-packages/openai/api_resources/abstract/engine_api_resource.py", line 153, in create
    response, _, api_key = requestor.request(
  File "/home/ubuntu/miniconda3/envs/h2ollm/lib/python3.10/site-packages/openai/api_requestor.py", line 298, in request
    resp, got_stream = self._interpret_response(result, stream)
  File "/home/ubuntu/miniconda3/envs/h2ollm/lib/python3.10/site-packages/openai/api_requestor.py", line 700, in _interpret_response
    self._interpret_response_line(
  File "/home/ubuntu/miniconda3/envs/h2ollm/lib/python3.10/site-packages/openai/api_requestor.py", line 763, in _interpret_response_line
    raise self.handle_error_response(
```