### PR TITLE
Document how to disable chroma telemetry

### DIFF
--- a/docs/README_LINUX.md
+++ b/docs/README_LINUX.md
@@ -105,11 +105,6 @@ These instructions are for Ubuntu x86_64 (other linux would be similar with diff
     ```
     See [exllama](README_GPU.md#exllama) about running exllama models.
 
-* To avoid unauthorized telemetry, which document options still do not disable, run:
-    ```bash
-    sp=`python -c 'import site; print(site.getsitepackages()[0])'`
-    sed -i 's/posthog\.capture/return\n            posthog.capture/' $sp/chromadb/telemetry/posthog.py
-    ```
 * GPU Optional: Support LLaMa.cpp with CUDA:
   * Download/Install [CUDA llama-cpp-python wheel](https://github.com/jllllll/llama-cpp-python-cuBLAS-wheels), E.g.:
     ```bash

--- a/docs/README_offline.md
+++ b/docs/README_offline.md
@@ -5,68 +5,70 @@ Note, when running `generate.py` and asking your first question, it will downloa
 If all data has been put into `~/.cache` by HF transformers, then these following steps (those related to downloading HF models) are not required.
 
 1) Download model and tokenizer of choice
-
-```python
-from transformers import AutoTokenizer, AutoModelForCausalLM
-model_name = 'h2oai/h2ogpt-oasst1-512-12b'
-model = AutoModelForCausalLM.from_pretrained(model_name)
-model.save_pretrained(model_name)
-tokenizer = AutoTokenizer.from_pretrained(model_name)
-tokenizer.save_pretrained(model_name)
-```
+    
+    ```python
+    from transformers import AutoTokenizer, AutoModelForCausalLM
+    model_name = 'h2oai/h2ogpt-oasst1-512-12b'
+    model = AutoModelForCausalLM.from_pretrained(model_name)
+    model.save_pretrained(model_name)
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    tokenizer.save_pretrained(model_name)
+    ```
 
 2) Download reward model, unless pass `--score_model='None'` to `generate.py`
-```python
-# and reward model
-reward_model = 'OpenAssistant/reward-model-deberta-v3-large-v2'
-from transformers import AutoModelForSequenceClassification, AutoTokenizer
-model = AutoModelForSequenceClassification.from_pretrained(reward_model)
-model.save_pretrained(reward_model)
-tokenizer = AutoTokenizer.from_pretrained(reward_model)
-tokenizer.save_pretrained(reward_model)
-```
-
+    ```python
+    # and reward model
+    reward_model = 'OpenAssistant/reward-model-deberta-v3-large-v2'
+    from transformers import AutoModelForSequenceClassification, AutoTokenizer
+    model = AutoModelForSequenceClassification.from_pretrained(reward_model)
+    model.save_pretrained(reward_model)
+    tokenizer = AutoTokenizer.from_pretrained(reward_model)
+    tokenizer.save_pretrained(reward_model)
+    ```
+    
 3) For LangChain support, download embedding model:
