### PR TITLE
added in rudimentary specificity in terms of the url loader to use

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -1055,6 +1055,8 @@ except (pkg_resources.DistributionNotFound, AssertionError):
 # disable, hangs too often
 have_playwright = False
 
+only_selenium = os.environ.get("ONLY_SELENIUM", "0") == "1"
+only_playwright = os.environ.get("ONLY_PLAYWRIGHT", "0") == "1"
 
 def set_openai(inference_server):
     if inference_server.startswith('vllm'):


### PR DESCRIPTION
Let me preface this with the fact that python is not something I have much experience in at all. That being said, this PR addresses #586 and allows for overriding the unstructuredURLloader with selenium or playwright by means of environment variables (ONLY_SELENIUM / ONLY_PLAYWRIGHT). I figured environment variables would make this easier to implement in other areas/scripts, some kind of getter pattern may be even better but this works.

added in modifications to the get_docs_with_score to help increment down slightly faster instead of -10 each time (honestly not sure if this is working, but starting at 1000 and then decrementing 10 each time is not great if your store only has say 50 docs, it's a workaround to a workaround), as well as added in rudimentary specificity in terms of the url loader to use

