### PR TITLE
Update docs for llama metal support

### DIFF
--- a/docs/README_MACOS.md
+++ b/docs/README_MACOS.md
@@ -117,3 +117,29 @@ python generate.py --base_model=h2oai/h2ogpt-gm-oasst1-en-2048-open-llama-7b --l
 For the above, ignore the CLI output saying `0.0.0.0`, and instead point browser at http://localhost:7860 (for windows/mac) or the public live URL printed by the server (disable shared link with `--share=False`).
 
 See [CPU](README_CPU.md) and [GPU](README_GPU.md) for some other general aspects about using h2oGPT on CPU or GPU, such as which models to try.
+
+---
+
+#### GPU with LLaMa
+
+**Note**: Currently `llama-cpp-python` only supports v3 ggml 4 bit quantized models, so use llama models ends with `ggmlv3` & `q4_x.bin`.
+
+1. Install dependencies
+    ```bash
+    # Required for Doc Q/A: LangChain:
+    pip install -r reqs_optional/requirements_optional_langchain.txt
+    # Required for CPU: LLaMa/GPT4All:
+    pip install -r reqs_optional/requirements_optional_gpt4all.txt
+    ```
+2. Install the LATEST llama-cpp-python...which happily supports MacOS Metal GPU as of version 0.1.62 (you should now have llama-cpp-python v0.1.62 or higher installed)
+    ```bash
+    pip uninstall llama-cpp-python -y
+    CMAKE_ARGS="-DLLAMA_METAL=on" FORCE_CMAKE=1 pip install -U llama-cpp-python --no-cache-dir
+    ```
+3. Edit below settings in `.env_gpt4all`
+    - Uncomment line with `n_gpu_layers=20`
+    - Change model name with your preferred model at line with `model_path_llama=WizardLM-7B-uncensored.ggmlv3.q8_0.bin`
+4. Run LLaMa model
+    ```bash
+    python generate.py --base_model='llama' --cli==True
+    ```

--- a/docs/README_MACOS.md
+++ b/docs/README_MACOS.md
@@ -122,7 +122,7 @@ See [CPU](README_CPU.md) and [GPU](README_GPU.md) for some other general aspects
 
 #### GPU with LLaMa
 
-**Note**: Currently `llama-cpp-python` only supports v3 ggml 4 bit quantized models, so use llama models ends with `ggmlv3` & `q4_x.bin`.
+**Note**: Currently `llama-cpp-python` only supports v3 ggml 4 bit quantized models for MPS, so use llama models ends with `ggmlv3` & `q4_x.bin`.
 
 1. Install dependencies
     ```bash


### PR DESCRIPTION
Fix #449 

Follow the instructions on doc to run llama model with MPS on Mac m1

Output:

```bash
  ~/Desktop/h2ogpt on   main !2 ❯ python generate.py --base_model=llama --cli=True                                                                                                                                                                                                                                                          ✘ INT  h2ogpt
