### PR TITLE
the message copy button moved closer to top border and message padding increased to 16px

### DIFF
--- a/gradio_utils/css.py
+++ b/gradio_utils/css.py
@@ -57,4 +57,16 @@ def make_css_base() -> str:
     .gradio-container {
         max-width: none !important;
     }
+    
+    div.message {
+        padding: var(--text-lg) !important;
+    }
+    
+    div.message.user > div.icon-button {
+        top: 0;
+    }
+    
+    div.message.bot > div.icon-button {
+        top: 0;
+    }
     """


### PR DESCRIPTION
- the message copy button moved closer to top border
- message padding increased to 16px

<img width="1284" alt="image" src="https://github.com/h2oai/h2ogpt/assets/18228330/150a69fc-0067-4e89-8d2f-a14603b7d975">
