### PR TITLE
Improve bitsandbytes usage and control in UI

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -12,7 +12,7 @@ def run_cli(  # for local function:
         debug=None, chat_context=None,
         examples=None, memory_restriction_level=None,
         # for get_model:
-        score_model=None, load_8bit=None, load_4bit=None, load_half=None,
+        score_model=None, load_8bit=None, load_4bit=None, low_bit_mode=None, load_half=None,
         load_gptq=None, load_exllama=None, use_safetensors=None, revision=None,
         use_gpu_id=None, tokenizer_base_model=None,
         gpu_id=None, n_jobs=None, local_files_only=None, resume_download=None, use_auth_token=None,

--- a/src/eval.py
+++ b/src/eval.py
@@ -19,7 +19,7 @@ def run_eval(  # for local function:
         eval_filename=None, eval_prompts_only_num=None, eval_prompts_only_seed=None, eval_as_output=None,
         examples=None, memory_restriction_level=None,
         # for get_model:
-        score_model=None, load_8bit=None, load_4bit=None, load_half=None,
+        score_model=None, load_8bit=None, load_4bit=None, low_bit_mode=None, load_half=None,
         load_gptq=None, load_exllama=None, use_safetensors=None, revision=None,
         use_gpu_id=None, tokenizer_base_model=None,
         gpu_id=None, n_jobs=None, local_files_only=None, resume_download=None, use_auth_token=None,
@@ -251,7 +251,7 @@ def run_eval(  # for local function:
                     # dump every score in case abort
                     df_scores = pd.DataFrame(score_dump,
                                              columns=eval_func_param_names +
-                                             eval_extra_columns)
+                                                     eval_extra_columns)
                     df_scores.to_parquet(eval_out_filename, index=False)
                     # plot histogram so far
                     plt.figure(figsize=(10, 10))

--- a/src/gen.py
+++ b/src/gen.py
@@ -1477,20 +1477,17 @@ def get_hf_model(load_8bit: bool = False,
         pop_unused_model_kwargs(model_kwargs)
 
         if load_4bit:
+            # these all only valid for 4-bit
             if low_bit_mode == 1:
-                assert load_4bit, "low_bit_mode==1 only valid for load_4bit=True"
                 from transformers import BitsAndBytesConfig
                 model_kwargs['quantization_config'] = BitsAndBytesConfig(bnb_4bit_compute_dtype=torch.bfloat16)
             elif low_bit_mode == 2:
-                assert load_4bit, "low_bit_mode==2 only valid for load_4bit=True"
                 from transformers import BitsAndBytesConfig
                 model_kwargs['quantization_config'] = BitsAndBytesConfig(bnb_4bit_quant_type="nf4")
             elif low_bit_mode == 3:
-                assert load_4bit, "low_bit_mode==3 only valid for load_4bit=True"
                 from transformers import BitsAndBytesConfig
                 model_kwargs['quantization_config'] = BitsAndBytesConfig(bnb_4bit_use_double_quant=True)
             elif low_bit_mode == 4:
-                assert load_4bit, "low_bit_mode==4 only valid for load_4bit=True"
                 from transformers import BitsAndBytesConfig
                 model_kwargs['quantization_config'] = BitsAndBytesConfig(bnb_4bit_use_double_quant=True,
                                                                          bnb_4bit_quant_type="nf4")

--- a/src/gen.py
+++ b/src/gen.py
@@ -1020,7 +1020,7 @@ def get_config(base_model,
 
     # allow override
     if max_seq_len is not None:
-        print("Overriding max_seq_len %d -> %d" % (max_seq_len, max_seq_len), flush=True)
+        print("Overriding max_seq_len -> %d" % max_seq_len, flush=True)
     else:
         if hasattr(config, 'max_seq_len'):
             max_seq_len = int(config.max_seq_len)

--- a/src/gen.py
+++ b/src/gen.py
@@ -241,6 +241,7 @@ def main(
     :param load_4bit: load model in 4-bit using bitsandbytes
     :param low_bit_mode: 0: no quantization config 1: change compute 2: nf4 3: double quant 4: 2 and 3
            See: https://huggingface.co/docs/transformers/main_classes/quantization
+           If using older bitsandbytes or transformers, 0 is required
     :param load_half: load model in float16
     :param load_gptq: to load model with GPTQ, put model_basename here, e.g. gptq_model-4bit--1g
     :param load_exllama: whether to use exllama (only applicable to LLaMa1/2 models with 16-bit or GPTQ

--- a/src/gradio_runner.py
+++ b/src/gradio_runner.py
@@ -941,6 +941,7 @@ def go_gradio(**kwargs):
                                     max_seq_len = gr.Number(value=kwargs['max_seq_len'] or 2048,
                                                             minimum=128,
                                                             maximum=2 ** 18,
+                                                            info="If standard LLaMa, choose up to 4096",
                                                             label="max_seq_len")
                                     rope_scaling = gr.Textbox(value=str(kwargs['rope_scaling'] or {}),
                                                               label="rope_scaling")
@@ -1030,7 +1031,10 @@ def go_gradio(**kwargs):
                                     server_choice2 = gr.Dropdown(server_options_state.value[0], label="Choose Server 2",
                                                                  value=no_server_str,
                                                                  visible=not is_public)
-                                    max_seq_len2 = gr.Number(value=kwargs['max_seq_len'], minimum=128, maximum=2 ** 18,
+                                    max_seq_len2 = gr.Number(value=kwargs['max_seq_len'] or 2048,
+                                                             minimum=128,
+                                                             maximum=2 ** 18,
+                                                             info="If standard LLaMa, choose up to 4096",
                                                              label="max_seq_len Model 2")
                                     rope_scaling2 = gr.Textbox(value=str(kwargs['rope_scaling'] or {}),
                                                                label="rope_scaling Model 2")

--- a/src/gradio_runner.py
+++ b/src/gradio_runner.py
@@ -555,7 +555,7 @@ def go_gradio(**kwargs):
                             fileup_output = gr.File(label=f'Upload {file_types_str}',
                                                     show_label=False,
                                                     file_types=['.' + x for x in file_types],
-                                                    #file_types=['*', '*.*'],  # for iPhone etc. needs to be unconstrained else doesn't work with extension-based restrictions
+                                                    # file_types=['*', '*.*'],  # for iPhone etc. needs to be unconstrained else doesn't work with extension-based restrictions
                                                     file_count="multiple",
                                                     scale=1,
                                                     min_width=0,
@@ -980,9 +980,25 @@ def go_gradio(**kwargs):
                                 with gr.Column(scale=1, visible=not kwargs['model_lock']):
                                     load_model_button = gr.Button(load_msg, variant=variant_load_msg, scale=0,
                                                                   size='sm', interactive=not is_public)
+                                    model_load4bit_checkbox = gr.components.Checkbox(
+                                        label="Load 4-bit [requires support]",
+                                        value=kwargs['load_4bit'], interactive=not is_public)
+                                    model_low_bit_mode = gr.Slider(value=kwargs['low_bit_mode'],
+                                                                   minimum=0, maximum=4, step=1,
+                                                                   label="low_bit_mode")
                                     model_load8bit_checkbox = gr.components.Checkbox(
                                         label="Load 8-bit [requires support]",
                                         value=kwargs['load_8bit'], interactive=not is_public)
+                                    model_load_gptq = gr.Textbox(label="gptq", value=kwargs['load_gptq'],
+                                                                 interactive=not is_public)
+                                    model_load_exllama_checkbox = gr.components.Checkbox(
+                                        label="Load load_exllama [requires support]",
+                                        value=kwargs['load_exllama'], interactive=not is_public)
+                                    model_safetensors_checkbox = gr.components.Checkbox(
+                                        label="Safetensors [requires support]",
+                                        value=kwargs['use_safetensors'], interactive=not is_public)
+                                    model_revision = gr.Textbox(label="revision", value=kwargs['revision'],
+                                                                interactive=not is_public)
                                     model_use_gpu_id_checkbox = gr.components.Checkbox(
                                         label="Choose Devices [If not Checked, use all GPUs]",
                                         value=kwargs['use_gpu_id'], interactive=not is_public,
@@ -1058,9 +1074,26 @@ def go_gradio(**kwargs):
                                 with gr.Column(scale=1, visible=not kwargs['model_lock']):
                                     load_model_button2 = gr.Button(load_msg2, variant=variant_load_msg, scale=0,
                                                                    size='sm', interactive=not is_public)
+                                    model_load4bit_checkbox2 = gr.components.Checkbox(
+                                        label="Load 4-bit 2 [requires support]",
+                                        value=kwargs['load_4bit'], interactive=not is_public)
+                                    model_low_bit_mode2 = gr.Slider(value=kwargs['low_bit_mode'],
+                                                                    # ok that same as Model 1
+                                                                    minimum=0, maximum=4, step=1,
+                                                                    label="low_bit_mode (Model 2)")
                                     model_load8bit_checkbox2 = gr.components.Checkbox(
                                         label="Load 8-bit 2 [requires support]",
                                         value=kwargs['load_8bit'], interactive=not is_public)
+                                    model_load_gptq2 = gr.Textbox(label="gptq", value='',
+                                                                  interactive=not is_public)
+                                    model_load_exllama_checkbox2 = gr.components.Checkbox(
+                                        label="Load load_exllama [requires support]",
+                                        value=False, interactive=not is_public)
+                                    model_safetensors_checkbox2 = gr.components.Checkbox(
+                                        label="Safetensors 2 [requires support]",
+                                        value=False, interactive=not is_public)
+                                    model_revision2 = gr.Textbox(label="revision 2", value='',
+                                                                 interactive=not is_public)
                                     model_use_gpu_id_checkbox2 = gr.components.Checkbox(
                                         label="Choose Devices 2 [If not Checked, use all GPUs]",
                                         value=kwargs[
@@ -2904,7 +2937,9 @@ def go_gradio(**kwargs):
                                                           api_name='submit_nochat_api' if allow_api else None) \
             .then(clear_torch_cache)
 
-        def load_model(model_name, lora_weights, server_name, model_state_old, prompt_type_old, load_8bit,
+        def load_model(model_name, lora_weights, server_name, model_state_old, prompt_type_old,
+                       load_4bit, load_8bit, low_bit_mode,
+                       load_gptq, load_exllama, use_safetensors, revision,
                        use_gpu_id, gpu_id, max_seq_len1, rope_scaling1,
                        model_path_llama1, model_name_gptj1, model_name_gpt4all_llama1,
                        n_gpu_layers1, n_batch1, n_gqa1, llamacpp_dict_more1):
@@ -2968,7 +3003,13 @@ def go_gradio(**kwargs):
             # don't deepcopy, can contain model itself
             all_kwargs1 = all_kwargs.copy()
             all_kwargs1['base_model'] = model_name.strip()
+            all_kwargs1['load_4bit'] = load_4bit
             all_kwargs1['load_8bit'] = load_8bit
+            all_kwargs1['low_bit_mode'] = low_bit_mode
+            all_kwargs1['load_gptq'] = load_gptq
+            all_kwargs1['load_exllama'] = load_exllama
+            all_kwargs1['use_safetensors'] = use_safetensors
+            all_kwargs1['revision'] = None if not revision else revision  # transcribe, don't pass ''
             all_kwargs1['use_gpu_id'] = use_gpu_id
             all_kwargs1['gpu_id'] = int(gpu_id) if gpu_id not in [None, 'None'] else None  # detranscribe
             all_kwargs1['llamacpp_dict'] = llamacpp_dict
@@ -3041,7 +3082,10 @@ def go_gradio(**kwargs):
 
         load_model_args = dict(fn=load_model,
                                inputs=[model_choice, lora_choice, server_choice, model_state, prompt_type,
-                                       model_load8bit_checkbox, model_use_gpu_id_checkbox, model_gpu,
+                                       model_load4bit_checkbox, model_load8bit_checkbox, model_low_bit_mode,
+                                       model_load_gptq, model_load_exllama_checkbox,
+                                       model_safetensors_checkbox, model_revision,
+                                       model_use_gpu_id_checkbox, model_gpu,
                                        max_seq_len, rope_scaling,
                                        model_path_llama, model_name_gptj, model_name_gpt4all_llama,
                                        n_gpu_layers, n_batch, n_gqa, llamacpp_dict_more],
@@ -3061,7 +3105,10 @@ def go_gradio(**kwargs):
 
         load_model_args2 = dict(fn=load_model,
                                 inputs=[model_choice2, lora_choice2, server_choice2, model_state2, prompt_type2,
-                                        model_load8bit_checkbox2, model_use_gpu_id_checkbox2, model_gpu2,
+                                        model_load4bit_checkbox2, model_load8bit_checkbox2, model_low_bit_mode2,
+                                        model_load_gptq2, model_load_exllama_checkbox2,
+                                        model_safetensors_checkbox2, model_revision2,
+                                        model_use_gpu_id_checkbox2, model_gpu2,
                                         max_seq_len2, rope_scaling2,
                                         model_path_llama2, model_name_gptj2, model_name_gpt4all_llama2,
                                         n_gpu_layers2, n_batch2, n_gqa2, llamacpp_dict_more2],

--- a/src/gradio_runner.py
+++ b/src/gradio_runner.py
@@ -980,15 +980,15 @@ def go_gradio(**kwargs):
                                 with gr.Column(scale=1, visible=not kwargs['model_lock']):
                                     load_model_button = gr.Button(load_msg, variant=variant_load_msg, scale=0,
                                                                   size='sm', interactive=not is_public)
+                                    model_load8bit_checkbox = gr.components.Checkbox(
+                                        label="Load 8-bit [requires support]",
+                                        value=kwargs['load_8bit'], interactive=not is_public)
                                     model_load4bit_checkbox = gr.components.Checkbox(
                                         label="Load 4-bit [requires support]",
                                         value=kwargs['load_4bit'], interactive=not is_public)
                                     model_low_bit_mode = gr.Slider(value=kwargs['low_bit_mode'],
                                                                    minimum=0, maximum=4, step=1,
                                                                    label="low_bit_mode")
-                                    model_load8bit_checkbox = gr.components.Checkbox(
-                                        label="Load 8-bit [requires support]",
-                                        value=kwargs['load_8bit'], interactive=not is_public)
                                     model_load_gptq = gr.Textbox(label="gptq", value=kwargs['load_gptq'],
                                                                  interactive=not is_public)
                                     model_load_exllama_checkbox = gr.components.Checkbox(
@@ -1074,42 +1074,42 @@ def go_gradio(**kwargs):
                                 with gr.Column(scale=1, visible=not kwargs['model_lock']):
                                     load_model_button2 = gr.Button(load_msg2, variant=variant_load_msg, scale=0,
                                                                    size='sm', interactive=not is_public)
+                                    model_load8bit_checkbox2 = gr.components.Checkbox(
+                                        label="Load 8-bit (Model 2) [requires support]",
+                                        value=kwargs['load_8bit'], interactive=not is_public)
                                     model_load4bit_checkbox2 = gr.components.Checkbox(
-                                        label="Load 4-bit 2 [requires support]",
+                                        label="Load 4-bit (Model 2) [requires support]",
                                         value=kwargs['load_4bit'], interactive=not is_public)
                                     model_low_bit_mode2 = gr.Slider(value=kwargs['low_bit_mode'],
                                                                     # ok that same as Model 1
                                                                     minimum=0, maximum=4, step=1,
                                                                     label="low_bit_mode (Model 2)")
-                                    model_load8bit_checkbox2 = gr.components.Checkbox(
-                                        label="Load 8-bit 2 [requires support]",
-                                        value=kwargs['load_8bit'], interactive=not is_public)
                                     model_load_gptq2 = gr.Textbox(label="gptq", value='',
                                                                   interactive=not is_public)
                                     model_load_exllama_checkbox2 = gr.components.Checkbox(
-                                        label="Load load_exllama [requires support]",
+                                        label="Load load_exllama (Model 2) [requires support]",
                                         value=False, interactive=not is_public)
                                     model_safetensors_checkbox2 = gr.components.Checkbox(
-                                        label="Safetensors 2 [requires support]",
+                                        label="Safetensors (Model 2) [requires support]",
                                         value=False, interactive=not is_public)
                                     model_revision2 = gr.Textbox(label="revision 2", value='',
                                                                  interactive=not is_public)
                                     model_use_gpu_id_checkbox2 = gr.components.Checkbox(
-                                        label="Choose Devices 2 [If not Checked, use all GPUs]",
+                                        label="Choose Devices (Model 2) [If not Checked, use all GPUs]",
                                         value=kwargs[
                                             'use_gpu_id'], interactive=not is_public)
                                     model_gpu2 = gr.Dropdown(n_gpus_list,
-                                                             label="GPU ID 2 [-1 = all GPUs, if choose is enabled]",
+                                                             label="GPU ID (Model 2) [-1 = all GPUs, if choose is enabled]",
                                                              value=kwargs['gpu_id'], interactive=not is_public)
                                     # no model/lora loaded ever in model2 by default
                                     model_used2 = gr.Textbox(label="Current Model 2", value=no_model_str,
                                                              interactive=False)
-                                    lora_used2 = gr.Textbox(label="Current LORA 2", value=no_lora_str,
+                                    lora_used2 = gr.Textbox(label="Current LORA (Model 2)", value=no_lora_str,
                                                             visible=kwargs['show_lora'], interactive=False)
-                                    server_used2 = gr.Textbox(label="Current Server 2", value=no_server_str,
+                                    server_used2 = gr.Textbox(label="Current Server (Model 2)", value=no_server_str,
                                                               interactive=False,
                                                               visible=not is_public)
-                                    prompt_dict2 = gr.Textbox(label="Prompt (or Custom) 2",
+                                    prompt_dict2 = gr.Textbox(label="Prompt (or Custom) (Model 2)",
                                                               value=pprint.pformat(kwargs['prompt_dict'], indent=4),
                                                               interactive=not is_public, lines=4)
                     with gr.Row(visible=not kwargs['model_lock']):
@@ -2938,7 +2938,7 @@ def go_gradio(**kwargs):
             .then(clear_torch_cache)
 
         def load_model(model_name, lora_weights, server_name, model_state_old, prompt_type_old,
-                       load_4bit, load_8bit, low_bit_mode,
+                       load_8bit, load_4bit, low_bit_mode,
                        load_gptq, load_exllama, use_safetensors, revision,
                        use_gpu_id, gpu_id, max_seq_len1, rope_scaling1,
                        model_path_llama1, model_name_gptj1, model_name_gpt4all_llama1,
@@ -3003,8 +3003,8 @@ def go_gradio(**kwargs):
             # don't deepcopy, can contain model itself
             all_kwargs1 = all_kwargs.copy()
             all_kwargs1['base_model'] = model_name.strip()
-            all_kwargs1['load_4bit'] = load_4bit
             all_kwargs1['load_8bit'] = load_8bit
+            all_kwargs1['load_4bit'] = load_4bit
             all_kwargs1['low_bit_mode'] = low_bit_mode
             all_kwargs1['load_gptq'] = load_gptq
             all_kwargs1['load_exllama'] = load_exllama
@@ -3082,7 +3082,7 @@ def go_gradio(**kwargs):
 
         load_model_args = dict(fn=load_model,
                                inputs=[model_choice, lora_choice, server_choice, model_state, prompt_type,
-                                       model_load4bit_checkbox, model_load8bit_checkbox, model_low_bit_mode,
+                                       model_load8bit_checkbox, model_load4bit_checkbox, model_low_bit_mode,
                                        model_load_gptq, model_load_exllama_checkbox,
                                        model_safetensors_checkbox, model_revision,
                                        model_use_gpu_id_checkbox, model_gpu,
@@ -3105,7 +3105,7 @@ def go_gradio(**kwargs):
 
         load_model_args2 = dict(fn=load_model,
                                 inputs=[model_choice2, lora_choice2, server_choice2, model_state2, prompt_type2,
-                                        model_load4bit_checkbox2, model_load8bit_checkbox2, model_low_bit_mode2,
+                                        model_load8bit_checkbox2, model_load4bit_checkbox2, model_low_bit_mode2,
                                         model_load_gptq2, model_load_exllama_checkbox2,
                                         model_safetensors_checkbox2, model_revision2,
                                         model_use_gpu_id_checkbox2, model_gpu2,

--- a/src/gradio_runner.py
+++ b/src/gradio_runner.py
@@ -941,7 +941,7 @@ def go_gradio(**kwargs):
                                     max_seq_len = gr.Number(value=kwargs['max_seq_len'] or 2048,
                                                             minimum=128,
                                                             maximum=2 ** 18,
-                                                            info="If standard LLaMa, choose up to 4096",
+                                                            info="If standard LLaMa-2, choose up to 4096",
                                                             label="max_seq_len")
                                     rope_scaling = gr.Textbox(value=str(kwargs['rope_scaling'] or {}),
                                                               label="rope_scaling")
@@ -1034,7 +1034,7 @@ def go_gradio(**kwargs):
                                     max_seq_len2 = gr.Number(value=kwargs['max_seq_len'] or 2048,
                                                              minimum=128,
                                                              maximum=2 ** 18,
-                                                             info="If standard LLaMa, choose up to 4096",
+                                                             info="If standard LLaMa-2, choose up to 4096",
                                                              label="max_seq_len Model 2")
                                     rope_scaling2 = gr.Textbox(value=str(kwargs['rope_scaling'] or {}),
                                                                label="rope_scaling Model 2")

--- a/src/loaders.py
+++ b/src/loaders.py
@@ -2,7 +2,7 @@ import functools
 
 
 def get_loaders(model_name, reward_type, llama_type=None, load_gptq='', load_exllama=False, config=None,
-                rope_scaling=None, max_seq_len=None):
+                rope_scaling=None, max_seq_len=None, model_name_exllama_if_no_config=''):
     # NOTE: Some models need specific new prompt_type
     # E.g. t5_xxl_true_nli_mixture has input format: "premise: PREMISE_TEXT hypothesis: HYPOTHESIS_TEXT".)
     if load_exllama:
@@ -17,7 +17,7 @@ def get_loaders(model_name, reward_type, llama_type=None, load_gptq='', load_exl
         else:
             # then use path in env file
             # Directory containing model, tokenizer, generator
-            model_directory = env_kwargs['model_name_exllama_if_no_config']
+            model_directory = model_name_exllama_if_no_config
 
         # download model
         revision = config._commit_hash


### PR DESCRIPTION
Goes from 5 -> 16 tokens/sec in 4-bit mode

For:
```
UserWarning: Input type into Linear4bit is torch.float16, but bnb_4bit_compute_type=torch.float32 (default). This will lead to slow inference or training speed. warnings.warn(f'Input type into Linear4bit is torch.float16, but bnb_4bit_compute_type=torch.float32 (default). This will lead to slow inference or training speed.')
```

![image](https://github.com/h2oai/h2ogpt/assets/2249614/b77b38c9-819d-4f8c-96ba-687ca4d48339)

![image](https://github.com/h2oai/h2ogpt/assets/2249614/f012245a-73fd-4a6f-b24c-3d74d41ab4af)