-```python
-hf_embedding_model = "sentence-transformers/all-MiniLM-L6-v2"
-model_kwargs = 'cpu'
-from langchain.embeddings import HuggingFaceEmbeddings
-embedding = HuggingFaceEmbeddings(model_name=hf_embedding_model, model_kwargs=model_kwargs)
-```
-
-4) For HF inference server and OpenAI, this downloads the tokenizers used for Hugging Face text generation inference server and gpt-3.5-turbo:
-```python
-import tiktoken
-encoding = tiktoken.get_encoding("cl100k_base")
-encoding = tiktoken.encoding_for_model("gpt-3.5-turbo")
-```
+    ```python
+    hf_embedding_model = "sentence-transformers/all-MiniLM-L6-v2"
+    model_kwargs = 'cpu'
+    from langchain.embeddings import HuggingFaceEmbeddings
+    embedding = HuggingFaceEmbeddings(model_name=hf_embedding_model, model_kwargs=model_kwargs)
+    ```
+    
+    4) For HF inference server and OpenAI, this downloads the tokenizers used for Hugging Face text generation inference server and gpt-3.5-turbo:
+    ```python
+    import tiktoken
+    encoding = tiktoken.get_encoding("cl100k_base")
+    encoding = tiktoken.encoding_for_model("gpt-3.5-turbo")
+    ```
 
 5) Run generate with transformers in [Offline Mode](https://huggingface.co/docs/transformers/installation#offline-mode)
 
-```bash
-HF_DATASETS_OFFLINE=1 TRANSFORMERS_OFFLINE=1 python generate.py --base_model='h2oai/h2ogpt-oasst1-512-12b' --gradio_offline_level=2 --share=False
-```
-
-Some code is always disabled that involves uploads out of user control: Huggingface telemetry, gradio telemetry, chromadb posthog.
-
-The additional option `--gradio_offline_level=2` changes fonts to avoid download of google fonts. This option disables google fonts for downloading, which is less intrusive than uploading, but still required in air-gapped case.  The fonts don't look as nice as google fonts, but ensure full offline behavior.
-
-If the front-end can still access internet, but just backend should not, then one can use `--gradio_offline_level=1` for slightly better-looking fonts.
-
-Note that gradio attempts to download [iframeResizer.contentWindow.min.js](https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.1/iframeResizer.contentWindow.min.js),
-but nothing prevents gradio from working without this.  So a simple firewall block is sufficient.  For more details, see: https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/10324.
+    ```bash
+    HF_DATASETS_OFFLINE=1 TRANSFORMERS_OFFLINE=1 python generate.py --base_model='h2oai/h2ogpt-oasst1-512-12b' --gradio_offline_level=2 --share=False
+    ```
+    
+    Some code is always disabled that involves uploads out of user control: Huggingface telemetry, gradio telemetry, chromadb posthog.
+    
+    The additional option `--gradio_offline_level=2` changes fonts to avoid download of google fonts. This option disables google fonts for downloading, which is less intrusive than uploading, but still required in air-gapped case.  The fonts don't look as nice as google fonts, but ensure full offline behavior.
+    
+    If the front-end can still access internet, but just backend should not, then one can use `--gradio_offline_level=1` for slightly better-looking fonts.
+    
+    Note that gradio attempts to download [iframeResizer.contentWindow.min.js](https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.1/iframeResizer.contentWindow.min.js),
+    but nothing prevents gradio from working without this.  So a simple firewall block is sufficient.  For more details, see: https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/10324.
 
 6. Disable access or port
 
-To ensure nobody can access your gradio server, disable the port via firewall.  If that is a hassle, then one can enable authentication by adding to CLI when running `python generate.py`:
-```
---auth=[('jon','password')]
-```
-with no spaces.  Run `python generate.py --help` for more details.
+    To ensure nobody can access your gradio server, disable the port via firewall.  If that is a hassle, then one can enable authentication by adding to CLI when running `python generate.py`:
+    ```
+    --auth=[('jon','password')]
+    ```
+    with no spaces.  Run `python generate.py --help` for more details.
 
-7. To avoid unauthorized telemetry, which document options still do not disable, run:
-```bash
-sp=`python -c 'import site; print(site.getsitepackages()[0])'`
-sed -i 's/posthog\.capture/return\n            posthog.capture/' $sp/chromadb/telemetry/posthog.py
-```
-or the equivalent for windows/mac using.  Or edit the file manually to just return in the `capture` function.
+7. To fully disable Chroma telemetry, which documented options still do not disable, run:
+    ```bash
+    sp=`python -c 'import site; print(site.getsitepackages()[0])'`
+    sed -i 's/posthog\.capture/return\n            posthog.capture/' $sp/chromadb/telemetry/posthog.py
+    ```
+    or the equivalent for windows/mac using.  Or edit the file manually to just return in the `capture` function.
+
+8. To avoid h2oGPT monitoring which elements are clicked in UI, set the ENV `H2OGPT_ENABLE_HEAP_ANALYTICS=False` pass `--enable-heap-analytics=False` to `generate.py`.  Note that no data or user inputs are included, only raw svelte UI element IDs and nothing from the user inputs or data.

--- a/src/gen.py
+++ b/src/gen.py
@@ -207,6 +207,11 @@ def main(
         caption_gpu: bool = True,
         enable_ocr: bool = False,
         enable_pdf_ocr: str = 'auto',
+        # Heap telemetry
+        enable_heap_analytics: bool = False,
+        # Heap telemetry tracking ID - default corresponds
+        # to Heap Main Dev environment.
+        heap_app_id: str = "1680123994",
 ):
     """
 
@@ -287,8 +292,8 @@ def main(
            but still required in air-gapped case.  The fonts don't look as nice as google fonts, but ensure full offline behavior.
            Also set --share=False to avoid sharing a gradio live link.
     :param root_path: The root path (or "mount point") of the application,
-           if it's not served from the root ("/") of the domain. Often used when the application is behind a reverse proxy 
-           that forwards requests to the application. For example, if the application is served at "https://example.com/myapp", 
+           if it's not served from the root ("/") of the domain. Often used when the application is behind a reverse proxy
+           that forwards requests to the application. For example, if the application is served at "https://example.com/myapp",
            the `root_path` should be set to "/myapp".
     :param chat: whether to enable chat mode with chat history
     :param chat_context: whether to use extra helpful context if human_bot
@@ -437,6 +442,8 @@ def main(
     :param enable_pdf_ocr: 'auto' means only use OCR if normal text extraction fails.  Useful for pure image-based PDFs with text
                             'on' means always do OCR as additional parsing of same documents
                             'off' means don't do OCR (e.g. because it's slow even if 'auto' only would trigger if nothing else worked)
+    :param enable_heap_analytics: Toggle application telemetry.
+    :param heap_app_id: Tracking App ID for Heap analytics.
     :return:
     """
     if base_model is None:
@@ -2528,11 +2535,11 @@ def get_generate_params(model_lower,
         else:
             show_examples = True
 
-    summarize_example1 = """Jeff: Can I train a ? Transformers model on Amazon SageMaker? 
-Philipp: Sure you can use the new Hugging Face Deep Learning Container. 
+    summarize_example1 = """Jeff: Can I train a ? Transformers model on Amazon SageMaker?
+Philipp: Sure you can use the new Hugging Face Deep Learning Container.
 Jeff: ok.
-Jeff: and how can I get started? 
-Jeff: where can I find documentation? 
+Jeff: and how can I get started?
+Jeff: where can I find documentation?
 Philipp: ok, ok you can find everything here. https://huggingface.co/blog/the-partnership-amazon-sagemaker-and-hugging-face"""
 
     use_placeholder_instruction_as_example = False
@@ -2897,7 +2904,7 @@ def entrypoint_main():
     WORLD_SIZE=4 CUDA_VISIBLE_DEVICES="0,1,2,3" torchrun --nproc_per_node=4 --master_port=1234 generate.py --base_model='EleutherAI/gpt-j-6B' --lora_weights=lora-alpaca_6B
     python generate.py --base_model='EleutherAI/gpt-j-6B' --lora_weights='lora-alpaca_6B'
     python generate.py --base_model='EleutherAI/gpt-neox-20b' --lora_weights='lora-alpaca_20B'
-    
+
     # generate without lora weights, no prompt
     python generate.py --base_model='EleutherAI/gpt-neox-20b' --prompt_type='plain'
     python generate.py --base_model='togethercomputer/GPT-NeoXT-Chat-Base-20B' --prompt_type='dai_faq'

--- a/src/gradio_runner.py
+++ b/src/gradio_runner.py
@@ -52,8 +52,9 @@ fix_pydantic_duplicate_validators_error()
 
 from enums import DocumentSubset, no_model_str, no_lora_str, no_server_str, LangChainAction, LangChainMode, \
     DocumentChoice, langchain_modes_intrinsic
-from gradio_themes import H2oTheme, SoftTheme, get_h2o_title, get_simple_title, get_dark_js, spacing_xsm, radius_xsm, \
-    text_xsm
+from gradio_themes import H2oTheme, SoftTheme, get_h2o_title, get_simple_title,\
+    get_dark_js, get_heap_js, wrap_js_to_lambda,\
+    spacing_xsm, radius_xsm, text_xsm
 from prompter import prompt_type_to_model_name, prompt_types_strings, inv_prompt_type_to_model_lower, non_hf_types, \
     get_prompt
 from utils import flatten_list, zip_data, s3up, clear_torch_cache, get_torch_allocated, system_info_print, \
@@ -128,6 +129,9 @@ def go_gradio(**kwargs):
     langchain_modes0 = kwargs['langchain_modes']
     visible_langchain_modes0 = kwargs['visible_langchain_modes']
     langchain_mode_paths0 = kwargs['langchain_mode_paths']
+    # For Heap analytics
+    is_heap_analytics_enabled = kwargs['enable_heap_analytics']
+    heap_app_id = kwargs['heap_app_id']
 
     # easy update of kwargs needed for evaluate() etc.
     queue = True
@@ -1368,7 +1372,7 @@ def go_gradio(**kwargs):
             None,
             None,
             None,
-            _js=get_dark_js(),
+            _js=wrap_js_to_lambda(get_dark_js()),
             api_name="dark" if allow_api else None,
             queue=False,
         )
@@ -2567,7 +2571,10 @@ def go_gradio(**kwargs):
                        ,
                        queue=False, api_name='stop' if allow_api else None).then(clear_torch_cache, queue=False)
 
