### PR TITLE
mac install readme updated - the tessaract command

### DIFF
--- a/docs/README_MACOS.md
+++ b/docs/README_MACOS.md
@@ -42,7 +42,8 @@ Supports CPU and MPS (Metal M1/M2).
     brew install libmagic
     brew link libmagic
     brew install poppler
-    brew install tesseract --all-languages
+    brew install tesseract
+    brew install tesseract-lang
     ```
 * Metal M1/M2 Only: Install newer Torch for GPU support:
    ```bash


### PR DESCRIPTION
- the `brew install tesseract --all-languages` command in https://github.com/h2oai/h2ogpt/blob/main/docs/README_MACOS.md was incorrect - it wasn't an allowed command
- updated based on @Mathanraj-Sharma feedback