### PR TITLE
[DevOps] Isolate docker image build & push

### DIFF
--- a/ci/jenkinsfile
+++ b/ci/jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
         booleanParam(name: 'skipTesting', defaultValue: false, description: 'Skip testing')
         text(name: "testTargets", defaultValue: "${ALL_TESTS.keySet().join('\n')}", description: "A select set of tests to run")
         booleanParam(name: 'buildWheels', defaultValue: true, description: 'Build Python wheels')
-        booleanParam(name: 'buildAndpush', defaultValue: true, description: 'Build h2ogpt docker image & push if image does not exists in harbor')
+        booleanParam(name: 'buildAndPush', defaultValue: true, description: 'Build h2ogpt docker image & push if image does not exists in harbor')
         booleanParam(name: 'publish', defaultValue: false, description: 'Upload to HF')
     }
     options {
@@ -82,7 +82,7 @@ pipeline {
         stage('Build & Push Docker Image') {
             when {
                 anyOf {
-                    expression { return params.buildAndpush }
+                    expression { return params.buildAndPush }
                 }
                 beforeAgent true
             }

--- a/ci/jenkinsfile
+++ b/ci/jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
         booleanParam(name: 'skipTesting', defaultValue: false, description: 'Skip testing')
         text(name: "testTargets", defaultValue: "${ALL_TESTS.keySet().join('\n')}", description: "A select set of tests to run")
         booleanParam(name: 'buildWheels', defaultValue: true, description: 'Build Python wheels')
-        booleanParam(name: 'build&push', defaultValue: true, description: 'Build h2ogpt docker image & push if image does not exists in harbor')
+        booleanParam(name: 'buildAndpush', defaultValue: true, description: 'Build h2ogpt docker image & push if image does not exists in harbor')
         booleanParam(name: 'publish', defaultValue: false, description: 'Upload to HF')
     }
     options {
@@ -60,7 +60,7 @@ pipeline {
         stage('Build Wheels') {
             when {
                 anyOf {
-                    expression { return !params.buildWheels }
+                    expression { return params.buildWheels }
                 }
                 beforeAgent true
             }
@@ -82,7 +82,7 @@ pipeline {
         stage('Build & Push Docker Image') {
             when {
                 anyOf {
-                    expression { return !params.build&push }
+                    expression { return params.buildAndpush }
                 }
                 beforeAgent true
             }

--- a/ci/jenkinsfile
+++ b/ci/jenkinsfile
@@ -34,6 +34,8 @@ pipeline {
     parameters {
         booleanParam(name: 'skipTesting', defaultValue: false, description: 'Skip testing')
         text(name: "testTargets", defaultValue: "${ALL_TESTS.keySet().join('\n')}", description: "A select set of tests to run")
+        booleanParam(name: 'buildWheels', defaultValue: true, description: 'Build Python wheels')
+        booleanParam(name: 'build&push', defaultValue: true, description: 'Build h2ogpt docker image & push if image does not exists in harbor')
         booleanParam(name: 'publish', defaultValue: false, description: 'Upload to HF')
     }
     options {
@@ -41,7 +43,7 @@ pipeline {
         timestamps()
     }
     stages {
-        stage('Build') {
+        stage('Init') {
             agent {
                 label "linux && docker"
             }
@@ -51,14 +53,45 @@ pipeline {
                     def commitMsg = sh(returnStdout: true, script: 'git log -1 --pretty=format:"[%an] %s"').trim()
                     currentBuild.displayName = "${env.BUILD_ID} - [${shortHash}]"
                     currentBuild.description = "${commitMsg}"
+                }
+            }
+        }
 
-                    sh "make docker_build"
+        stage('Build Wheels') {
+            when {
+                anyOf {
+                    expression { return !params.buildWheels }
+                }
+                beforeAgent true
+            }
+            agent {
+                label "linux && docker"
+            }
+            steps {
+                script {
                     docker.image("harbor.h2o.ai/library/python:3.10").inside("--entrypoint='' --security-opt seccomp=unconfined -e USE_WHEEL=1 -e HOME=${WORKSPACE}") {
                         sh "make clean dist"
                     }
 
                     archiveArtifacts allowEmptyArchive: true, artifacts: "dist/h2ogpt-*.whl"
                     stash includes: "dist/h2ogpt-*.whl", name: "wheel_file"
+                }
+            }
+        }
+
+        stage('Build & Push Docker Image') {
+            when {
+                anyOf {
+                    expression { return !params.build&push }
+                }
+                beforeAgent true
+            }
+            agent {
+                label "linux && docker"
+            }
+            steps {
+                script {
+                    sh "make docker_build"
                 }
             }
         }


### PR DESCRIPTION
**Notes**

- Modified the pipeline such that a user can run the pipeline, just to build & push the h2ogpt docker image to harbor when needed.
- Example runs:
    1. http://jenkins.h2o.local:8080/job/h2ogpt-test/40/
    2. http://jenkins.h2o.local:8080/job/h2ogpt-test/39/
    
**Parent Issue**
- https://github.com/h2oai/h2ogpt/issues/315