-        demo.load(None, None, None, _js=get_dark_js() if kwargs['dark'] else None)
+        app_js = wrap_js_to_lambda(
+            get_dark_js(),
+            get_heap_js(heap_app_id) if is_heap_analytics_enabled else None)
+        demo.load(None, None, None, _js=app_js)
 
     demo.queue(concurrency_count=kwargs['concurrency_count'], api_open=kwargs['api_open'])
     favicon_path = "h2o-logo.svg"

--- a/src/gradio_themes.py
+++ b/src/gradio_themes.py
@@ -221,11 +221,23 @@ def get_simple_title(title, description):
     return f"""{description}<h1 align="center"> {title}</h1>"""
 
 
-def get_dark_js():
-    return """() => {
+def get_dark_js() -> str:
+    return """
         if (document.querySelectorAll('.dark').length) {
             document.querySelectorAll('.dark').forEach(el => el.classList.remove('dark'));
         } else {
             document.querySelector('body').classList.add('dark');
         }
-    }"""
+    """
+
+def get_heap_js(heapAppId: str) -> str:
+    return ("""globalThis.window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=document.createElement("script");r.type="text/javascript",r.async=!0,r.src="https://cdn.heapanalytics.com/js/heap-"+e+".js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(r,a);for(var n=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","resetIdentity","removeEventProperty","setEventProperties","track","unsetEventProperty"],o=0;o<p.length;o++)heap[p[o]]=n(p[o])};"""
+           f"""heap.load("{heapAppId}");""")
+
+def wrap_js_to_lambda(*args: str) -> str:
+    newline = "\n"
+    return f"""
+        () => {{
+            {newline.join([a for a in args if a is not None])}
+        }}
+    """


### PR DESCRIPTION
The change enables Heap telemetry in Gradio UI to be able to improve
user experience.
The default tracking app id point to Heap project `Main` and its `Development` environment.

For any H2O.ai deployment we should use tracking app id from Heap
project `Main` and environment `Production`. @mmalohlava or from
@mtanco.

The analytics DO NOT track any prompts, only user interactions in UI
(click on buttons, links).
