### PR TITLE
Revert "Use latest bitsandbytes and accelerate."

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,8 +17,8 @@ numpy==1.24.3
 pandas==2.0.2
 matplotlib==3.7.1
 loralib==0.1.1
-bitsandbytes==0.40.0
-accelerate==0.21.0
+bitsandbytes==0.39.0
+accelerate==0.20.3
 https://h2o-release.s3.amazonaws.com/h2ogpt/peft-0.4.0.dev0-py3-none-any.whl
 transformers==4.30.2
 tokenizers==0.13.3


### PR DESCRIPTION
Reverts h2oai/h2ogpt#485

Getting total garbage results for 4-bit after accelerate/bitsandbytes upgrade, e.g.
```
pytest -s -v tests/test_eval.py::test_eval1 -k False-4-h2oai/h2ogpt-oig-oasst1-512-6_9b
```
gives as output:

```
The normal contact',debtedodryodarodossedosschasiychinthpjunkchondrogetjaljuhjuhjuhjuhjgj &TGATwentyu(((nudharmsj2oyRurriss & 2n2u2)printhapyprassopriopoeosstelemastear-.STIStF."sseMPosintooeSRREopMPR1bepreswonderointTLbackKrisSwachjop/tlho(TLockerrbackopuntwop-termeropsinagjefinopoietfajonjoch1Swishohesirpoietintlinjurt-swithin-TGiinumiIt-termaniereintopobovetjargalisibmopreisi'bootstrap'o+utentwitalissob. (W.B.ίνiese'spojgs.sersy'BiasBheckukbojanksubb. (jukjapr. oterubmeBiancrosstermestojpruid-ubb. (tho. SSC (thill
```
it was working perfectly fine before.  It was detected as a unusually small reward score failure.

I'll probably revert that change until we figure out, since at least all other older things were working before.