### PR TITLE
Update readme for semver docker runtime image

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ docker run \
     -p 8888:8888 -p 7860:7860 \
     --rm --init \
     -v `pwd`/h2ogpt_env:/h2ogpt_env \
-    gcr.io/vorvan/h2oai/h2ogpt-runtime:61d6aea6fff3b1190aa42eee7fa10d6c
+    gcr.io/vorvan/h2oai/h2ogpt-runtime:0.1.0
 ```
 3. Navigate to http://localhost:7860/  & start using h2oGPT.
 


### PR DESCRIPTION
- Pushed a new h2ogpt docker-runtime image for revision [cae8cb9b46e701b4eeddf55da46297f7d55a7121](https://github.com/h2oai/h2ogpt/tree/cae8cb9b46e701b4eeddf55da46297f7d55a7121) with semver tag 0.1.0