### PR TITLE
Add a docker runtime, to be used to run h2o gpt models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ dist
 .local
 .bash_history
 .benchmarks
+Dockerfile-runner.dockerfile
 
 # IDEs
 .idea/

--- a/Dockerfile-runner.in
+++ b/Dockerfile-runner.in
@@ -1,0 +1,15 @@
+FROM BASE_DOCKER_IMAGE_SUBST
+
+LABEL imagetype="runtime-h2ogpt"
+LABEL maintainer="H2O.ai <ops@h2o.ai>"
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TRANSFORMERS_CACHE=/h2ogpt_env/.cache
+ENV HF_MODEL=h2oai/h2ogpt-gm-oasst1-en-2048-falcon-7b-v3
+
+COPY run-gpt.sh /run-gpt.sh
+
+EXPOSE 8888
+EXPOSE 7860
+
+ENTRYPOINT ["/run-gpt.sh"]

--- a/Makefile
+++ b/Makefile
@@ -46,14 +46,18 @@ else
 	docker push $(DOCKER_TEST_IMAGE)
 endif
 
+.PHONY: Dockerfile-runner.dockerfile
+
 Dockerfile-runner.dockerfile: Dockerfile-runner.in
 	cat $< \
 	| sed 's|BASE_DOCKER_IMAGE_SUBST|$(DOCKER_TEST_IMAGE)|g' \
 	> $@
 
 docker_build_runner: docker_build Dockerfile-runner.dockerfile
+	docker pull $(DOCKER_TEST_IMAGE)
 	DOCKER_BUILDKIT=1 docker build -t $(DOCKER_RUN_IMAGE) -f Dockerfile-runner.dockerfile .
 	docker push $(DOCKER_RUN_IMAGE)
+	docker tag $(DOCKER_RUN_IMAGE) gcr.io/vorvan/h2oai/h2ogpt-runtime:$(BUILD_TAG)
 
 print-%:
 	@echo $($*)

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ PACKAGE_VERSION       := `cat version.txt | tr -d '\n'`
 BUILD_TAG_FILES       := requirements.txt Dockerfile `ls reqs_optional/*.txt | sort`
 BUILD_TAG             := $(shell md5sum $(BUILD_TAG_FILES) 2> /dev/null | sort | md5sum | cut -d' ' -f1)
 DOCKER_TEST_IMAGE     := harbor.h2o.ai/h2ogpt/test-image:$(BUILD_TAG)
+DOCKER_RUN_IMAGE      := $(DOCKER_TEST_IMAGE)-runtime
 PYTHON_BINARY         ?= `which python`
 DEFAULT_MARKERS       ?= "not need_tokens and not need_gpu"
 
@@ -44,6 +45,15 @@ else
 	DOCKER_BUILDKIT=1 docker build -t $(DOCKER_TEST_IMAGE) -f Dockerfile .
 	docker push $(DOCKER_TEST_IMAGE)
 endif
+
+Dockerfile-runner.dockerfile: Dockerfile-runner.in
+	cat $< \
+	| sed 's|BASE_DOCKER_IMAGE_SUBST|$(DOCKER_TEST_IMAGE)|g' \
+	> $@
+
+docker_build_runner: docker_build Dockerfile-runner.dockerfile
+	DOCKER_BUILDKIT=1 docker build -t $(DOCKER_RUN_IMAGE) -f Dockerfile-runner.dockerfile .
+	docker push $(DOCKER_RUN_IMAGE)
 
 print-%:
 	@echo $($*)

--- a/run-gpt.sh
+++ b/run-gpt.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo "$(date '+%F %T') BEGIN: run-gpt.sh"
+
+set -e
+
+export TRANSFORMERS_CACHE=/h2ogpt_env/.cache
+
+# run generate.py
+mkdir -p /h2ogpt_env && cd /h2ogpt_env
+exec python3.10 /workspace/generate.py --base_model=${HF_MODEL} --load_8bit=True  --score_model=None --local_files_only=True

--- a/run-gpt.sh
+++ b/run-gpt.sh
@@ -8,4 +8,4 @@ export TRANSFORMERS_CACHE=/h2ogpt_env/.cache
 
 # run generate.py
 mkdir -p /h2ogpt_env && cd /h2ogpt_env
-exec python3.10 /workspace/generate.py --base_model=${HF_MODEL} --load_8bit=True  --score_model=None --local_files_only=True
+exec python3.10 /workspace/generate.py --base_model=${HF_MODEL}


### PR DESCRIPTION
Once images are built, one can run like following:
```
docker run --runtime nvidia -e HF_MODEL=h2oai/h2ogpt-gm-oasst1-en-2048-falcon-7b-v3 -p 8888:8888 gcr.io/vorvan/h2oai/h2ogpt-runtime:61d6aea6fff3b1190aa42eee7fa10d6c
```

- to persist cache, can add: 
```
 -v `pwd`/h2ogpt_env:/h2ogpt_env
```
- to run with custom entrypoint, can modify the local run-gpt.sh then add:
```
-v `pwd`/run-gpt.sh:/run-gpt.sh
```
- to select different model, set the HF source in `HF_MODEL`