Auto set langchain_mode=ChatLLM.  Could use MyData instead.  To allow UserData to pull files from disk, set user_path and ensure allow_upload_to_user_data=True
Using Model llama
Prep: persist_directory=db_dir_UserData does not exist, regenerating
Chose UserData but user_path is empty/None
Starting get_model: llama 
llama.cpp: loading model from WizardLM-7B-uncensored.ggmlv3.q4_0.bin
llama_model_load_internal: format     = ggjt v3 (latest)
llama_model_load_internal: n_vocab    = 32001
llama_model_load_internal: n_ctx      = 1792
llama_model_load_internal: n_embd     = 4096
llama_model_load_internal: n_mult     = 256
llama_model_load_internal: n_head     = 32
llama_model_load_internal: n_layer    = 32
llama_model_load_internal: n_rot      = 128
llama_model_load_internal: ftype      = 2 (mostly Q4_0)
llama_model_load_internal: n_ff       = 11008
llama_model_load_internal: model size = 7B
llama_model_load_internal: ggml ctx size =    0.08 MB
llama_model_load_internal: mem required  = 5407.72 MB (+ 1026.00 MB per state)
llama_new_context_with_model: kv self size  =  896.00 MB
ggml_metal_init: allocating
ggml_metal_init: using MPS
ggml_metal_init: loading '/Users/mathanraj/miniconda3/envs/h2ogpt/lib/python3.10/site-packages/llama_cpp/ggml-metal.metal'
ggml_metal_init: loaded kernel_add                            0x1713c0660
ggml_metal_init: loaded kernel_mul                            0x1713c08f0
ggml_metal_init: loaded kernel_mul_row                        0x1713c0b50
ggml_metal_init: loaded kernel_scale                          0x13c9558d0
ggml_metal_init: loaded kernel_silu                           0x13c94cc10
ggml_metal_init: loaded kernel_relu                           0x12af77570
ggml_metal_init: loaded kernel_gelu                           0x12af5ed60
ggml_metal_init: loaded kernel_soft_max                       0x12af42330
ggml_metal_init: loaded kernel_diag_mask_inf                  0x12af42590
ggml_metal_init: loaded kernel_get_rows_f16                   0x12af878a0
ggml_metal_init: loaded kernel_get_rows_q4_0                  0x12af84460
ggml_metal_init: loaded kernel_get_rows_q4_1                  0x12af846c0
ggml_metal_init: loaded kernel_get_rows_q2_K                  0x12af84920
ggml_metal_init: loaded kernel_get_rows_q3_K                  0x12af84b80
ggml_metal_init: loaded kernel_get_rows_q4_K                  0x12af84de0
ggml_metal_init: loaded kernel_get_rows_q5_K                  0x17152bae0
ggml_metal_init: loaded kernel_get_rows_q6_K                  0x17152c0e0
ggml_metal_init: loaded kernel_rms_norm                       0x17152c5f0
ggml_metal_init: loaded kernel_norm                           0x17152cb00
ggml_metal_init: loaded kernel_mul_mat_f16_f32                0x17152d1c0
ggml_metal_init: loaded kernel_mul_mat_q4_0_f32               0x17152d6e0
ggml_metal_init: loaded kernel_mul_mat_q4_1_f32               0x17152dc20
ggml_metal_init: loaded kernel_mul_mat_q2_K_f32               0x17152e160
ggml_metal_init: loaded kernel_mul_mat_q3_K_f32               0x17152e840
ggml_metal_init: loaded kernel_mul_mat_q4_K_f32               0x17152ed80
ggml_metal_init: loaded kernel_mul_mat_q5_K_f32               0x17152f2c0
ggml_metal_init: loaded kernel_mul_mat_q6_K_f32               0x17152f800
ggml_metal_init: loaded kernel_rope                           0x171530150
ggml_metal_init: loaded kernel_alibi_f32                      0x171530870
ggml_metal_init: loaded kernel_cpy_f32_f16                    0x171530f60
ggml_metal_init: loaded kernel_cpy_f32_f32                    0x1715318b0
ggml_metal_init: loaded kernel_cpy_f16_f16                    0x171531fa0
ggml_metal_init: recommendedMaxWorkingSetSize = 10922.67 MB
ggml_metal_init: hasUnifiedMemory             = true
ggml_metal_init: maxTransferRate              = built-in GPU
llama_new_context_with_model: max tensor size =    70.31 MB
ggml_metal_add_buffer: allocated 'data            ' buffer, size =  3616.08 MB, ( 3616.53 / 10922.67)
ggml_metal_add_buffer: allocated 'eval            ' buffer, size =   768.00 MB, ( 4384.53 / 10922.67)
ggml_metal_add_buffer: allocated 'kv              ' buffer, size =   898.00 MB, ( 5282.53 / 10922.67)
ggml_metal_add_buffer: allocated 'scr0            ' buffer, size =   512.00 MB, ( 5794.53 / 10922.67)
ggml_metal_add_buffer: allocated 'scr1            ' buffer, size =   512.00 MB, ( 6306.53 / 10922.67)
AVX = 0 | AVX2 = 0 | AVX512 = 0 | AVX512_VBMI = 0 | AVX512_VNNI = 0 | FMA = 0 | NEON = 1 | ARM_FMA = 1 | F16C = 0 | FP16_VA = 1 | WASM_SIMD = 0 | BLAS = 1 | SSE3 = 0 | VSX = 0 | 

Enter an instruction: hi
Hello! How can I assist you today?
```



---

NOTE:

Currently `llama-cpp-python` only supports v3 ggml 4 bit quantized models for MPS, so use llama models ends with `ggmlv3` & `q4_x.bin`.

For more info: https://github.com/abetlen/llama-cpp-python/blob/main/docs/install/macos.md

![image](https://github.com/h2oai/h2ogpt/assets/30664910/d53a6d79-edd1-4008-8532-284451984fa8)
