### PR TITLE
upgrade chroma to 0.4.0

### DIFF
--- a/reqs_optional/requirements_optional_langchain.txt
+++ b/reqs_optional/requirements_optional_langchain.txt
@@ -8,7 +8,7 @@ pypdf==3.9.1
 sentence_transformers==2.2.2
 
 # local vector db
-chromadb==0.3.25
+chromadb==0.4.0
 # server vector db
 #pymilvus==2.2.8
 

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -1445,7 +1445,7 @@ def get_existing_db(db, persist_directory, load_db_if_exists, db_type, use_opena
             embedding = get_embedding(use_openai_embedding, hf_embedding_model=hf_embedding_model)
             from chromadb.config import Settings
             client_settings = Settings(anonymized_telemetry=False,
-                                       chroma_db_impl="duckdb+parquet",
+                                       is_persistent=True,
                                        persist_directory=persist_directory)
             db = Chroma(persist_directory=persist_directory, embedding_function=embedding,
                         collection_name=langchain_mode.replace(' ', '_'),


### PR DESCRIPTION
** This should land Monday the 17th ** 

Chroma is upgrading from `0.3.29` to `0.4.0`. `0.4.0` is easier to build, more durable, faster, smaller, and more extensible. This comes with a few changes:

1. A simplified and improved client setup. Instead of having to remember weird settings, users can just do `EphemeralClient`, `PersistentClient` or `HttpClient` (the underlying direct `Client` implementation is also still accessible)

2. We migrated data stores away from `duckdb` and `clickhouse`. This changes the api for the `PersistentClient` that used to reference `chroma_db_impl="duckdb+parquet"`. Now we simply set `is_persistent=true`. `is_persistent` is set for you to `true` if you use `PersistentClient`. 

3. Because we migrated away from `duckdb` and `clickhouse` - this also means that users need to migrate their data into the new layout and schema. Chroma is committed to providing extension notification and tooling around any schema and data migrations (for example - this PR!). 

After upgrading to `0.4.0` - if users try to access their data that was stored in the previous regime, the system will throw an `Exception` and instruct them how to use the migration assistant to migrate their data. The migration assitant is a pip installable CLI: `pip install chroma_migrate`. And is runnable by calling `chroma_migrate` 

Please reference the readme at [chroma-core/chroma-migrate](https://github.com/chroma-core/chroma-migrate) to see a full write-up of our philosophy on migrations as well as more details about this particular migration. 

Please direct any users facing issues upgrading to our Discord channel called [#get-help](https://discord.com/channels/1073293645303795742/1129200523111841883). We have also created a [email listserv](https://airtable.com/shrHaErIs1j9F97BE) to notify developers directly in the future about breaking changes. 

TODO
- [x] Migrated any `duckdb+parquet` strings to the new format
- [ ] Notified users about the breaking change (this PR, other suggestions?)
