### PR TITLE
Support exllama

### DIFF
--- a/.env_gpt4all
+++ b/.env_gpt4all
@@ -15,3 +15,5 @@ max_tokens=1792
 model_name_gpt4all_llama=ggml-wizardLM-7B.q4_2.bin
 
 # PDF_CLASS_NAME=UnstructuredPDFLoader
+
+model_name_exllama_if_no_config=TheBloke/Nous-Hermes-Llama2-GPTQ

--- a/README.md
+++ b/README.md
@@ -147,8 +147,10 @@ sudo apt-get install -y libmagic-dev poppler-utils tesseract-ocr libtesseract-de
 python -m nltk.downloader all
 # Optional: For AutoGPTQ support on x86_64 linux
 pip uninstall -y auto-gptq ; CUDA_HOME=/usr/local/cuda-11.8  GITHUB_ACTIONS=true pip install auto-gptq --no-cache-dir
+# Optional: For exllama support on x86_64 linux
+pip uninstall -y exllama ; pip install https://github.com/jllllll/exllama/releases/download/0.0.7/exllama-0.0.7+cu118-cp310-cp310-linux_x86_64.whl --no-cache-dir
 ```
-See [AutoGPTQ](docs/README_GPU.md#autogptq) for more details for AutoGPTQ and other GPU installation aspects.
+See [AutoGPTQ](docs/README_GPU.md#autogptq) for more details for AutoGPTQ and other GPU installation aspects.  See [exllama](docs/README_GPU.md#) for more details for AutoGPTQ and other GPU installation aspects.
 #### Run h2oGPT
 
 Place all documents in `user_path` or upload in UI ([Help with UI](docs/README_ui.md)).

--- a/README.md
+++ b/README.md
@@ -151,7 +151,13 @@ pip uninstall -y auto-gptq ; CUDA_HOME=/usr/local/cuda-11.8  GITHUB_ACTIONS=true
 pip uninstall -y exllama ; pip install https://github.com/jllllll/exllama/releases/download/0.0.7/exllama-0.0.7+cu118-cp310-cp310-linux_x86_64.whl --no-cache-dir
 ```
 See [AutoGPTQ](docs/README_GPU.md#autogptq) for more details for AutoGPTQ and other GPU installation aspects.  See [exllama](docs/README_GPU.md#) for more details for AutoGPTQ and other GPU installation aspects.
+
 #### Run h2oGPT
+To avoid unauthorized telemetry, which document options still do not disable, run:
+```bash
+sp=`python -c 'import site; print(site.getsitepackages()[0])'`
+sed -i 's/posthog\.capture/return\n            posthog.capture/' $sp/chromadb/telemetry/posthog.py
+```
 
 Place all documents in `user_path` or upload in UI ([Help with UI](docs/README_ui.md)).
 

--- a/docs/README_GPU.md
+++ b/docs/README_GPU.md
@@ -101,6 +101,7 @@ python generate.py --base_model=TheBloke/Llama-2-7b-Chat-GPTQ --load_gptq="gptq_
 ```
 For full 16-bit with 16k context across all GPUs:
 ```bash
+pip install transformers==4.31.0  # breaks load_in_8bit=True in some cases (https://github.com/huggingface/transformers/issues/25026)
 python generate.py --base_model=meta-llama/Llama-2-70b-chat-hf --prompt_type=llama2 --rope_scaling="{'type': 'linear', 'factor': 4}" --use_gpu_id=False --save_dir=savemeta70b
 ```
 and running on 4xA6000 gives about 4tokens/sec consuming about 35GB per GPU of 4 GPUs when idle.

--- a/docs/README_GPU.md
+++ b/docs/README_GPU.md
@@ -106,6 +106,13 @@ python generate.py --base_model=meta-llama/Llama-2-70b-chat-hf --prompt_type=lla
 and running on 4xA6000 gives about 4tokens/sec consuming about 35GB per GPU of 4 GPUs when idle.
 Currently, Hugging Face transformers does not support GPTQ directly except in text-generation-inference (TGI) server, but TGI does not support RoPE scaling.  Also, vLLM supports LLaMa2 and AutoGPTQ but not RoPE scaling.  Only exllama supports AutoGPTQ with RoPE scaling.
 
+##### exllama
+
+Currently, only [exllama](https://github.com/turboderp/exllama) supports AutoGPTQ with RoPE scaling.  To install run:
+```bash
+pip uninstall -y exllama ; pip install https://github.com/jllllll/exllama/releases/download/0.0.7/exllama-0.0.7+cu118-cp310-cp310-linux_x86_64.whl
+```
+
 ---
 
 #### GPU with LLaMa

--- a/docs/README_GPU.md
+++ b/docs/README_GPU.md
@@ -112,6 +112,16 @@ Currently, only [exllama](https://github.com/turboderp/exllama) supports AutoGPT
 ```bash
 pip uninstall -y exllama ; pip install https://github.com/jllllll/exllama/releases/download/0.0.7/exllama-0.0.7+cu118-cp310-cp310-linux_x86_64.whl
 ```
+And then run with RoPE scaling the LLaMa-2 7B model for 16k context:
+```bash
+python generate.py --base_model=TheBloke/Llama-2-7b-Chat-GPTQ --load_gptq="gptq_model-4bit-128g" --use_safetensors=True --prompt_type=llama2 --save_dir='7bgptq4bit' --load_exllama=True --revision=gptq-4bit-32g-actorder_True --rope_scaling="{'alpha_value':4}"
+```
+which shows how to control `alpha_value` and the `revision` for a given model on [TheBloke/Llama-2-7b-Chat-GPTQ](https://huggingface.co/TheBloke/Llama-2-7b-Chat-GPTQ).  Be careful as setting `alpha_value` higher consumes substantially more GPU memory.  Also, some models have wrong config values for `max_position_embeddings` or `max_sequence_length`, and we try to fix those for LLaMa2 if `llama-2` appears in the lower-case version of the model name.
+Another type of model is
+```bash
+python generate.py --base_model=TheBloke/Nous-Hermes-Llama2-GPTQ --load_gptq="gptq_model-4bit-128g" --use_safetensors=True --prompt_type=wizard2 --save_dir='7bgptq4bit' --load_exllama=True --revision=gptq-4bit-32g-actorder_True --rope_scaling="{'alpha_value':4}"
+```
+and note the different `prompt_type`.
 
 ---
 

--- a/docs/README_WHEEL.md
+++ b/docs/README_WHEEL.md
@@ -19,3 +19,14 @@ once `whl` file is installed, two new scripts will be added to the current envir
 The wheel is not required to use h2oGPT locally from repo, but makes it portable with all required dependencies.
 
 See [setup.py](../setup.py) for controlling other options via `extras_require`.
+
+Once the wheel is built, if you do:
+```bash
+python -m pip check
+```
+you may see:
+```text
+h2ogpt 0.1.0 has requirement numpy==1.24.3, but you have numpy 1.23.5.
+h2ogpt 0.1.0 has requirement pandas==2.0.2, but you have pandas 1.5.3.
+```
+but that is expected.

--- a/docs/README_offline.md
+++ b/docs/README_offline.md
@@ -63,3 +63,10 @@ To ensure nobody can access your gradio server, disable the port via firewall.  
 --auth=[('jon','password')]
 ```
 with no spaces.  Run `python generate.py --help` for more details.
+
+7. To avoid unauthorized telemetry, which document options still do not disable, run:
+```bash
+sp=`python -c 'import site; print(site.getsitepackages()[0])'`
+sed -i 's/posthog\.capture/return\n            posthog.capture/' $sp/chromadb/telemetry/posthog.py
+```
+or the equivalent for windows/mac using.  Or edit the file manually to just return in the `capture` function.

--- a/reqs_optional/requirements_optional_training.txt
+++ b/reqs_optional/requirements_optional_training.txt
@@ -1,1 +1,1 @@
-xformers==0.0.20
+#xformers==0.0.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,8 @@ loralib==0.1.1
 bitsandbytes==0.39.0
 accelerate==0.20.3
 peft==0.4.0
-transformers==4.31.0
+# 4.31.0+ breaks load_in_8bit=True (https://github.com/huggingface/transformers/issues/25026)
+transformers==4.30.2
 tokenizers==0.13.3
 APScheduler==3.10.1
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -13,7 +13,7 @@ def run_cli(  # for local function:
         examples=None, memory_restriction_level=None,
         # for get_model:
         score_model=None, load_8bit=None, load_4bit=None, load_half=None,
-        load_gptq=None, load_exllama=None, use_safetensors=None,
+        load_gptq=None, load_exllama=None, use_safetensors=None, revision=None,
         use_gpu_id=None, tokenizer_base_model=None,
         gpu_id=None, local_files_only=None, resume_download=None, use_auth_token=None,
         trust_remote_code=None, offload_folder=None, rope_scaling=None, compile_model=None,

--- a/src/cli.py
+++ b/src/cli.py
@@ -4,7 +4,6 @@ import torch
 from evaluate_params import eval_func_param_names
 from gen import get_score_model, get_model, evaluate, check_locals
 from prompter import non_hf_types
-from src.enums import LangChainMode
 from utils import clear_torch_cache, NullContext, get_kwargs
 
 
@@ -14,7 +13,7 @@ def run_cli(  # for local function:
         examples=None, memory_restriction_level=None,
         # for get_model:
         score_model=None, load_8bit=None, load_4bit=None, load_half=None,
-        load_gptq=None, use_safetensors=None,
+        load_gptq=None, load_exllama=None, use_safetensors=None,
         use_gpu_id=None, tokenizer_base_model=None,
         gpu_id=None, local_files_only=None, resume_download=None, use_auth_token=None,
         trust_remote_code=None, offload_folder=None, rope_scaling=None, compile_model=None,

--- a/src/eval.py
+++ b/src/eval.py
@@ -20,7 +20,8 @@ def run_eval(  # for local function:
         eval_filename=None, eval_prompts_only_num=None, eval_prompts_only_seed=None, eval_as_output=None,
         examples=None, memory_restriction_level=None,
         # for get_model:
-        score_model=None, load_8bit=None, load_4bit=None, load_half=None, load_gptq=None, use_safetensors=None,
+        score_model=None, load_8bit=None, load_4bit=None, load_half=None,
+        load_gptq=None, load_exllama=None, use_safetensors=None,
         use_gpu_id=None, tokenizer_base_model=None,
         gpu_id=None, local_files_only=None, resume_download=None, use_auth_token=None,
         trust_remote_code=None, offload_folder=None, rope_scaling=None, compile_model=None,

--- a/src/eval.py
+++ b/src/eval.py
@@ -21,7 +21,7 @@ def run_eval(  # for local function:
         examples=None, memory_restriction_level=None,
         # for get_model:
         score_model=None, load_8bit=None, load_4bit=None, load_half=None,
-        load_gptq=None, load_exllama=None, use_safetensors=None,
+        load_gptq=None, load_exllama=None, use_safetensors=None, revision=None,
         use_gpu_id=None, tokenizer_base_model=None,
         gpu_id=None, local_files_only=None, resume_download=None, use_auth_token=None,
         trust_remote_code=None, offload_folder=None, rope_scaling=None, compile_model=None,

--- a/src/gen.py
+++ b/src/gen.py
@@ -2256,6 +2256,42 @@ class H2OTextIteratorStreamer(TextIteratorStreamer):
         with self.text_queue.mutex:
             self.text_queue.queue.clear()
 
+    def put(self, value):
+        """
+        Receives tokens, decodes them, and prints them to stdout as soon as they form entire words.
+        # same as base class, except remove hack w.r.t. text.rfind(" ") that ruins LLaMa2
+        """
+        if len(value.shape) > 1 and value.shape[0] > 1:
+            raise ValueError("TextStreamer only supports batch size 1")
+        elif len(value.shape) > 1:
+            value = value[0]
+
+        if self.skip_prompt and self.next_tokens_are_prompt:
+            self.next_tokens_are_prompt = False
+            return
+
+        # Add the new token to the cache and decodes the entire thing.
+        self.token_cache.extend(value.tolist())
+        text = self.tokenizer.decode(self.token_cache, **self.decode_kwargs)
+
+        # After the symbol for a new line, we flush the cache.
+        if text.endswith("\n"):
+            printable_text = text[self.print_len:]
+            self.token_cache = []
+            self.print_len = 0
+        # If the last token is a CJK character, we print the characters.
+        elif len(text) > 0 and self._is_chinese_char(ord(text[-1])):
+            printable_text = text[self.print_len:]
+            self.print_len += len(printable_text)
+        # Otherwise, prints until the last space char (simple heuristic to avoid printing incomplete words,
+        # which may change with the subsequent token -- there are probably smarter ways to do this!)
+        else:
+            # printable_text = text[self.print_len : text.rfind(" ") + 1]
+            printable_text = text[self.print_len:]
+            self.print_len += len(printable_text)
+
+        self.on_finalized_text(printable_text)
+
 
 def generate_with_exceptions(func, *args, prompt='', inputs_decoded='', raise_generate_gpu_exceptions=True, **kwargs):
     try:

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -695,11 +695,6 @@ def get_llm(use_openai_model=False,
             sanitize_bot_response=False,
             verbose=False,
             ):
-    assert prompter is not None
-    terminate_response = prompter.terminate_response or []
-    stop_sequences = list(set(terminate_response + [prompter.PreResponse]))
-    stop_sequences = [x for x in stop_sequences if x]
-
     if inference_server is None:
         inference_server = ''
     if use_openai_model or inference_server.startswith('openai') or inference_server.startswith('vllm'):
@@ -714,7 +709,7 @@ def get_llm(use_openai_model=False,
         else:
             cls = H2OOpenAI
             if inf_type == 'vllm':
-                kwargs_extra = dict(stop_sequences=stop_sequences,
+                kwargs_extra = dict(stop_sequences=prompter.stop_sequences,
                                     sanitize_bot_response=sanitize_bot_response,
                                     prompter=prompter,
                                     context=context,
@@ -800,7 +795,7 @@ def get_llm(use_openai_model=False,
                 return_full_text=True,
                 seed=SEED,
 
-                stop_sequences=stop_sequences,
+                stop_sequences=prompter.stop_sequences,
                 temperature=temperature,
                 top_k=top_k,
                 top_p=top_p,
@@ -863,7 +858,7 @@ def get_llm(use_openai_model=False,
                       typical=.7,
                       beams=1,
                       # beam_length = 40,
-                      stop_sequences=stop_sequences,
+                      stop_sequences=prompter.stop_sequences,
                       callbacks=callbacks,
                       verbose=verbose,
                       max_seq_len=max_max_tokens,

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -2219,7 +2219,7 @@ def get_chain(query=None,
     elif langchain_action in [LangChainAction.SUMMARIZE_ALL.value, LangChainAction.SUMMARIZE_MAP.value]:
         none = ['', '\n', None]
         if query in none and iinput in none:
-            prompt_summary = "Using only the text above, write a condensed and concise summary:\n"
+            prompt_summary = "Using only the text above, write a condensed and concise summary (preferably as bullet points):\n"
         elif query not in none:
             prompt_summary = "Focusing on %s, write a condensed and concise Summary:\n" % query
         elif iinput not in None:

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -2312,7 +2312,8 @@ def get_chain(query=None,
                                 docs_with_score = db.similarity_search_with_score(query, k=k_db, **filter_kwargs)[
                                                   :top_k_docs_tokenize]
                                 break
-                            except RuntimeError as e:
+                            except (RuntimeError, AttributeError) as e:
+                                # AttributeError is for people with wrong version of langchain
                                 if verbose:
                                     print("chroma bug: %s" % str(e), flush=True)
                                 if k_db == 1:

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -559,14 +559,14 @@ class H2OHuggingFaceTextGenInference(HuggingFaceTextGenInference):
                 # stream part
                 is_stop = False
                 for stop_seq in stop:
-                    if stop_seq in response.token.text:
+                    if stop_seq in text_chunk:
                         is_stop = True
                         break
                 if is_stop:
                     break
                 if not response.token.special:
                     if text_callback:
-                        text_callback(response.token.text)
+                        text_callback(text_chunk)
         return text
 
 

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -2219,7 +2219,7 @@ def get_chain(query=None,
     elif langchain_action in [LangChainAction.SUMMARIZE_ALL.value, LangChainAction.SUMMARIZE_MAP.value]:
         none = ['', '\n', None]
         if query in none and iinput in none:
-            prompt_summary = "Using only the text above, write a condensed and concise summary (preferably as bullet points):\n"
+            prompt_summary = "Using only the text above, write a condensed and concise summary of key results (preferably as bullet points):\n"
         elif query not in none:
             prompt_summary = "Focusing on %s, write a condensed and concise Summary:\n" % query
         elif iinput not in None:

--- a/src/image_captions.py
+++ b/src/image_captions.py
@@ -37,6 +37,7 @@ class H2OImageCaptionLoader(ImageCaptionLoader):
                  load_gptq='',
                  load_exllama=False,
                  use_safetensors=False,
+                 revision=None,
                  min_new_tokens=20,
                  max_tokens=50):
         if blip_model is None or blip_model is None:
@@ -56,6 +57,7 @@ class H2OImageCaptionLoader(ImageCaptionLoader):
         self.load_gptq = load_gptq
         self.load_exllama = load_exllama
         self.use_safetensors = use_safetensors
+        self.revision = revision
         self.gpu_id = 'auto'
         # default prompt
         self.prompt = "image of"

--- a/src/image_captions.py
+++ b/src/image_captions.py
@@ -35,6 +35,7 @@ class H2OImageCaptionLoader(ImageCaptionLoader):
                  # True doesn't seem to work, even though https://huggingface.co/Salesforce/blip2-flan-t5-xxl#in-8-bit-precision-int8
                  load_half=False,
                  load_gptq='',
+                 load_exllama=False,
                  use_safetensors=False,
                  min_new_tokens=20,
                  max_tokens=50):
@@ -53,6 +54,7 @@ class H2OImageCaptionLoader(ImageCaptionLoader):
         self.load_in_8bit = load_in_8bit and have_bitsandbytes  # only for blip2
         self.load_half = load_half
         self.load_gptq = load_gptq
+        self.load_exllama = load_exllama
         self.use_safetensors = use_safetensors
         self.gpu_id = 'auto'
         # default prompt

--- a/src/llm_exllama.py
+++ b/src/llm_exllama.py
@@ -1,0 +1,342 @@
+from langchain.llms.base import LLM
+from langchain.callbacks.manager import CallbackManagerForLLMRun
+from typing import Any, Dict, Generator, List, Optional
+from pydantic import Field, root_validator
+from exllama.model import ExLlama, ExLlamaCache, ExLlamaConfig
+from exllama.tokenizer import ExLlamaTokenizer
+from exllama.generator import ExLlamaGenerator
+from exllama.lora import ExLlamaLora
+import os, glob
+from langchain.callbacks.base import BaseCallbackHandler
+
+
+class H2OExLlamaTokenizer(ExLlamaTokenizer):
+    def __call__(self, text, *args, **kwargs):
+        return dict(input_ids=self.encode(text))
+
+
+class H2OExLlamaGenerator(ExLlamaGenerator):
+    def is_exlama(self):
+        return True
+
+
+class Exllama(LLM):
+    client: Any  #: :meta private:
+    model_path: str = None
+    model: Any = None
+    sanitize_bot_response: bool = False
+    prompter: Any = None
+    context: Any = ''
+    iinput: Any = ''
+
+    """The path to the GPTQ model folder."""
+    exllama_cache: ExLlamaCache = None  #: :meta private:
+    config: ExLlamaConfig = None  #: :meta private:
+    generator: ExLlamaGenerator = None  #: :meta private:
+    tokenizer: ExLlamaTokenizer = None  #: :meta private:
+
+    ##Langchain parameters
+    logfunc = print
+    stop_sequences: Optional[List[str]] = Field("", description="Sequences that immediately will stop the generator.")
+    streaming: Optional[bool] = Field(True, description="Whether to stream the results, token by token.")
+
+    ##Generator parameters
+    disallowed_tokens: Optional[List[int]] = Field(None, description="List of tokens to disallow during generation.")
+    temperature: Optional[float] = Field(None, description="Temperature for sampling diversity.")
+    top_k: Optional[int] = Field(None,
+                                 description="Consider the most probable top_k samples, 0 to disable top_k sampling.")
+    top_p: Optional[float] = Field(None,
+                                   description="Consider tokens up to a cumulative probabiltiy of top_p, 0.0 to disable top_p sampling.")
+    min_p: Optional[float] = Field(None, description="Do not consider tokens with probability less than this.")
+    typical: Optional[float] = Field(None,
+                                     description="Locally typical sampling threshold, 0.0 to disable typical sampling.")
+    token_repetition_penalty_max: Optional[float] = Field(None,
+                                                          description="Repetition penalty for most recent tokens.")
+    token_repetition_penalty_sustain: Optional[int] = Field(None,
+                                                            description="No. most recent tokens to repeat penalty for, -1 to apply to whole context.")
+    token_repetition_penalty_decay: Optional[int] = Field(None,
+                                                          description="Gradually decrease penalty over this many tokens.")
+    beams: Optional[int] = Field(None, description="Number of beams for beam search.")
+    beam_length: Optional[int] = Field(None, description="Length of beams for beam search.")
+
+    ##Config overrides
+    max_seq_len: Optional[int] = Field(2048,
+                                       decription="Reduce to save memory. Can also be increased, ideally while also using compress_pos_emn and a compatible model/LoRA")
+    compress_pos_emb: Optional[float] = Field(1.0,
+                                              description="Amount of compression to apply to the positional embedding.")
+    set_auto_map: Optional[str] = Field(None,
+                                        description="Comma-separated list of VRAM (in GB) to use per GPU device for model layers, e.g. 20,7,7")
+    gpu_peer_fix: Optional[bool] = Field(None, description="Prevent direct copies of data between GPUs")
+    alpha_value: Optional[float] = Field(1.0, description="Rope context extension alpha")
+
+    ##Tuning
+    matmul_recons_thd: Optional[int] = Field(None)
+    fused_mlp_thd: Optional[int] = Field(None)
+    sdp_thd: Optional[int] = Field(None)
+    fused_attn: Optional[bool] = Field(None)
+    matmul_fused_remap: Optional[bool] = Field(None)
+    rmsnorm_no_half2: Optional[bool] = Field(None)
+    rope_no_half2: Optional[bool] = Field(None)
+    matmul_no_half2: Optional[bool] = Field(None)
+    silu_no_half2: Optional[bool] = Field(None)
+    concurrent_streams: Optional[bool] = Field(None)
+
+    ##Lora Parameters
+    lora_path: Optional[str] = Field(None, description="Path to your lora.")
+
+    @staticmethod
+    def get_model_path_at(path):
+        patterns = ["*.safetensors", "*.bin", "*.pt"]
+        model_paths = []
+        for pattern in patterns:
+            full_pattern = os.path.join(path, pattern)
+            model_paths = glob.glob(full_pattern)
+            if model_paths:  # If there are any files matching the current pattern
+                break  # Exit the loop as soon as we find a matching file
+        if model_paths:  # If there are any files matching any of the patterns
+            return model_paths[0]
+        else:
+            return None  # Return None if no matching files were found
+
+    @staticmethod
+    def configure_object(params, values, logfunc):
+        obj_params = {k: values.get(k) for k in params}
+
+        def apply_to(obj):
+            for key, value in obj_params.items():
+                if value:
+                    if hasattr(obj, key):
+                        setattr(obj, key, value)
+                        logfunc(f"{key} {value}")
+                    else:
+                        raise AttributeError(f"{key} does not exist in {obj}")
+
+        return apply_to
+
+    @root_validator()
+    def validate_environment(cls, values: Dict) -> Dict:
+        model_param_names = [
+            "temperature",
+            "top_k",
+            "top_p",
+            "min_p",
+            "typical",
+            "token_repetition_penalty_max",
+            "token_repetition_penalty_sustain",
+            "token_repetition_penalty_decay",
+            "beams",
+            "beam_length",
+        ]
+
+        config_param_names = [
+            "max_seq_len",
+            "compress_pos_emb",
+            "gpu_peer_fix",
+            "alpha_value"
+        ]
+
+        tuning_parameters = [
+            "matmul_recons_thd",
+            "fused_mlp_thd",
+            "sdp_thd",
+            "matmul_fused_remap",
+            "rmsnorm_no_half2",
+            "rope_no_half2",
+            "matmul_no_half2",
+            "silu_no_half2",
+            "concurrent_streams",
+            "fused_attn",
+        ]
+
+        ##Set logging function if verbose or set to empty lambda
+        verbose = values['verbose']
+        if not verbose:
+            values['logfunc'] = lambda *args, **kwargs: None
+        logfunc = values['logfunc']
+
+        if values['model'] is None:
+            model_path = values["model_path"]
+            lora_path = values["lora_path"]
+
+            tokenizer_path = os.path.join(model_path, "tokenizer.model")
+            model_config_path = os.path.join(model_path, "config.json")
+            model_path = Exllama.get_model_path_at(model_path)
+
+            config = ExLlamaConfig(model_config_path)
+            tokenizer = ExLlamaTokenizer(tokenizer_path)
+            config.model_path = model_path
+
+            configure_config = Exllama.configure_object(config_param_names, values, logfunc)
+            configure_config(config)
+            configure_tuning = Exllama.configure_object(tuning_parameters, values, logfunc)
+            configure_tuning(config)
+
+            ##Special parameter, set auto map, it's a function
+            if values['set_auto_map']:
+                config.set_auto_map(values['set_auto_map'])
+                logfunc(f"set_auto_map {values['set_auto_map']}")
+
+            model = ExLlama(config)
+            exllama_cache = ExLlamaCache(model)
+            generator = ExLlamaGenerator(model, tokenizer, exllama_cache)
+
+            ##Load and apply lora to generator
+            if lora_path is not None:
+                lora_config_path = os.path.join(lora_path, "adapter_config.json")
+                lora_path = Exllama.get_model_path_at(lora_path)
+                lora = ExLlamaLora(model, lora_config_path, lora_path)
+                generator.lora = lora
+                logfunc(f"Loaded LORA @ {lora_path}")
+        else:
+            generator = values['model']
+            exllama_cache = generator.cache
+            model = generator.model
+            config = model.config
+            tokenizer = generator.tokenizer
+
+        # Set if model existed before or not since generation-time parameters
+        configure_model = Exllama.configure_object(model_param_names, values, logfunc)
+        values["stop_sequences"] = [x.strip().lower() for x in values["stop_sequences"]]
+        configure_model(generator.settings)
+
+        setattr(generator.settings, "stop_sequences", values["stop_sequences"])
+        logfunc(f"stop_sequences {values['stop_sequences']}")
+
+        disallowed = values.get("disallowed_tokens")
+        if disallowed:
+            generator.disallow_tokens(disallowed)
+            print(f"Disallowed Tokens: {generator.disallowed_tokens}")
+
+        values["client"] = model
+        values["generator"] = generator
+        values["config"] = config
+        values["tokenizer"] = tokenizer
+        values["exllama_cache"] = exllama_cache
+
+        return values
+
+    @property
+    def _llm_type(self) -> str:
+        """Return type of llm."""
+        return "Exllama"
+
+    def get_num_tokens(self, text: str) -> int:
+        """Get the number of tokens present in the text."""
+        return self.generator.tokenizer.num_tokens(text)
+
+    def _call(
+            self,
+            prompt: str,
+            stop: Optional[List[str]] = None,
+            run_manager: Optional[CallbackManagerForLLMRun] = None,
+            **kwargs: Any,
+    ) -> str:
+        assert self.tokenizer is not None
+        from h2oai_pipeline import H2OTextGenerationPipeline
+        prompt, num_prompt_tokens = H2OTextGenerationPipeline.limit_prompt(prompt, self.tokenizer)
+
+        # NOTE: TGI server does not add prompting, so must do here
+        data_point = dict(context=self.context, instruction=prompt, input=self.iinput)
+        prompt = self.prompter.generate_prompt(data_point)
+
+        text = ""
+        for token in self.stream(prompt=prompt, stop=stop, run_manager=run_manager):
+            text += token
+        text = self.prompter.get_response(prompt + text, prompt=prompt,
+                                          sanitize_bot_response=self.sanitize_bot_response)
+        return text
+
+    from enum import Enum
+
+    class MatchStatus(Enum):
+        EXACT_MATCH = 1
+        PARTIAL_MATCH = 0
+        NO_MATCH = 2
+
+    def match_status(self, sequence: str, banned_sequences: List[str]):
+        sequence = sequence.strip().lower()
+        for banned_seq in banned_sequences:
+            if banned_seq == sequence:
+                return self.MatchStatus.EXACT_MATCH
+            elif banned_seq.startswith(sequence):
+                return self.MatchStatus.PARTIAL_MATCH
+        return self.MatchStatus.NO_MATCH
+
+    def stream(
+            self,
+            prompt: str,
+            stop: Optional[List[str]] = None,
+            run_manager: Optional[CallbackManagerForLLMRun] = None,
+    ) -> str:
+        config = self.config
+        generator = self.generator
+        beam_search = (self.beams and self.beams >= 1 and self.beam_length and self.beam_length >= 1)
+
+        ids = generator.tokenizer.encode(prompt)
+        generator.gen_begin_reuse(ids)
+
+        if beam_search:
+            generator.begin_beam_search()
+            token_getter = generator.beam_search
+        else:
+            generator.end_beam_search()
+            token_getter = generator.gen_single_token
+
+        last_newline_pos = 0
+        text = ""
+
+        seq_length = len(generator.tokenizer.decode(generator.sequence_actual[0]))
+        response_start = seq_length
+        cursor_head = response_start
+
+        while (generator.gen_num_tokens() <= (
+                self.max_seq_len - 4)):  # Slight extra padding space as we seem to occassionally get a few more than 1-2 tokens
+            # Fetch a token
+            token = token_getter()
+
+            # If it's the ending token replace it and end the generation.
+            if token.item() == generator.tokenizer.eos_token_id:
+                generator.replace_last_token(generator.tokenizer.newline_token_id)
+                if beam_search:
+                    generator.end_beam_search()
+                return
+
+            # Tokenize the string from the last new line, we can't just decode the last token due to how sentencepiece decodes.
+            stuff = generator.tokenizer.decode(generator.sequence_actual[0][last_newline_pos:])
+            cursor_tail = len(stuff)
+            text_chunk = stuff[cursor_head:cursor_tail]
+            cursor_head = cursor_tail
+
+            # Append the generated chunk to our stream buffer
+            text += text_chunk
+            text = self.prompter.get_response(prompt + text, prompt=prompt,
+                                              sanitize_bot_response=self.sanitize_bot_response)
+
+            if token.item() == generator.tokenizer.newline_token_id:
+                last_newline_pos = len(generator.sequence_actual[0])
+                cursor_head = 0
+                cursor_tail = 0
+
+            # Check if the stream buffer is one of the stop sequences
+            status = self.match_status(text, self.stop_sequences)
+
+            if status == self.MatchStatus.EXACT_MATCH:
+                # Encountered a stop, rewind our generator to before we hit the match and end generation.
+                rewind_length = generator.tokenizer.encode(text).shape[-1]
+                generator.gen_rewind(rewind_length)
+                gen = generator.tokenizer.decode(generator.sequence_actual[0][response_start:])
+                if beam_search:
+                    generator.end_beam_search()
+                return
+            elif status == self.MatchStatus.PARTIAL_MATCH:
+                # Partially matched a stop, continue buffering but don't yield.
+                continue
+            elif status == self.MatchStatus.NO_MATCH:
+                if run_manager:
+                    run_manager.on_llm_new_token(
+                        token=text, verbose=self.verbose,
+                    )
+                yield text  # Not a stop, yield the match buffer.
+                text = ""
+
+        return

--- a/src/llm_exllama.py
+++ b/src/llm_exllama.py
@@ -240,11 +240,9 @@ class Exllama(LLM):
         data_point = dict(context=self.context, instruction=prompt, input=self.iinput)
         prompt = self.prompter.generate_prompt(data_point)
 
-        text = ""
-        for token in self.stream(prompt=prompt, stop=stop, run_manager=run_manager):
-            text += token
-        text = self.prompter.get_response(prompt + text, prompt=prompt,
-                                          sanitize_bot_response=self.sanitize_bot_response)
+        text = ''
+        for text1 in self.stream(prompt=prompt, stop=stop, run_manager=run_manager):
+            text = text1
         return text
 
     from enum import Enum
@@ -332,7 +330,7 @@ class Exllama(LLM):
                 # Encountered a stop, rewind our generator to before we hit the match and end generation.
                 rewind_length = generator.tokenizer.encode(text).shape[-1]
                 generator.gen_rewind(rewind_length)
-                gen = generator.tokenizer.decode(generator.sequence_actual[0][response_start:])
+                #gen = generator.tokenizer.decode(generator.sequence_actual[0][response_start:])
                 if beam_search:
                     generator.end_beam_search()
                 return
@@ -343,6 +341,5 @@ class Exllama(LLM):
                 if text_callback:
                     text_callback(text_chunk)
                 yield text  # Not a stop, yield the match buffer.
-                text = ""
 
         return

--- a/src/loaders.py
+++ b/src/loaders.py
@@ -1,7 +1,7 @@
 import functools
 
 
-def get_loaders(model_name, reward_type, llama_type=None, load_gptq='', load_exllama=False):
+def get_loaders(model_name, reward_type, llama_type=None, load_gptq='', load_exllama=False, config=None, rope_scaling=None):
     # NOTE: Some models need specific new prompt_type
     # E.g. t5_xxl_true_nli_mixture has input format: "premise: PREMISE_TEXT hypothesis: HYPOTHESIS_TEXT".)
     if load_exllama:
@@ -9,26 +9,52 @@ def get_loaders(model_name, reward_type, llama_type=None, load_gptq='', load_exl
         from exllama.model import ExLlama, ExLlamaCache, ExLlamaConfig
         import os, glob
 
-        # Directory containing model, tokenizer, generator
-        model_directory = "Llama-2-7b-Chat-GPTQ/"  # FIXME:
+        if config:
+            # then use HF path
+            from transformers import TRANSFORMERS_CACHE
+            model_directory = os.path.join(TRANSFORMERS_CACHE, 'models--' + config.name_or_path.replace('/', '--'), 'snapshots', config._commit_hash)
+        else:
+            # then use path in env file
+            env_gpt4all_file = ".env_gpt4all"
+            from dotenv import dotenv_values
+            env_kwargs = dotenv_values(env_gpt4all_file)
+            # Directory containing model, tokenizer, generator
+            model_directory = env_kwargs['model_name_exllama_if_no_config']
+
+        # download model
+        revision = config._commit_hash
+        from huggingface_hub import snapshot_download
+        snapshot_download(repo_id=model_name, revision=revision)
 
         # Locate files we need within that directory
         tokenizer_path = os.path.join(model_directory, "tokenizer.model")
+        assert os.path.isfile(tokenizer_path), "Missing %s" % tokenizer_path
         model_config_path = os.path.join(model_directory, "config.json")
+        assert os.path.isfile(model_config_path), "Missing %s" % model_config_path
         st_pattern = os.path.join(model_directory, "*.safetensors")
         model_path = glob.glob(st_pattern)[0]
+        assert os.path.isfile(model_path), "Missing %s" % model_path
 
         # Create config, model, tokenizer and generator
+        exconfig = ExLlamaConfig(model_config_path)               # create config from config.json
+        rope_scaling = rope_scaling or {}
+        exconfig.alpha_value = rope_scaling.get('alpha_value', 1)  # rope
+        exconfig.compress_pos_emb = rope_scaling.get('compress_pos_emb', 1)  # related rope
+        # update max_seq_len
+        assert hasattr(config, 'max_position_embeddings') or hasattr(config, 'max_sequence_length'), "Improve code if no such argument"
+        if hasattr(config, 'max_position_embeddings'):
+            exconfig.max_seq_len = int(config.max_position_embeddings * exconfig.alpha_value)
+        else:
+            exconfig.max_seq_len = int(config.max_sequence_length * exconfig.alpha_value)
+        if 'Llama-2'.lower() in model_name:
+            # override bad defaults
+            exconfig.max_seq_len = int(4096 * exconfig.alpha_value)
 
-        config = ExLlamaConfig(model_config_path)               # create config from config.json
-        # FIXME:
-        config.alpha_value = 1.0  # rope
-        config.compress_pos_emb = 1.0  # related rope
-        config.model_path = model_path                          # supply path to model weights file
+        exconfig.model_path = model_path                          # supply path to model weights file
 
-        model = ExLlama(config)                                 # create ExLlama instance and load the weights
+        model = ExLlama(exconfig)                                 # create ExLlama instance and load the weights
         tokenizer = H2OExLlamaTokenizer(tokenizer_path)            # create tokenizer from tokenizer model file
-        tokenizer.model_max_length = int(config.max_seq_len * config.alpha_value)
+        tokenizer.model_max_length = exconfig.max_seq_len
 
         cache = ExLlamaCache(model)                             # create cache for inference
         generator = H2OExLlamaGenerator(model, tokenizer, cache)   # create generator

--- a/src/prompter.py
+++ b/src/prompter.py
@@ -748,7 +748,7 @@ class Prompter(object):
                        use_system_prompt=use_system_prompt)
         self.pre_response = self.PreResponse
 
-    def get_stop_sequences(self):
+    def stop_sequences(self):
         terminate_response = self.terminate_response or []
         stop_sequences = list(set(terminate_response + [self.PreResponse]))
         stop_sequences = [x for x in stop_sequences if x]

--- a/src/prompter.py
+++ b/src/prompter.py
@@ -748,6 +748,7 @@ class Prompter(object):
                        use_system_prompt=use_system_prompt)
         self.pre_response = self.PreResponse
 
+    @property
     def stop_sequences(self):
         terminate_response = self.terminate_response or []
         stop_sequences = list(set(terminate_response + [self.PreResponse]))

--- a/src/prompter.py
+++ b/src/prompter.py
@@ -748,6 +748,12 @@ class Prompter(object):
                        use_system_prompt=use_system_prompt)
         self.pre_response = self.PreResponse
 
+    def get_stop_sequences(self):
+        terminate_response = self.terminate_response or []
+        stop_sequences = list(set(terminate_response + [self.PreResponse]))
+        stop_sequences = [x for x in stop_sequences if x]
+        return stop_sequences
+
     def generate_prompt(self, data_point, reduced=None):
         """
         data_point['context'] is assumed to be like a system prompt or pre-conversation, not inserted after user prompt

--- a/src/prompter.py
+++ b/src/prompter.py
@@ -811,10 +811,10 @@ class Prompter(object):
                     pass
                 elif self.botstr in output:
                     if self.humanstr:
-                        output = clean_response(output.split(self.botstr)[1].split(self.humanstr)[0])
+                        output = clean_response(output.split(self.botstr)[-1].split(self.humanstr)[0])
                     else:
                         # i.e. use after bot but only up to next bot
-                        output = clean_response(output.split(self.botstr)[1].split(self.botstr)[0])
+                        output = clean_response(output.split(self.botstr)[-1].split(self.botstr)[0])
                 else:
                     # output = clean_response(output)
                     # assume just not printed yet

--- a/tests/test_client_calls.py
+++ b/tests/test_client_calls.py
@@ -322,7 +322,8 @@ def test_client_chat_stream_langchain_steps(max_new_tokens, top_k_docs):
             'Whisper is a secure, anonymous, and encrypted' in res_dict['response'] or
             'secure, decentralized, and anonymous chat platform' in res_dict['response'] or
             'A low-code development framework' in res_dict['response'] or
-            'secure messaging app' in res_dict['response']
+            'secure messaging app' in res_dict['response'] or
+            'privacy-focused messaging app that allows' in res_dict['response']
             ) \
            and ('FAQ.md' in res_dict['response'] or 'README.md' in res_dict['response'])
 
@@ -369,7 +370,8 @@ def test_client_chat_stream_langchain_steps(max_new_tokens, top_k_docs):
             'is a platform for deploying' in res_dict['response'] or
             'is a language model that is trained' in res_dict['response'] or
             'private, and anonymous communication' in res_dict['response'] or
-            'The large language model is' in res_dict['response']
+            'The large language model is' in res_dict['response'] or
+            'is a private, secure, and encrypted' in res_dict['response']
             ) \
            and '.md' in res_dict['response']
 

--- a/tests/test_client_calls.py
+++ b/tests/test_client_calls.py
@@ -483,7 +483,8 @@ def test_exllama():
     prompt = 'Who are you?'
     stream_output = False
     max_new_tokens = 256
-    base_model = 'TheBloke/Llama-2-70B-chat-GPTQ'
+    #base_model = 'TheBloke/Llama-2-70B-chat-GPTQ'
+    base_model = 'TheBloke/Llama-2-7B-chat-GPTQ'
     load_exllama = True
     prompt_type = 'llama2'
     langchain_mode = 'Disabled'

--- a/tests/test_client_calls.py
+++ b/tests/test_client_calls.py
@@ -478,6 +478,42 @@ def test_autogptq():
     assert "am a virtual assistant" in res_dict['response']
 
 
+@wrap_test_forked
+def test_exllama():
+    prompt = 'Who are you?'
+    stream_output = False
+    max_new_tokens = 256
+    base_model = 'TheBloke/Llama-2-70B-chat-GPTQ'
+    load_exllama = True
+    prompt_type = 'llama2'
+    langchain_mode = 'Disabled'
+    langchain_action = LangChainAction.QUERY.value
+    langchain_agents = []
+    user_path = None
+    visible_langchain_modes = ['UserData', 'MyData']
+    reverse_docs = True
+    from src.gen import main
+    main(base_model=base_model, load_exllama=load_exllama,
+         prompt_type=prompt_type, chat=True,
+         stream_output=stream_output, gradio=True, num_beams=1, block_gradio_exit=False,
+         max_new_tokens=max_new_tokens,
+         langchain_mode=langchain_mode, user_path=user_path,
+         visible_langchain_modes=visible_langchain_modes,
+         reverse_docs=reverse_docs)
+
+    from src.client_test import run_client_chat
+    res_dict, client = run_client_chat(prompt=prompt, prompt_type=prompt_type, stream_output=stream_output,
+                                       max_new_tokens=max_new_tokens, langchain_mode=langchain_mode,
+                                       langchain_action=langchain_action, langchain_agents=langchain_agents)
+    assert res_dict['prompt'] == prompt
+    assert res_dict['iinput'] == ''
+    assert "Hello! I'm LLaMA, an AI assistant developed by Meta AI that can understand and respond to human input" \
+           " in a conversational manner. My training data is based on a massive dataset of text from the internet," \
+           " which allows me to generate human-like responses to a wide range of topics and questions. " \
+           "I'm here to help answer any questions you may have, so feel free to ask me anything!" in \
+           res_dict['response']
+
+
 @pytest.mark.skip(reason="Local file required")
 @wrap_test_forked
 def test_client_long():

--- a/tests/test_client_calls.py
+++ b/tests/test_client_calls.py
@@ -483,7 +483,7 @@ def test_exllama():
     prompt = 'Who are you?'
     stream_output = False
     max_new_tokens = 256
-    #base_model = 'TheBloke/Llama-2-70B-chat-GPTQ'
+    # base_model = 'TheBloke/Llama-2-70B-chat-GPTQ'
     base_model = 'TheBloke/Llama-2-7B-chat-GPTQ'
     load_exllama = True
     prompt_type = 'llama2'
@@ -512,6 +512,8 @@ def test_exllama():
            " in a conversational manner. My training data is based on a massive dataset of text from the internet," \
            " which allows me to generate human-like responses to a wide range of topics and questions. " \
            "I'm here to help answer any questions you may have, so feel free to ask me anything!" in \
+           res_dict['response'] or \
+           """I am LLaMA, an AI assistant developed by Meta AI that can understand and respond to human input in a conversational manner. My primary function is to assist users with their inquiries and provide information on a wide range of topics. I'm here to help you with any questions or tasks you may have!""" in \
            res_dict['response']
 
 

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -74,7 +74,8 @@ def run_eval1(cpu=False, bits=None, base_model='h2oai/h2ogpt-oig-oasst1-512-6_9b
         langchain_mode='Disabled', add_chat_history_to_context=True,
         langchain_action=LangChainAction.QUERY.value, langchain_agents=[],
         chunk=True, chunk_size=512,
-        load_half=False, load_4bit=False, load_8bit=False, load_gptq=False, use_safetensors=False)
+        load_half=False, load_4bit=False, load_8bit=False,
+        load_gptq=False, load_exllama=False, use_safetensors=False)
     if bits == 4:
         kwargs['load_4bit'] = True
     elif bits == 8:
@@ -84,6 +85,7 @@ def run_eval1(cpu=False, bits=None, base_model='h2oai/h2ogpt-oig-oasst1-512-6_9b
     elif bits == 32:
         pass
     kwargs['load_gptq'] = False
+    kwargs['load_exllama'] = False
     kwargs['use_safetensors'] = False
     eval_out_filename = main(base_model=base_model,
                              gradio=False,
@@ -115,7 +117,7 @@ def run_eval1(cpu=False, bits=None, base_model='h2oai/h2ogpt-oig-oasst1-512-6_9b
                  'langchain_agents': np.array([]),  # matches return
                  }
     expected1.update({k: v for k, v in kwargs.items() if
-                      k not in ['load_half', 'load_4bit', 'load_8bit', 'load_gptq', 'use_safetensors']})
+                      k not in ['load_half', 'load_4bit', 'load_8bit', 'load_gptq', 'load_exllama', 'use_safetensors']})
     drop_keys = ['document_choice', 'langchain_agents']
     expected1 = {k: v for k, v in expected1.items() if k not in drop_keys}
     actual1 = {k: v for k, v in actual1.items() if k not in drop_keys}

--- a/tests/test_inference_servers.py
+++ b/tests/test_inference_servers.py
@@ -170,7 +170,7 @@ def run_docker(inf_port, base_model):
     p = subprocess.Popen(cmd,
                          stdout=None, stderr=subprocess.STDOUT,
                          )
-    print("Done starting autoviz server", flush=True)
+    print("Done starting TGI server", flush=True)
     return p.pid
 
 

--- a/tests/test_langchain_units.py
+++ b/tests/test_langchain_units.py
@@ -216,6 +216,7 @@ def test_qa_daidocs_db_chunk_hf_dbs_switch_embedding(db_type):
                       load_4bit=False,
                       load_half=True,
                       load_gptq=False,
+                      load_exllama=False,
                       use_safetensors=False,
                       use_gpu_id=True,
                       base_model=base_model,

--- a/tests/test_langchain_units.py
+++ b/tests/test_langchain_units.py
@@ -297,6 +297,7 @@ def test_qa_wiki_db_chunk_hf_dbs_llama(db_type):
                      langchain_agents=[],
                      db_type=db_type,
                      prompt_type='wizard2',
+                     langchain_only_model=True,
                      model_name=model_name, model=model, tokenizer=tokenizer,
                      )
     check_ret(ret)
@@ -621,7 +622,7 @@ def test_md_add(db_type):
             assert db is not None
             docs = db.similarity_search("What is h2oGPT?")
             assert len(docs) == 4
-            assert 'Query and summarize your documents' in docs[0].page_content
+            assert 'Query and summarize your documents' in docs[1].page_content
             assert os.path.normpath(docs[0].metadata['source']) == os.path.normpath(test_file1)
 
 

--- a/tests/test_langchain_units.py
+++ b/tests/test_langchain_units.py
@@ -218,6 +218,7 @@ def test_qa_daidocs_db_chunk_hf_dbs_switch_embedding(db_type):
                       load_gptq=False,
                       load_exllama=False,
                       use_safetensors=False,
+                      revision=None,
                       use_gpu_id=True,
                       base_model=base_model,
                       tokenizer_base_model=base_model,


### PR DESCRIPTION
- [x] Add exllama like other non-hf models, loaded up front, passed through langchain
- [x] Add test, passes
- [x] Check streaming works
- [x] Make exllama loader act on HF type name and download correctly
- [x] Add revision so can control which TheBloke model to use
- [x] Fix inconsistency in prompt=None parsing.  exllama differs from rest for some reason.  If make exllama work so not showing wrong block of text before streaming, then others show wrong block of text just before streaming.


```
python generate.py --base_model=TheBloke/Llama-2-7b-Chat-GPTQ --load_gptq="gptq_model-4bit-128g" --use_safetensors=True --prompt_type=llama2 --save_dir='7bgptq4bit` --load_exllama=True
```

Or run with RoPE scaling the LLaMa-2 7B model for 16k context:
```bash
python generate.py --base_model=TheBloke/Llama-2-7b-Chat-GPTQ --load_gptq="gptq_model-4bit-128g" --use_safetensors=True --prompt_type=llama2 --save_dir='7bgptq4bit' --load_exllama=True --revision=gptq-4bit-32g-actorder_True --rope_scaling="{'alpha_value':4}"
```
which shows how to control `alpha_value` and the `revision` for a given model on [TheBloke/Llama-2-7b-Chat-GPTQ](https://huggingface.co/TheBloke/Llama-2-7b-Chat-GPTQ).  Be careful as setting `alpha_value` higher consumes substantially more GPU memory.  Also, some models have wrong config values for 
Another type of model is
```bash
python generate.py --base_model=TheBloke/Nous-Hermes-Llama2-GPTQ --load_gptq="gptq_model-4bit-128g" --use_safetensors=True --prompt_type=wizard2 --save_dir='7bgptq4bit' --load_exllama=True --revision=gptq-4bit-32g-actorder_True --rope_scaling="{'alpha_value':4}"
```
and note the different `prompt_type`.


![image](https://github.com/h2oai/h2ogpt/assets/2249614/0f75a96d-4fe6-45d6-9041-416bd3d641fb)

![image](https://github.com/h2oai/h2ogpt/assets/2249614/94145657-854d-4c7f-b673-7c7da5ca530a)
