### PR TITLE
Minor Shell Script Changes

### DIFF
--- a/papers/technical-report/compile.sh
+++ b/papers/technical-report/compile.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/bin/sh
 latexmk -pdf h2oGPT-TR.tex

--- a/run-gpt.sh
+++ b/run-gpt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 echo "$(date '+%F %T') BEGIN: run-gpt.sh"
 
@@ -8,4 +8,4 @@ export TRANSFORMERS_CACHE=/h2ogpt_env/.cache
 
 # run generate.py
 mkdir -p /h2ogpt_env && cd /h2ogpt_env
-exec python3.10 /workspace/generate.py --base_model=${HF_MODEL}
+exec python3.10 /workspace/generate.py --base_model="${HF_MODEL}"

--- a/spaces/chatbot/repo_to_spaces.sh
+++ b/spaces/chatbot/repo_to_spaces.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # NOTE: start in h2ogpt repo base directory
 # i.e. can run below to update both spaces (assumes repos already existed, else will have to login HF for each)
@@ -9,12 +9,12 @@ echo "Space name: $spacename"
 
 # NOTE: start in h2ogpt repo base directory
 
-h2ogpt_hash=`git rev-parse HEAD`
+h2ogpt_hash="$(git rev-parse HEAD)"
 
 ln -sr src/gen.py src/evaluate_params.py src/gradio_runner.py src/gradio_themes.py h2o-logo.svg LICENSE src/stopping.py src/prompter.py src/enums.py src/utils.py src/utils_langchain.py src/client_test.py src/gpt_langchain.py src/create_data.py src/h2oai_pipeline.py src/gpt4all_llm.py src/loaders.py requirements.txt iterators reqs_optional gradio_utils spaces/chatbot/
 cd ..
 
-rm -rf ${spacename}
+rm -rf "${spacename}"
 git clone https://huggingface.co/spaces/h2oai/"${spacename}"
 cd "${spacename}"
 git reset --hard origin/main


### PR DESCRIPTION
Changed shell scripts for portability:
1) Changed to use /bin/sh instead of /bin/bash

Scripts all used posix-compliant commands, so /bin/sh will work and this way the scripts will run on a system that does not have bash

2) Changed backtick `` usage to "$()"
The former is largely deprecated.

3) Added quotes to variables as recommended by shellcheck utility