### PR TITLE
feat: expose 'root_path' from gradio

### DIFF
--- a/src/gen.py
+++ b/src/gen.py
@@ -110,6 +110,7 @@ def main(
         cli_loop: bool = True,
         gradio: bool = True,
         gradio_offline_level: int = 0,
+        root_path: str = "",
         chat: bool = True,
         chat_context: bool = False,
         stream_output: bool = True,
@@ -266,6 +267,10 @@ def main(
            This option further disables google fonts for downloading, which is less intrusive than uploading,
            but still required in air-gapped case.  The fonts don't look as nice as google fonts, but ensure full offline behavior.
            Also set --share=False to avoid sharing a gradio live link.
+    :param root_path: The root path (or "mount point") of the application,
+           if it's not served from the root ("/") of the domain. Often used when the application is behind a reverse proxy 
+           that forwards requests to the application. For example, if the application is served at "https://example.com/myapp", 
+           the `root_path` should be set to "/myapp".
     :param chat: whether to enable chat mode with chat history
     :param chat_context: whether to use extra helpful context if human_bot
     :param stream_output: whether to stream output

--- a/src/gradio_runner.py
+++ b/src/gradio_runner.py
@@ -2504,7 +2504,7 @@ def go_gradio(**kwargs):
 
     demo.launch(share=kwargs['share'], server_name="0.0.0.0", show_error=True,
                 favicon_path=favicon_path, prevent_thread_lock=True,
-                auth=kwargs['auth'])
+                auth=kwargs['auth'], root_path=kwargs['root_path'])
     if kwargs['verbose']:
         print("Started GUI", flush=True)
     if kwargs['block_gradio_exit']:


### PR DESCRIPTION
Adds additional param '--root_path' to from gradio Blocks.launch() arguments.

I've found this super simple change is a really handy feature and wanted to give it back in case others found it useful. It allows you to place the gradio interface behind a URL ingress subpath like https://domain.com/some-llm/

Thanks!