### PR TITLE
Isolate n_gpus base handling for CUDA from MPS

### DIFF
--- a/src/gen.py
+++ b/src/gen.py
@@ -566,37 +566,43 @@ def main(
 
     n_gpus = torch.cuda.device_count() if torch.cuda.is_available() else 0
     n_gpus, gpu_ids = cuda_vis_check(n_gpus)
-    if n_gpus == 0:
-        print("No GPUs detected", flush=True)
-        enable_captions = False
-        gpu_id = None
-        load_8bit = False
-        load_4bit = False
-        load_half = False
-        load_gptq = ''
-        load_exllama = False
-        use_safetensors = False
-        revision = None
-        use_gpu_id = False
-        torch.backends.cudnn.benchmark = True
-        torch.backends.cudnn.enabled = False
-        torch.set_default_dtype(torch.float32)
-        if psutil.virtual_memory().available < 94 * 1024 ** 3 and not inference_server and not model_lock:
-            # 12B uses ~94GB
-            # 6.9B uses ~47GB
-            base_model = 'h2oai/h2ogpt-oig-oasst1-512-6_9b' if not base_model else base_model
-        if hf_embedding_model is None:
-            # if no GPUs, use simpler embedding model to avoid cost in time
-            hf_embedding_model = "sentence-transformers/all-MiniLM-L6-v2"
-        if score_model == 'auto':
-            score_model = ''
-    else:
-        if score_model == 'auto':
-            if n_gpus >= 2:
-                # will by default place scoring model on last GPU
-                score_model = 'OpenAssistant/reward-model-deberta-v3-large-v2'
-            else:
+
+    if get_device() == "cuda":
+        if n_gpus == 0:
+            print("No GPUs detected", flush=True)
+            enable_captions = False
+            gpu_id = None
+            load_8bit = False
+            load_4bit = False
+            load_half = False
+            load_gptq = ''
+            load_exllama = False
+            use_safetensors = False
+            revision = None
+            use_gpu_id = False
+            torch.backends.cudnn.benchmark = True
+            torch.backends.cudnn.enabled = False
+            torch.set_default_dtype(torch.float32)
+            if psutil.virtual_memory().available < 94 * 1024 ** 3 and not inference_server and not model_lock:
+                # 12B uses ~94GB
+                # 6.9B uses ~47GB
+                base_model = 'h2oai/h2ogpt-oig-oasst1-512-6_9b' if not base_model else base_model
+            if hf_embedding_model is None:
+                # if no GPUs, use simpler embedding model to avoid cost in time
+                hf_embedding_model = "sentence-transformers/all-MiniLM-L6-v2"
+            if score_model == 'auto':
                 score_model = ''
+        else:
+            if score_model == 'auto':
+                if n_gpus >= 2:
+                    # will by default place scoring model on last GPU
+                    score_model = 'OpenAssistant/reward-model-deberta-v3-large-v2'
+                else:
+                    score_model = ''
+            if hf_embedding_model is None:
+                # if still None, then set default
+                hf_embedding_model = 'hkunlp/instructor-large'
+    elif get_device() == "mps":
         if hf_embedding_model is None:
             # if still None, then set default
             hf_embedding_model = 'hkunlp/instructor-large'


### PR DESCRIPTION
Fix #559 

```bash
  ~/Desktop/h2ogpt on   main !2 ❯ python generate.py --base_model='llama' --prompt_type=wizard2 --score_model=None --langchain_mode='UserData'                                                                                                                                                                                ✘ INT took  1m 19s  h2ogpt
Using Model llama
Prep: persist_directory=db_dir_UserData does not exist, regenerating
Did not generate db since no sources
Starting get_model: llama 
Could not determine --max_seq_len, setting to 2048.  Pass if not correct
llama.cpp: loading model from WizardLM-7B-uncensored.ggmlv3.q4_0.bin
llama_model_load_internal: format     = ggjt v3 (latest)
llama_model_load_internal: n_vocab    = 32001
llama_model_load_internal: n_ctx      = 1792
llama_model_load_internal: n_embd     = 4096
llama_model_load_internal: n_mult     = 256
llama_model_load_internal: n_head     = 32
llama_model_load_internal: n_layer    = 32
llama_model_load_internal: n_rot      = 128
llama_model_load_internal: ftype      = 2 (mostly Q4_0)
llama_model_load_internal: n_ff       = 11008
llama_model_load_internal: model size = 7B
llama_model_load_internal: ggml ctx size =    0.08 MB
llama_model_load_internal: mem required  = 5407.72 MB (+ 1026.00 MB per state)
llama_new_context_with_model: kv self size  =  896.00 MB
ggml_metal_init: allocating
ggml_metal_init: using MPS
ggml_metal_init: loading '/Users/mathanraj/miniconda3/envs/h2ogpt/lib/python3.10/site-packages/llama_cpp/ggml-metal.metal'
ggml_metal_init: loaded kernel_add                            0x1730a3980
ggml_metal_init: loaded kernel_mul                            0x1730a3be0
ggml_metal_init: loaded kernel_mul_row                        0x1730a3e40
ggml_metal_init: loaded kernel_scale                          0x1730a40a0
ggml_metal_init: loaded kernel_silu                           0x1730a4300
ggml_metal_init: loaded kernel_relu                           0x1730a4560
ggml_metal_init: loaded kernel_gelu                           0x1730a47c0
ggml_metal_init: loaded kernel_soft_max                       0x1730a4a20
ggml_metal_init: loaded kernel_diag_mask_inf                  0x1730a4c80
ggml_metal_init: loaded kernel_get_rows_f16                   0x1730a4ee0
ggml_metal_init: loaded kernel_get_rows_q4_0                  0x1730a5140
ggml_metal_init: loaded kernel_get_rows_q4_1                  0x1730a53a0
ggml_metal_init: loaded kernel_get_rows_q2_K                  0x1730a5600
ggml_metal_init: loaded kernel_get_rows_q3_K                  0x1730a5860
ggml_metal_init: loaded kernel_get_rows_q4_K                  0x1730a5ac0
ggml_metal_init: loaded kernel_get_rows_q5_K                  0x1730a5d20
ggml_metal_init: loaded kernel_get_rows_q6_K                  0x1730a5f80
ggml_metal_init: loaded kernel_rms_norm                       0x1730a6370
ggml_metal_init: loaded kernel_norm                           0x1730a6760
ggml_metal_init: loaded kernel_mul_mat_f16_f32                0x1730a6d00
ggml_metal_init: loaded kernel_mul_mat_q4_0_f32               0x1730a7100
ggml_metal_init: loaded kernel_mul_mat_q4_1_f32               0x1730a7520
ggml_metal_init: loaded kernel_mul_mat_q2_K_f32               0x1730a7940
ggml_metal_init: loaded kernel_mul_mat_q3_K_f32               0x1730a7f00
ggml_metal_init: loaded kernel_mul_mat_q4_K_f32               0x1730a8320
ggml_metal_init: loaded kernel_mul_mat_q5_K_f32               0x1730a8740
ggml_metal_init: loaded kernel_mul_mat_q6_K_f32               0x1730a8b60
ggml_metal_init: loaded kernel_rope                           0x1730a9390
ggml_metal_init: loaded kernel_alibi_f32                      0x1730a9990
ggml_metal_init: loaded kernel_cpy_f32_f16                    0x1730a9f60
ggml_metal_init: loaded kernel_cpy_f32_f32                    0x1730aa530
ggml_metal_init: loaded kernel_cpy_f16_f16                    0x1730aab00
ggml_metal_init: recommendedMaxWorkingSetSize = 10922.67 MB
ggml_metal_init: hasUnifiedMemory             = true
ggml_metal_init: maxTransferRate              = built-in GPU
llama_new_context_with_model: max tensor size =    70.31 MB
ggml_metal_add_buffer: allocated 'data            ' buffer, size =  3616.08 MB, ( 3616.53 / 10922.67)
ggml_metal_add_buffer: allocated 'eval            ' buffer, size =   768.00 MB, ( 4384.53 / 10922.67)
ggml_metal_add_buffer: allocated 'kv              ' buffer, size =   898.00 MB, ( 5282.53 / 10922.67)
ggml_metal_add_buffer: allocated 'scr0            ' buffer, size =   512.00 MB, ( 5794.53 / 10922.67)
ggml_metal_add_buffer: allocated 'scr1            ' buffer, size =   512.00 MB, ( 6306.53 / 10922.67)
AVX = 0 | AVX2 = 0 | AVX512 = 0 | AVX512_VBMI = 0 | AVX512_VNNI = 0 | FMA = 0 | NEON = 1 | ARM_FMA = 1 | F16C = 0 | FP16_VA = 1 | WASM_SIMD = 0 | BLAS = 1 | SSE3 = 0 | VSX = 0 | 
Model {'base_model': 'llama', 'tokenizer_base_model': '', 'lora_weights': '', 'inference_server': '', 'prompt_type': 'wizard2', 'prompt_dict': {'promptA': 'Below is an instruction that describes a task. Write a response that appropriately completes the request.', 'promptB': 'Below is an instruction that describes a task. Write a response that appropriately completes the request.', 'PreInstruct': '\n### Instruction:\n', 'PreInput': None, 'PreResponse': '\n### Response:\n', 'terminate_response': ['\n### Response:\n'], 'chat_sep': '\n', 'chat_turn_sep': '\n', 'humanstr': '\n### Instruction:\n', 'botstr': '\n### Response:\n', 'generates_leading_space': False}}
Running on local URL:  http://0.0.0.0:7860

To create a public link, set `share=True` in `launch()`.
Did not generate db since no sources
Did not generate db since no sources
Did not generate db since no sources
Did not generate db since no sources

```

![image](https://github.com/h2oai/h2ogpt/assets/30664910/e6b14a13-db7f-4a2b-a64a-699b1b19c17c)
