### PR TITLE
Fixes #678 and Fixes #451 and Fixes #434

### DIFF
--- a/docs/README_WINDOWS.md
+++ b/docs/README_WINDOWS.md
@@ -1,6 +1,6 @@
 # Windows 10/11
 
-If using GPU on Windows 10 Pro 64-bit, we recommend [downloading and installing Windows installer](https://h2o-release.s3.amazonaws.com/h2ogpt/h2oGPT_0.0.1.exe)
+If using GPU on Windows 10/11 Pro 64-bit, we recommend using [Windows installers](../README.md#windows-1011-64-bit-with-full-document-qa-capability).
 
 For newer builds of windows versions of 10/11.
 

--- a/finetune.py
+++ b/finetune.py
@@ -187,7 +187,8 @@ def train(
             log("num_gpus: %d" % gpus)
             log("max mem: %s" % max_memory)
 
-    model_loader, tokenizer_loader = get_loaders(model_name=base_model, reward_type=False, llama_type=llama_type)
+    model_loader, tokenizer_loader, conditional_type = (
+        get_loaders(model_name=base_model, reward_type=False, llama_type=llama_type))
 
     model = model_loader(
         base_model,

--- a/src/client_test.py
+++ b/src/client_test.py
@@ -344,7 +344,7 @@ def run_client_gen(client, prompt, args, kwargs, do_md_to_text=True, verbose=Fal
     res_dict['prompt'] = prompt
     if not kwargs['stream_output']:
         res = client.predict(str(dict(kwargs)), api_name='/submit_nochat_api')
-        res_dict['response'] = res[0]
+        res_dict.update(ast.literal_eval(res))
         print(md_to_text(res_dict['response'], do_md_to_text=do_md_to_text))
         return res_dict, client
     else:

--- a/src/create_data.py
+++ b/src/create_data.py
@@ -1608,7 +1608,8 @@ def test_check_stats_data():
 
     llama_type = False
     tokenizer_base_model = base_model = 'h2oai/h2ogpt-oasst1-512-20b'
-    model_loader, tokenizer_loader = get_loaders(model_name=base_model, reward_type=False, llama_type=llama_type)
+    model_loader, tokenizer_loader, conditional_type = (
+        get_loaders(model_name=base_model, reward_type=False, llama_type=llama_type))
     local_files_only = False
     resume_download = True
     use_auth_token = False

--- a/src/enums.py
+++ b/src/enums.py
@@ -35,6 +35,7 @@ class PromptType(Enum):
     llama2 = 29
     beluga = 30
     wizard3nospace = 31
+    one_shot = 32
 
 
 class DocumentSubset(Enum):

--- a/src/enums.py
+++ b/src/enums.py
@@ -134,3 +134,10 @@ source_postfix = "End Sources<p>"
 
 super_source_prefix = f"""<details><summary><font size="{font_size}">Sources</font></summary><font size="{font_size}"><font size="{font_size}">Sources [Score | Link]:"""
 super_source_postfix = f"""End Sources<p></font></font></details>"""
+
+
+def t5_type(model_name):
+    return 't5' == model_name.lower() or \
+        't5-' in model_name.lower() or \
+        'flan-' in model_name.lower() or \
+        'fastchat-t5' in model_name.lower()

--- a/src/export_hf_checkpoint.py
+++ b/src/export_hf_checkpoint.py
@@ -35,7 +35,8 @@ def do_export():
     as_pytorch = False  # False -> HF
 
     from loaders import get_loaders
-    model_loader, tokenizer_loader = get_loaders(model_name=BASE_MODEL, reward_type=False, llama_type=llama_type)
+    model_loader, tokenizer_loader, conditional_type = (
+        get_loaders(model_name=BASE_MODEL, reward_type=False, llama_type=llama_type))
 
     tokenizer = tokenizer_loader.from_pretrained(
         BASE_MODEL,

--- a/src/gen.py
+++ b/src/gen.py
@@ -26,8 +26,8 @@ warnings.filterwarnings('ignore', category=UserWarning, message='TypedStorage is
 from evaluate_params import eval_func_param_names, no_default_param_names, input_args_list
 from enums import DocumentSubset, LangChainMode, no_lora_str, model_token_mapping, no_model_str, \
     LangChainAction, LangChainAgent, DocumentChoice, LangChainTypes, super_source_prefix, \
-    super_source_postfix
-from loaders import get_loaders, t5_type
+    super_source_postfix, t5_type
+from loaders import get_loaders
 from utils import set_seed, clear_torch_cache, NullContext, wrapped_partial, EThread, get_githash, \
     import_matplotlib, get_device, makedirs, get_kwargs, start_faulthandler, get_hf_server, FakeTokenizer, \
     have_langchain, set_openai, cuda_vis_check, H2O_Fire
@@ -2363,7 +2363,7 @@ def evaluate(
         assert src_lang is not None
         tokenizer.src_lang = languages_covered()[src_lang]
 
-    stopping_criteria = get_stopping(prompt_type, prompt_dict, tokenizer, device,
+    stopping_criteria = get_stopping(prompt_type, prompt_dict, tokenizer, device, base_model,
                                      model_max_length=tokenizer.model_max_length)
 
     inputs = tokenizer(prompt, return_tensors="pt")

--- a/src/gen.py
+++ b/src/gen.py
@@ -504,7 +504,11 @@ def main(
     :param enable_sources_list: Whether to allow list (or download for non-shared db) of list of sources for chosen db
     :param chunk: Whether to chunk data (True unless know data is already optimally chunked)
     :param chunk_size: Size of chunks, with typically top-4 passed to LLM, so needs to be in context length
-    :param top_k_docs: number of chunks to give LLM
+    :param top_k_docs: For langchain_action query: number of chunks to give LLM
+                       -1 : auto-fills context up to max_seq_len
+                       For langchain_action summarize: number of document parts, like pages for PDF.
+                       There's no such thing as chunks for summarization.
+                       -1 : auto-fills context up to max_seq_len
     :param reverse_docs: whether to reverse docs order so most relevant is closest to question.
            Best choice for sufficiently smart model, and truncation occurs for oldest context, so best then too.
            But smaller 6_9 models fail to use newest context and can get stuck on old information.

--- a/src/gen.py
+++ b/src/gen.py
@@ -2472,6 +2472,8 @@ def evaluate(
                     decoder = decoder_raw
                     decoder_kwargs = decoder_raw_kwargs
                 else:
+                    # decode(encode(prompt)) != prompt, then assume tokenizer issue and generation cleaner, so use real prompt
+                    inputs_decoded = prompt
                     if verbose:
                         print("WARNING: Special characters in prompt", flush=True)
                 if stream_output:

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -347,7 +347,7 @@ class GradioInference(LLM):
     do_sample: bool = False
     chat_client: bool = False
 
-    return_full_text: bool = True
+    return_full_text: bool = False
     stream_output: bool = False
     sanitize_bot_response: bool = False
 
@@ -990,7 +990,7 @@ def get_llm(use_openai_model=False,
             chat_client = False
             llm = GradioInference(
                 inference_server_url=inference_server,
-                return_full_text=True,
+                return_full_text=False,
 
                 temperature=temperature,
                 top_p=top_p,
@@ -1133,12 +1133,12 @@ def get_llm(use_openai_model=False,
                           max_time=max_time,
                           repetition_penalty=repetition_penalty,
                           num_return_sequences=num_return_sequences,
-                          return_full_text=True,
+                          return_full_text=False,
                           handle_long_generation=None)
         assert len(set(gen_hyper).difference(gen_kwargs.keys())) == 0
 
         if stream_output:
-            skip_prompt = False
+            skip_prompt = True
             from gen import H2OTextIteratorStreamer
             decoder_kwargs = {}
             streamer = H2OTextIteratorStreamer(tokenizer, skip_prompt=skip_prompt, block=False, **decoder_kwargs)
@@ -2604,7 +2604,6 @@ def _run_qa_db(query=None,
                 thread = EThread(target=chain, streamer=streamer, bucket=bucket)
                 thread.start()
                 outputs = ""
-                prompt = None  # FIXME
                 try:
                     for new_text in streamer:
                         # print("new_text: %s" % new_text, flush=True)
@@ -2622,7 +2621,9 @@ def _run_qa_db(query=None,
                                     output_with_prompt = outputs
                                     only_new_text = True
                             else:
+                                prompt = None  # FIXME
                                 output_with_prompt = outputs
+                                only_new_text = True
                             output1 = prompter.get_response(output_with_prompt, prompt=prompt,
                                                             only_new_text=only_new_text,
                                                             sanitize_bot_response=sanitize_bot_response)

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -1158,6 +1158,7 @@ def get_llm(use_openai_model=False,
                                          tokenizer=tokenizer,
                                          # leave some room for 1 paragraph, even if min_new_tokens=0
                                          max_input_tokens=max_max_tokens - max(min_new_tokens, 256),
+                                         base_model=model_name,
                                          **gen_kwargs)
         # pipe.task = "text-generation"
         # below makes it listen only to our prompt removal,

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -3464,7 +3464,9 @@ def _update_user_db(file,
                 assert get_dbid(db1) is not None, "db hash was None, not allowed"
                 # then create
                 # if added has to original state and didn't change, then would be shared db for all users
-                persist_directory, langchain_type = get_persist_directory(langchain_mode, db1s=db1s, dbs=dbs)
+                langchain_type = langchain_mode_types.get(langchain_mode, LangChainTypes.EITHER.value)
+                persist_directory, langchain_type = get_persist_directory(langchain_mode, db1s=db1s, dbs=dbs,
+                                                                          langchain_type=langchain_type)
                 langchain_mode_types[langchain_mode] = langchain_type
                 db = get_db(sources, use_openai_embedding=use_openai_embedding,
                             db_type=db_type,
@@ -3479,7 +3481,9 @@ def _update_user_db(file,
             source_files_added = get_source_files(db=db1[0], exceptions=exceptions)
             return None, langchain_mode, source_files_added, '\n'.join(exceptions_strs)
         else:
-            persist_directory, langchain_type = get_persist_directory(langchain_mode, db1s=db1s, dbs=dbs)
+            langchain_type = langchain_mode_types.get(langchain_mode, LangChainTypes.EITHER.value)
+            persist_directory, langchain_type = get_persist_directory(langchain_mode, db1s=db1s, dbs=dbs,
+                                                                      langchain_type=langchain_type)
             langchain_mode_types[langchain_mode] = langchain_type
             if langchain_mode in dbs and dbs[langchain_mode] is not None:
                 # then add

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -2616,12 +2616,15 @@ def _run_qa_db(query=None,
                                 if prompter.botstr:
                                     prompt = prompter.botstr
                                     output_with_prompt = prompt + outputs
+                                    only_new_text = False
                                 else:
                                     prompt = None
                                     output_with_prompt = outputs
+                                    only_new_text = True
                             else:
                                 output_with_prompt = outputs
                             output1 = prompter.get_response(output_with_prompt, prompt=prompt,
+                                                            only_new_text=only_new_text,
                                                             sanitize_bot_response=sanitize_bot_response)
                             yield output1, ''
                         else:

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -2588,10 +2588,14 @@ def _run_qa_db(query=None,
     # context stuff similar to used in evaluate()
     import torch
     device, torch_dtype, context_class = get_device_dtype()
-    conditional_type = hasattr(llm, 'pipeline') and hasattr(llm.pipeline, 'model') and hasattr(llm.pipeline.model, 'conditional_type') and llm.pipeline.model.conditional_type
+    conditional_type = hasattr(llm, 'pipeline') and hasattr(llm.pipeline, 'model') and hasattr(llm.pipeline.model,
+                                                                                               'conditional_type') and llm.pipeline.model.conditional_type
     with torch.no_grad():
         have_lora_weights = lora_weights not in [no_lora_str, '', None]
         context_class_cast = NullContext if device == 'cpu' or have_lora_weights else torch.autocast
+        if conditional_type:
+            # issues when casting to float16, can mess up t5 model, e.g. only when not streaming, or other odd behaviors
+            context_class_cast = NullContext
         with context_class_cast(device):
             if stream_output and streamer:
                 answer = None

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -159,6 +159,10 @@ def _get_unique_sources_in_weaviate(db):
 def del_from_db(db, sources, db_type=None):
     if db_type == 'chroma':
         # sources should be list of x.metadata['source'] from document metadatas
+        if isinstance(sources, str):
+            sources = [sources]
+        else:
+            assert isinstance(sources, (list, tuple, types.GeneratorType))
         metadatas = set(sources)
         client_collection = db._client.get_collection(name=db._collection.name,
                                                       embedding_function=db._collection._embedding_function)

--- a/src/gradio_runner.py
+++ b/src/gradio_runner.py
@@ -695,7 +695,7 @@ def go_gradio(**kwargs):
                                                         visible=sources_visible)
                             # handle API get sources
                             get_sources_api_btn = gr.Button(visible=False)
-                            get_sources_text = gr.Textbox(visible=False)
+                            get_sources_api_text = gr.Textbox(visible=False)
 
                             show_sources_btn = gr.Button(value="Show Sources from DB", scale=0, size='sm',
                                                          visible=sources_visible)
@@ -1403,8 +1403,8 @@ def go_gradio(**kwargs):
             .then(fn=update_dropdown, inputs=docs_state, outputs=document_choice)
 
         get_sources_api_args = dict(fn=functools.partial(get_sources1, api=True),
-                                    inputs=[my_db_state, selection_docs_state, langchain_mode],
-                                    outputs=get_sources_text,
+                                    inputs=[my_db_state, selection_docs_state, requests_state, langchain_mode],
+                                    outputs=get_sources_api_text,
                                     queue=queue)
         get_sources_api_btn.click(**get_sources_api_args,
                                   api_name='get_sources_api' if allow_api else None)

--- a/src/gradio_runner.py
+++ b/src/gradio_runner.py
@@ -58,7 +58,7 @@ from prompter import prompt_type_to_model_name, prompt_types_strings, inv_prompt
     get_prompt
 from utils import flatten_list, zip_data, s3up, clear_torch_cache, get_torch_allocated, system_info_print, \
     ping, makedirs, get_kwargs, system_info, ping_gpu, get_url, get_local_ip, \
-    save_generate_output, url_alive
+    save_generate_output, url_alive, remove
 from gen import get_model, languages_covered, evaluate, score_qa, inputs_kwargs_list, \
     get_max_max_new_tokens, get_minmax_top_k_docs, history_to_context, langchain_actions, langchain_agents_list
 from evaluate_params import eval_func_param_names, no_default_param_names, eval_func_param_names_defaults, \
@@ -426,7 +426,7 @@ def go_gradio(**kwargs):
             allow = False
         return allow
 
-    with demo:
+    with (demo):
         # avoid actual model/tokenizer here or anything that would be bad to deepcopy
         # https://github.com/gradio-app/gradio/issues/3558
         model_state = gr.State(
@@ -693,8 +693,14 @@ def go_gradio(**kwargs):
                         with gr.Column(scale=1):
                             get_sources_btn = gr.Button(value="Update UI with Document(s) from DB", scale=0, size='sm',
                                                         visible=sources_visible)
+                            # handle API get sources
+                            get_sources_api_btn = gr.Button(visible=False)
+                            get_sources_text = gr.Textbox(visible=False)
+
                             show_sources_btn = gr.Button(value="Show Sources from DB", scale=0, size='sm',
                                                          visible=sources_visible)
+                            delete_sources_btn = gr.Button(value="Delete Selected Sources from DB", scale=0, size='sm',
+                                                           visible=sources_visible)
                             refresh_sources_btn = gr.Button(value="Update DB with new/changed files on disk", scale=0,
                                                             size='sm',
                                                             visible=sources_visible and allow_upload_to_user_data)
@@ -713,9 +719,13 @@ def go_gradio(**kwargs):
                                                                  placeholder=add_placeholder,
                                                                  interactive=True)
                             remove_langchain_mode_text = gr.Textbox(value="", visible=visible_add_remove_collection,
-                                                                    label='Remove Collection',
+                                                                    label='Remove Collection from UI',
                                                                     placeholder=remove_placeholder,
                                                                     interactive=True)
+                            purge_langchain_mode_text = gr.Textbox(value="", visible=visible_add_remove_collection,
+                                                                   label='Purge Collection (UI, DB, & source files)',
+                                                                   placeholder=remove_placeholder,
+                                                                   interactive=True)
                             load_langchain = gr.Button(value="Load LangChain State", scale=0, size='sm',
                                                        visible=allow_upload_to_user_data and
                                                                kwargs['langchain_mode'] != 'Disabled')
@@ -1324,7 +1334,14 @@ def go_gradio(**kwargs):
                      eventdb3a, eventdb3b, eventdb3, eventdb3c]
 
         get_sources1 = functools.partial(get_sources_gr, dbs=dbs, docs_state0=docs_state0,
-                                         get_userid_auth=get_userid_auth)
+                                         load_db_if_exists=load_db_if_exists,
+                                         db_type=db_type,
+                                         use_openai_embedding=use_openai_embedding,
+                                         hf_embedding_model=hf_embedding_model,
+                                         migrate_embedding_model=migrate_embedding_model,
+                                         verbose=verbose,
+                                         get_userid_auth=get_userid_auth,
+                                         )
 
         # if change collection source, must clear doc selections from it to avoid inconsistency
         def clear_doc_choice():
@@ -1373,17 +1390,25 @@ def go_gradio(**kwargs):
             return gr.Dropdown.update(choices=x, value=[docs_state0[0]])
 
         get_sources_args = dict(fn=get_sources1,
-                                inputs=[my_db_state, requests_state, langchain_mode],
+                                inputs=[my_db_state, selection_docs_state, requests_state, langchain_mode],
                                 outputs=[file_source, docs_state],
-                                queue=queue,
-                                api_name='get_sources' if allow_api else None)
+                                queue=queue)
 
         eventdb7a = get_sources_btn.click(user_state_setup,
                                           inputs=[my_db_state, requests_state, get_sources_btn, get_sources_btn],
                                           outputs=[my_db_state, requests_state, get_sources_btn],
                                           show_progress='minimal')
-        eventdb7 = eventdb7a.then(**get_sources_args) \
+        eventdb7 = eventdb7a.then(**get_sources_args,
+                                  api_name='get_sources' if allow_api else None) \
             .then(fn=update_dropdown, inputs=docs_state, outputs=document_choice)
+
+        get_sources_api_args = dict(fn=functools.partial(get_sources1, api=True),
+                                    inputs=[my_db_state, selection_docs_state, langchain_mode],
+                                    outputs=get_sources_text,
+                                    queue=queue)
+        get_sources_api_btn.click(**get_sources_api_args,
+                                  api_name='get_sources_api' if allow_api else None)
+
         # show button, else only show when add.
         # Could add to above get_sources for download/dropdown, but bit much maybe
         show_sources1 = functools.partial(get_source_files_given_langchain_mode_gr,
@@ -1399,18 +1424,26 @@ def go_gradio(**kwargs):
                                            inputs=[my_db_state, requests_state, show_sources_btn, show_sources_btn],
                                            outputs=[my_db_state, requests_state, show_sources_btn],
                                            show_progress='minimal')
-        eventdb8 = eventdb8a.then(fn=show_sources1,
-                                  inputs=[my_db_state, selection_docs_state, requests_state, langchain_mode],
-                                  outputs=sources_text,
+        show_sources_kwargs = dict(fn=show_sources1,
+                                   inputs=[my_db_state, selection_docs_state, requests_state, langchain_mode],
+                                   outputs=sources_text)
+        eventdb8 = eventdb8a.then(**show_sources_kwargs,
                                   api_name='show_sources' if allow_api else None)
 
         def update_viewable_dropdown(x):
             return gr.Dropdown.update(choices=x,
                                       value=viewable_docs_state0[0] if len(viewable_docs_state0) > 0 else None)
 
-        get_viewable_sources1 = functools.partial(get_sources_gr, dbs=dbs, docs_state0=viewable_docs_state0)
+        get_viewable_sources1 = functools.partial(get_sources_gr, dbs=dbs, docs_state0=viewable_docs_state0,
+                                                  load_db_if_exists=load_db_if_exists,
+                                                  db_type=db_type,
+                                                  use_openai_embedding=use_openai_embedding,
+                                                  hf_embedding_model=hf_embedding_model,
+                                                  migrate_embedding_model=migrate_embedding_model,
+                                                  verbose=kwargs['verbose'],
+                                                  get_userid_auth=get_userid_auth)
         get_viewable_sources_args = dict(fn=get_viewable_sources1,
-                                         inputs=[my_db_state, requests_state, langchain_mode],
+                                         inputs=[my_db_state, selection_docs_state, requests_state, langchain_mode],
                                          outputs=[file_source, viewable_docs_state],
                                          queue=queue,
                                          api_name='get_viewable_sources' if allow_api else None)
@@ -1543,6 +1576,28 @@ def go_gradio(**kwargs):
                                           langchain_mode, chunk, chunk_size],
                                   outputs=sources_text,
                                   api_name='refresh_sources' if allow_api else None)
+
+        delete_sources1 = functools.partial(del_source_files_given_langchain_mode_gr,
+                                            dbs=dbs,
+                                            load_db_if_exists=load_db_if_exists,
+                                            db_type=db_type,
+                                            use_openai_embedding=use_openai_embedding,
+                                            hf_embedding_model=hf_embedding_model,
+                                            migrate_embedding_model=migrate_embedding_model,
+                                            verbose=verbose,
+                                            get_userid_auth=get_userid_auth)
+        eventdb90a = delete_sources_btn.click(user_state_setup,
+                                              inputs=[my_db_state, requests_state,
+                                                      delete_sources_btn, delete_sources_btn],
+                                              outputs=[my_db_state, requests_state, delete_sources_btn],
+                                              show_progress='minimal')
+        eventdb90 = eventdb90a.then(fn=delete_sources1,
+                                    inputs=[my_db_state, selection_docs_state, requests_state, document_choice,
+                                            langchain_mode],
+                                    outputs=sources_text,
+                                    api_name='delete_sources' if allow_api else None) \
+            .then(**get_sources_args) \
+            .then(fn=update_dropdown, inputs=docs_state, outputs=document_choice)
 
         def check_admin_pass(x):
             return gr.update(visible=x == admin_pass)
@@ -1793,9 +1848,12 @@ def go_gradio(**kwargs):
                                                           value=langchain_mode2), textbox, df_langchain_mode_paths1
 
         def remove_langchain_mode(db1s, selection_docs_state1, requests_state1,
-                                  langchain_mode1, langchain_mode2, dbsu=None, auth_filename=None, auth_freeze=None):
+                                  langchain_mode1, langchain_mode2, dbsu=None, auth_filename=None, auth_freeze=None,
+                                  guest_name=None,
+                                  purge=False):
             assert auth_filename is not None
             assert auth_freeze is not None
+
             set_userid_gr(db1s, requests_state1, get_userid_auth)
             for k in db1s:
                 set_dbid_gr(db1s[k])
@@ -1803,39 +1861,73 @@ def go_gradio(**kwargs):
             langchain_modes = selection_docs_state1['langchain_modes']
             langchain_mode_paths = selection_docs_state1['langchain_mode_paths']
             langchain_mode_types = selection_docs_state1['langchain_mode_types']
+            langchain_type2 = langchain_mode_types.get(langchain_mode2, LangChainTypes.EITHER.value)
 
-            valid = False
+            changed_state = False
+            textbox = "Invalid access, cannot remove %s" % langchain_mode2
             in_scratch_db = langchain_mode2 in db1s
             in_user_db = dbsu is not None and langchain_mode2 in dbsu
             if in_scratch_db and not allow_upload_to_my_data or \
                     in_user_db and not allow_upload_to_user_data or \
                     langchain_mode2 in langchain_modes_intrinsic:
-                # NOTE: Doesn't fail if remove MyData, but didn't debug odd behavior seen with upload after gone
-                textbox = "Invalid access, cannot remove %s" % langchain_mode2
-                df_langchain_mode_paths1 = get_df_langchain_mode_paths(selection_docs_state1)
+                can_remove = False
+                can_purge = False
+                if langchain_mode2 in langchain_modes_intrinsic:
+                    can_purge = True
             else:
-                # change global variables
-                if langchain_mode2 in langchain_modes:
-                    langchain_modes.remove(langchain_mode2)
-                    textbox = ""
-                    valid = True
-                else:
-                    textbox = "%s was not visible" % langchain_mode2
-                if langchain_mode2 in langchain_mode_paths:
-                    langchain_mode_paths.pop(langchain_mode2)
-                if langchain_mode2 in db1s:
-                    # remove db entirely, so not in list, else need to manage visible list in update_langchain_mode_paths()
-                    # FIXME: Remove location?
-                    if langchain_mode2 != LangChainMode.MY_DATA.value:
+                can_remove = True
+                can_purge = True
+
+            # change global variables
+            if langchain_mode2 in langchain_modes or langchain_mode2 in langchain_mode_paths or langchain_mode2 in db1s:
+                if can_purge and purge:
+                    # remove source files
+                    from src.gpt_langchain import get_sources, del_from_db
+                    sources_file, source_list, db = get_sources(db1s, selection_docs_state1,
+                                                                requests_state1, langchain_mode2, dbs=dbsu,
+                                                                docs_state0=docs_state0,
+                                                                load_db_if_exists=load_db_if_exists,
+                                                                db_type=db_type,
+                                                                use_openai_embedding=use_openai_embedding,
+                                                                hf_embedding_model=hf_embedding_model,
+                                                                migrate_embedding_model=migrate_embedding_model,
+                                                                verbose=verbose,
+                                                                get_userid_auth=get_userid_auth)
+                    del_from_db(db, source_list, db_type=db_type)
+                    for fil in source_list:
+                        if os.path.isfile(fil):
+                            print("Purged %s" % fil, flush=True)
+                            remove(fil)
+                    # remove db directory
+                    from src.gpt_langchain import get_persist_directory
+                    persist_directory, langchain_type2 = \
+                        get_persist_directory(langchain_mode2, langchain_type=langchain_type2,
+                                              db1s=db1s, dbs=dbsu)
+                    print("removed persist_directory %s" % persist_directory, flush=True)
+                    remove(persist_directory)
+                    textbox = "Purged, but did not remove %s" % langchain_mode2
+                if can_remove:
+                    if langchain_mode2 in langchain_modes:
+                        langchain_modes.remove(langchain_mode2)
+                    if langchain_mode2 in langchain_mode_paths:
+                        langchain_mode_paths.pop(langchain_mode2)
+                    if langchain_mode2 in langchain_mode_types:
+                        langchain_mode_types.pop(langchain_mode2)
+                    if langchain_mode2 in db1s and langchain_mode2 != LangChainMode.MY_DATA.value:
                         # don't remove last MyData, used as user hash
                         db1s.pop(langchain_mode2)
-                # only show
-                selection_docs_state1 = update_langchain_mode_paths(selection_docs_state1)
-                df_langchain_mode_paths1 = get_df_langchain_mode_paths(selection_docs_state1)
+                    textbox = ""
+                    changed_state = True
+            else:
+                textbox = "%s is not visible" % langchain_mode2
 
-                if valid:
-                    save_auth(requests_state1, auth_filename, auth_freeze, selection_docs_state1=selection_docs_state1,
-                              langchain_mode1=langchain_mode2)
+            # update
+            selection_docs_state1 = update_langchain_mode_paths(selection_docs_state1)
+            df_langchain_mode_paths1 = get_df_langchain_mode_paths(selection_docs_state1)
+
+            if changed_state:
+                save_auth(requests_state1, auth_filename, auth_freeze, selection_docs_state1=selection_docs_state1,
+                          langchain_mode1=langchain_mode2)
 
             return db1s, selection_docs_state1, \
                 gr.update(choices=get_langchain_choices(selection_docs_state1),
@@ -1859,7 +1951,12 @@ def go_gradio(**kwargs):
                                               new_langchain_mode_text,
                                               langchain_mode_path_text],
                                      api_name='new_langchain_mode_text' if allow_api and allow_upload_to_user_data else None)
-        remove_langchain_mode_func = functools.partial(remove_langchain_mode, dbsu=dbs)
+        remove_langchain_mode_func = functools.partial(remove_langchain_mode,
+                                                       dbsu=dbs,
+                                                       auth_filename=kwargs['auth_filename'],
+                                                       auth_freeze=kwargs['auth_freeze'],
+                                                       guest_name=kwargs['guest_name'],
+                                                       )
         eventdb21a = remove_langchain_mode_text.submit(user_state_setup,
                                                        inputs=[my_db_state,
                                                                requests_state,
@@ -1867,14 +1964,38 @@ def go_gradio(**kwargs):
                                                        outputs=[my_db_state,
                                                                 requests_state, remove_langchain_mode_text],
                                                        show_progress='minimal')
-        eventdb21b = eventdb21a.then(fn=remove_langchain_mode_func,
-                                     inputs=[my_db_state, selection_docs_state, requests_state,
-                                             langchain_mode,
-                                             remove_langchain_mode_text],
-                                     outputs=[my_db_state, selection_docs_state, langchain_mode,
-                                              remove_langchain_mode_text,
-                                              langchain_mode_path_text],
+        remove_langchain_mode_kwargs = dict(fn=remove_langchain_mode_func,
+                                            inputs=[my_db_state, selection_docs_state, requests_state,
+                                                    langchain_mode,
+                                                    remove_langchain_mode_text],
+                                            outputs=[my_db_state, selection_docs_state, langchain_mode,
+                                                     remove_langchain_mode_text,
+                                                     langchain_mode_path_text])
+        eventdb21b = eventdb21a.then(**remove_langchain_mode_kwargs,
                                      api_name='remove_langchain_mode_text' if allow_api and allow_upload_to_user_data else None)
+
+        eventdb22a = purge_langchain_mode_text.submit(user_state_setup,
+                                                      inputs=[my_db_state,
+                                                              requests_state,
+                                                              purge_langchain_mode_text, purge_langchain_mode_text],
+                                                      outputs=[my_db_state,
+                                                               requests_state, purge_langchain_mode_text],
+                                                      show_progress='minimal')
+        purge_langchain_mode_func = functools.partial(remove_langchain_mode_func, purge=True)
+        purge_langchain_mode_kwargs = dict(fn=purge_langchain_mode_func,
+                                           inputs=[my_db_state, selection_docs_state, requests_state,
+                                                   langchain_mode,
+                                                   purge_langchain_mode_text],
+                                           outputs=[my_db_state, selection_docs_state, langchain_mode,
+                                                    purge_langchain_mode_text,
+                                                    langchain_mode_path_text])
+        # purge_langchain_mode_kwargs = remove_langchain_mode_kwargs.copy()
+        # purge_langchain_mode_kwargs['fn'] = functools.partial(remove_langchain_mode_kwargs['fn'], purge=True)
+        eventdb22b = eventdb22a.then(**purge_langchain_mode_kwargs,
+                                     api_name='purge_langchain_mode_text' if allow_api and allow_upload_to_user_data else None) \
+            .then(**get_sources_args) \
+            .then(**show_sources_kwargs) \
+            .then(fn=update_dropdown, inputs=docs_state, outputs=document_choice)
 
         def load_langchain_gr(db1s, selection_docs_state1, requests_state1, langchain_mode1, auth_filename=None):
             load_auth(db1s, requests_state1, auth_filename, selection_docs_state1=selection_docs_state1)
@@ -3311,9 +3432,11 @@ def go_gradio(**kwargs):
                                [submit_event_nochat, submit_event_nochat2] +
                                [eventdb1, eventdb2, eventdb3] +
                                [eventdb7a, eventdb7, eventdb8a, eventdb8, eventdb9a, eventdb9, eventdb12a, eventdb12] +
+                               [eventdb90a, eventdb90] +
                                db_events +
                                [eventdb20a, eventdb20b] +
                                [eventdb21a, eventdb21b] +
+                               [eventdb22a, eventdb22b] +
                                [eventdbloadla, eventdbloadlb] +
                                [clear_event] +
                                [submit_event_nochat_api, submit_event_nochat] +
@@ -3443,13 +3566,33 @@ def update_user_db_gr(file, db1s, selection_docs_state1, requests_state1,
                           **kwargs)
 
 
-def get_sources_gr(db1s, requests_state1, langchain_mode, dbs=None, docs_state0=None, get_userid_auth=None):
+def get_sources_gr(db1s, selection_docs_state1, requests_state1, langchain_mode, dbs=None, docs_state0=None,
+                   load_db_if_exists=None,
+                   db_type=None,
+                   use_openai_embedding=None,
+                   hf_embedding_model=None,
+                   migrate_embedding_model=None,
+                   verbose=False,
+                   get_userid_auth=None,
+                   api=False):
     from src.gpt_langchain import get_sources
-    return get_sources(db1s, requests_state1, langchain_mode, dbs=dbs, docs_state0=docs_state0,
-                       get_userid_auth=get_userid_auth)
+    sources_file, source_list, db = get_sources(db1s, selection_docs_state1, requests_state1, langchain_mode,
+                                                dbs=dbs, docs_state0=docs_state0,
+                                                load_db_if_exists=load_db_if_exists,
+                                                db_type=db_type,
+                                                use_openai_embedding=use_openai_embedding,
+                                                hf_embedding_model=hf_embedding_model,
+                                                migrate_embedding_model=migrate_embedding_model,
+                                                verbose=verbose,
+                                                get_userid_auth=get_userid_auth,
+                                                )
+    if api:
+        return source_list
+    return sources_file, source_list
 
 
-def get_source_files_given_langchain_mode_gr(db1s, selection_docs_state1, requests_state1, langchain_mode,
+def get_source_files_given_langchain_mode_gr(db1s, selection_docs_state1, requests_state1,
+                                             langchain_mode,
                                              dbs=None,
                                              load_db_if_exists=None,
                                              db_type=None,
@@ -3459,7 +3602,8 @@ def get_source_files_given_langchain_mode_gr(db1s, selection_docs_state1, reques
                                              verbose=False,
                                              get_userid_auth=None):
     from src.gpt_langchain import get_source_files_given_langchain_mode
-    return get_source_files_given_langchain_mode(db1s, selection_docs_state1, requests_state1, langchain_mode,
+    return get_source_files_given_langchain_mode(db1s, selection_docs_state1, requests_state1, None,
+                                                 langchain_mode,
                                                  dbs=dbs,
                                                  load_db_if_exists=load_db_if_exists,
                                                  db_type=db_type,
@@ -3467,7 +3611,32 @@ def get_source_files_given_langchain_mode_gr(db1s, selection_docs_state1, reques
                                                  hf_embedding_model=hf_embedding_model,
                                                  migrate_embedding_model=migrate_embedding_model,
                                                  verbose=verbose,
-                                                 get_userid_auth=get_userid_auth)
+                                                 get_userid_auth=get_userid_auth,
+                                                 delete_sources=False)
+
+
+def del_source_files_given_langchain_mode_gr(db1s, selection_docs_state1, requests_state1, document_choice1,
+                                             langchain_mode,
+                                             dbs=None,
+                                             load_db_if_exists=None,
+                                             db_type=None,
+                                             use_openai_embedding=None,
+                                             hf_embedding_model=None,
+                                             migrate_embedding_model=None,
+                                             verbose=False,
+                                             get_userid_auth=None):
+    from src.gpt_langchain import get_source_files_given_langchain_mode
+    return get_source_files_given_langchain_mode(db1s, selection_docs_state1, requests_state1, document_choice1,
+                                                 langchain_mode,
+                                                 dbs=dbs,
+                                                 load_db_if_exists=load_db_if_exists,
+                                                 db_type=db_type,
+                                                 use_openai_embedding=use_openai_embedding,
+                                                 hf_embedding_model=hf_embedding_model,
+                                                 migrate_embedding_model=migrate_embedding_model,
+                                                 verbose=verbose,
+                                                 get_userid_auth=get_userid_auth,
+                                                 delete_sources=True)
 
 
 def update_and_get_source_files_given_langchain_mode_gr(db1s,

--- a/src/gradio_runner.py
+++ b/src/gradio_runner.py
@@ -1923,6 +1923,11 @@ def go_gradio(**kwargs):
                 user_kwargs['langchain_action'] = LangChainAction.QUERY.value
             if 'langchain_agents' not in user_kwargs:
                 user_kwargs['langchain_agents'] = []
+            # be flexible
+            if 'instruction' in user_kwargs and 'instruction_nochat' not in user_kwargs:
+                user_kwargs['instruction_nochat'] = user_kwargs['instruction']
+            if 'iinput' in user_kwargs and 'iinput_nochat' not in user_kwargs:
+                user_kwargs['iinput_nochat'] = user_kwargs['iinput']
 
             set1 = set(list(default_kwargs1.keys()))
             set2 = set(eval_func_param_names)

--- a/src/gradio_runner.py
+++ b/src/gradio_runner.py
@@ -534,9 +534,22 @@ def go_gradio(**kwargs):
                 df2 = pd.DataFrame.from_dict(langchain_mode_types.items(), orient='columns')
                 df2.columns = ['Collection', 'Type']
                 df2 = df2.set_index('Collection')
+
+                from src.gpt_langchain import get_persist_directory
+                persist_directory_dict = {}
+                for langchain_mode3 in langchain_mode_types:
+                    langchain_type3 = langchain_mode_types.get(langchain_mode3, LangChainTypes.EITHER.value)
+                    persist_directory3, langchain_type3 = get_persist_directory(langchain_mode3, langchain_type=langchain_type3)
+                    persist_directory_dict[langchain_mode3] = persist_directory3
+
+                df3 = pd.DataFrame.from_dict(persist_directory_dict.items(), orient='columns')
+                df3.columns = ['Collection', 'Directory']
+                df3 = df3.set_index('Collection')
             else:
                 df2 = pd.DataFrame(None)
-            df = df2.join(df1, on='Collection').replace(np.nan, '')
+                df3 = pd.DataFrame(None)
+            df_tmp = df2.join(df1, on='Collection').replace(np.nan, '')
+            df = df_tmp.join(df3, on='Collection').replace(np.nan, '')
             df = df.reset_index()
             return df
 

--- a/src/gradio_runner.py
+++ b/src/gradio_runner.py
@@ -742,15 +742,13 @@ def go_gradio(**kwargs):
                             load_langchain = gr.Button(value="Load LangChain State", scale=0, size='sm',
                                                        visible=allow_upload_to_user_data and
                                                                kwargs['langchain_mode'] != 'Disabled')
-                        with gr.Column(scale=1):
+                        with gr.Column(scale=5):
                             df0 = get_df_langchain_mode_paths(selection_docs_state0)
                             langchain_mode_path_text = gr.Dataframe(value=df0,
                                                                     visible=visible_add_remove_collection,
                                                                     label='LangChain Mode-Path',
                                                                     show_label=False,
                                                                     interactive=False)
-                        with gr.Column(scale=4):
-                            pass
 
                     sources_row = gr.Row(visible=kwargs['langchain_mode'] != 'Disabled' and enable_sources_list,
                                          equal_height=False)

--- a/src/h2oai_pipeline.py
+++ b/src/h2oai_pipeline.py
@@ -188,13 +188,17 @@ class H2OTextGenerationPipeline(TextGenerationPipeline):
                     if self.prompter.botstr:
                         prompt = self.prompter.botstr
                         output_with_prompt = prompt + outputs
+                        only_new_text = False
                     else:
                         prompt = None
                         output_with_prompt = outputs
+                        only_new_text = True
                 else:
                     output_with_prompt = outputs
                     prompt = self.prompt_text
+                    only_new_text = False
                 outputs = self.prompter.get_response(output_with_prompt, prompt=prompt,
+                                                     only_new_text=only_new_text,
                                                      sanitize_bot_response=self.sanitize_bot_response)
             elif self.bot in rec[key]:
                 if self.human:

--- a/src/h2oai_pipeline.py
+++ b/src/h2oai_pipeline.py
@@ -13,7 +13,9 @@ class H2OTextGenerationPipeline(TextGenerationPipeline):
                  use_prompter=True, prompter=None,
                  context='', iinput='',
                  prompt_type=None, prompt_dict=None,
-                 max_input_tokens=2048 - 256, **kwargs):
+                 max_input_tokens=2048 - 256,
+                 base_model=None,
+                 **kwargs):
         """
         HF-like pipeline, but handle instruction prompting and stopping (for some models)
         :param args:
@@ -54,6 +56,7 @@ class H2OTextGenerationPipeline(TextGenerationPipeline):
             self.can_stop = False
         self.sanitize_bot_response = sanitize_bot_response
         self.max_input_tokens = max_input_tokens  # not for generate, so ok that not kwargs
+        self.base_model = base_model
 
     @staticmethod
     def limit_prompt(prompt_text, tokenizer, max_prompt_length=None):
@@ -206,6 +209,7 @@ class H2OTextGenerationPipeline(TextGenerationPipeline):
         if self.can_stop:
             stopping_criteria = get_stopping(self.prompt_type, self.prompt_dict,
                                              self.tokenizer, self.device,
+                                             self.base_model,
                                              human=self.human, bot=self.bot,
                                              model_max_length=self.tokenizer.model_max_length)
             generate_kwargs['stopping_criteria'] = stopping_criteria

--- a/src/h2oai_pipeline.py
+++ b/src/h2oai_pipeline.py
@@ -99,7 +99,9 @@ class H2OTextGenerationPipeline(TextGenerationPipeline):
                         print("using %s tokens with %s chars" % (num_prompt_tokens, len(prompt_text)), flush=True)
                     break
             if num_prompt_tokens is not None and num_prompt_tokens > model_max_length:
-                print("Failed to reduce %s tokens with %s chars: %s" % (num_prompt_tokens, len(prompt_text), prompt_text), flush=True)
+                print(
+                    "Failed to reduce %s tokens with %s chars: %s" % (num_prompt_tokens, len(prompt_text), prompt_text),
+                    flush=True)
 
             # Why Below False: don't limit max_new_tokens more, just rely upon stopping to reach limit of model
             if False:
@@ -116,7 +118,7 @@ class H2OTextGenerationPipeline(TextGenerationPipeline):
                 if max_new_tokens < generate_kwargs['max_new_tokens']:
                     if verbose:
                         print("Reduced max_new_tokens from %s -> %s" % (
-                        generate_kwargs['max_new_tokens'], max_new_tokens))
+                            generate_kwargs['max_new_tokens'], max_new_tokens))
                     generate_kwargs['max_new_tokens'] = max_new_tokens
         return prompt_text, num_prompt_tokens
 
@@ -178,7 +180,7 @@ class H2OTextGenerationPipeline(TextGenerationPipeline):
     def postprocess(self, model_outputs, return_type=ReturnType.FULL_TEXT, clean_up_tokenization_spaces=True):
         conditional_type = hasattr(self.model, 'conditional_type') and self.model.conditional_type
         records = self._postprocess(model_outputs, return_type=return_type,
-                                      clean_up_tokenization_spaces=clean_up_tokenization_spaces,
+                                    clean_up_tokenization_spaces=clean_up_tokenization_spaces,
                                     conditional_type=conditional_type)
         key = 'generated_text'
         for rec in records:

--- a/src/h2oai_pipeline.py
+++ b/src/h2oai_pipeline.py
@@ -127,14 +127,68 @@ class H2OTextGenerationPipeline(TextGenerationPipeline):
         return super().preprocess(prompt_text, prefix=prefix, handle_long_generation=handle_long_generation,
                                   **generate_kwargs)
 
+    def _postprocess(self, model_outputs, return_type=ReturnType.FULL_TEXT, clean_up_tokenization_spaces=True,
+                     conditional_type=False):
+        generated_sequence = model_outputs["generated_sequence"][0]
+        input_ids = model_outputs["input_ids"]
+        prompt_text = model_outputs["prompt_text"]
+        generated_sequence = generated_sequence.numpy().tolist()
+        records = []
+        for sequence in generated_sequence:
+            if return_type == ReturnType.TENSORS:
+                record = {"generated_token_ids": sequence}
+            elif return_type in {ReturnType.NEW_TEXT, ReturnType.FULL_TEXT}:
+                # Decode text
+                text = self.tokenizer.decode(
+                    sequence,
+                    skip_special_tokens=True,
+                    clean_up_tokenization_spaces=clean_up_tokenization_spaces,
+                )
+                if conditional_type:
+                    all_text = text
+                else:
+                    # Remove PADDING prompt of the sequence if XLNet or Transfo-XL model is used
+                    if input_ids is None:
+                        prompt_length = 0
+                    else:
+                        prompt_length = len(
+                            self.tokenizer.decode(
+                                input_ids[0],
+                                skip_special_tokens=True,
+                                clean_up_tokenization_spaces=clean_up_tokenization_spaces,
+                            )
+                        )
+
+                    if return_type == ReturnType.FULL_TEXT:
+                        all_text = prompt_text + text[prompt_length:]
+                    else:
+                        all_text = text[prompt_length:]
+
+                record = {"generated_text": all_text}
+            records.append(record)
+
+        return records
+
     def postprocess(self, model_outputs, return_type=ReturnType.FULL_TEXT, clean_up_tokenization_spaces=True):
-        records = super().postprocess(model_outputs, return_type=return_type,
-                                      clean_up_tokenization_spaces=clean_up_tokenization_spaces)
+        conditional_type = hasattr(self.model, 'conditional_type') and self.model.conditional_type
+        records = self._postprocess(model_outputs, return_type=return_type,
+                                      clean_up_tokenization_spaces=clean_up_tokenization_spaces,
+                                    conditional_type=conditional_type)
         key = 'generated_text'
         for rec in records:
             if self.use_prompter:
                 outputs = rec[key]
-                outputs = self.prompter.get_response(outputs, prompt=self.prompt_text,
+                if conditional_type:
+                    if self.prompter.botstr:
+                        prompt = self.prompter.botstr
+                        output_with_prompt = prompt + outputs
+                    else:
+                        prompt = None
+                        output_with_prompt = outputs
+                else:
+                    output_with_prompt = outputs
+                    prompt = self.prompt_text
+                outputs = self.prompter.get_response(output_with_prompt, prompt=prompt,
                                                      sanitize_bot_response=self.sanitize_bot_response)
             elif self.bot in rec[key]:
                 if self.human:

--- a/src/h2oai_pipeline.py
+++ b/src/h2oai_pipeline.py
@@ -184,7 +184,11 @@ class H2OTextGenerationPipeline(TextGenerationPipeline):
         for rec in records:
             if self.use_prompter:
                 outputs = rec[key]
-                if conditional_type:
+                if return_type == ReturnType.NEW_TEXT:
+                    output_with_prompt = outputs
+                    prompt = None
+                    only_new_text = True
+                elif conditional_type:
                     if self.prompter.botstr:
                         prompt = self.prompter.botstr
                         output_with_prompt = prompt + outputs

--- a/src/loaders.py
+++ b/src/loaders.py
@@ -1,6 +1,13 @@
 import functools
 
 
+def t5_type(model_name):
+    return 't5' == model_name.lower() or \
+        't5-' in model_name.lower() or \
+        'flan-' in model_name.lower() or \
+        'fastchat-t5' in model_name.lower()
+
+
 def get_loaders(model_name, reward_type, llama_type=None, load_gptq='', load_exllama=False, config=None,
                 rope_scaling=None, max_seq_len=None, model_name_exllama_if_no_config=''):
     # NOTE: Some models need specific new prompt_type
@@ -13,7 +20,8 @@ def get_loaders(model_name, reward_type, llama_type=None, load_gptq='', load_exl
         if config:
             # then use HF path
             from transformers import TRANSFORMERS_CACHE
-            model_directory = os.path.join(TRANSFORMERS_CACHE, 'models--' + config.name_or_path.replace('/', '--'), 'snapshots', config._commit_hash)
+            model_directory = os.path.join(TRANSFORMERS_CACHE, 'models--' + config.name_or_path.replace('/', '--'),
+                                           'snapshots', config._commit_hash)
         else:
             # then use path in env file
             # Directory containing model, tokenizer, generator
@@ -34,12 +42,13 @@ def get_loaders(model_name, reward_type, llama_type=None, load_gptq='', load_exl
         assert os.path.isfile(model_path), "Missing %s" % model_path
 
         # Create config, model, tokenizer and generator
-        exconfig = ExLlamaConfig(model_config_path)               # create config from config.json
+        exconfig = ExLlamaConfig(model_config_path)  # create config from config.json
         rope_scaling = rope_scaling or {}
         exconfig.alpha_value = rope_scaling.get('alpha_value', 1)  # rope
         exconfig.compress_pos_emb = rope_scaling.get('compress_pos_emb', 1)  # related rope
         # update max_seq_len
-        assert hasattr(config, 'max_position_embeddings') or hasattr(config, 'max_sequence_length'), "Improve code if no such argument"
+        assert hasattr(config, 'max_position_embeddings') or hasattr(config,
+                                                                     'max_sequence_length'), "Improve code if no such argument"
         if hasattr(config, 'max_position_embeddings'):
             exconfig.max_seq_len = int(config.max_position_embeddings * exconfig.alpha_value)
         else:
@@ -50,15 +59,15 @@ def get_loaders(model_name, reward_type, llama_type=None, load_gptq='', load_exl
         if max_seq_len is not None:
             exconfig.max_seq_len = max_seq_len
 
-        exconfig.model_path = model_path                          # supply path to model weights file
+        exconfig.model_path = model_path  # supply path to model weights file
 
-        model = ExLlama(exconfig)                                 # create ExLlama instance and load the weights
-        tokenizer = H2OExLlamaTokenizer(tokenizer_path)            # create tokenizer from tokenizer model file
+        model = ExLlama(exconfig)  # create ExLlama instance and load the weights
+        tokenizer = H2OExLlamaTokenizer(tokenizer_path)  # create tokenizer from tokenizer model file
         tokenizer.model_max_length = exconfig.max_seq_len
 
-        cache = ExLlamaCache(model)                             # create cache for inference
-        generator = H2OExLlamaGenerator(model, tokenizer, cache)   # create generator
-        return generator, tokenizer
+        cache = ExLlamaCache(model)  # create cache for inference
+        generator = H2OExLlamaGenerator(model, tokenizer, cache)  # create generator
+        return generator, tokenizer, False
     if load_gptq:
         from transformers import AutoTokenizer
         from auto_gptq import AutoGPTQForCausalLM
@@ -66,40 +75,38 @@ def get_loaders(model_name, reward_type, llama_type=None, load_gptq='', load_exl
         model_loader = functools.partial(AutoGPTQForCausalLM.from_quantized,
                                          quantize_config=None, use_triton=use_triton,
                                          )
-        return model_loader, AutoTokenizer
+        return model_loader, AutoTokenizer, False
     if llama_type is None:
         llama_type = "llama" in model_name.lower()
     if llama_type:
         from transformers import LlamaForCausalLM, LlamaTokenizer
-        return LlamaForCausalLM.from_pretrained, LlamaTokenizer
+        return LlamaForCausalLM.from_pretrained, LlamaTokenizer, False
     elif 'distilgpt2' in model_name.lower():
         from transformers import AutoModelForCausalLM, AutoTokenizer
-        return AutoModelForCausalLM.from_pretrained, AutoTokenizer
+        return AutoModelForCausalLM.from_pretrained, AutoTokenizer, False
     elif 'gpt2' in model_name.lower():
         from transformers import GPT2LMHeadModel, GPT2Tokenizer
-        return GPT2LMHeadModel.from_pretrained, GPT2Tokenizer
+        return GPT2LMHeadModel.from_pretrained, GPT2Tokenizer, False
     elif 'mbart-' in model_name.lower():
         from transformers import MBartForConditionalGeneration, MBart50TokenizerFast
-        return MBartForConditionalGeneration.from_pretrained, MBart50TokenizerFast
-    elif 't5' == model_name.lower() or \
-            't5-' in model_name.lower() or \
-            'flan-' in model_name.lower():
+        return MBartForConditionalGeneration.from_pretrained, MBart50TokenizerFast, True
+    elif t5_type(model_name):
         from transformers import AutoTokenizer, T5ForConditionalGeneration
-        return T5ForConditionalGeneration.from_pretrained, AutoTokenizer
+        return T5ForConditionalGeneration.from_pretrained, AutoTokenizer, True
     elif 'bigbird' in model_name:
         from transformers import BigBirdPegasusForConditionalGeneration, AutoTokenizer
-        return BigBirdPegasusForConditionalGeneration.from_pretrained, AutoTokenizer
+        return BigBirdPegasusForConditionalGeneration.from_pretrained, AutoTokenizer, True
     elif 'bart-large-cnn-samsum' in model_name or 'flan-t5-base-samsum' in model_name:
         from transformers import pipeline
-        return pipeline, "summarization"
+        return pipeline, "summarization", False
     elif reward_type or 'OpenAssistant/reward-model'.lower() in model_name.lower():
         from transformers import AutoModelForSequenceClassification, AutoTokenizer
-        return AutoModelForSequenceClassification.from_pretrained, AutoTokenizer
+        return AutoModelForSequenceClassification.from_pretrained, AutoTokenizer, False
     else:
         from transformers import AutoTokenizer, AutoModelForCausalLM
         model_loader = AutoModelForCausalLM
         tokenizer_loader = AutoTokenizer
-        return model_loader.from_pretrained, tokenizer_loader
+        return model_loader.from_pretrained, tokenizer_loader, False
 
 
 def get_tokenizer(tokenizer_loader, tokenizer_base_model, local_files_only, resume_download, use_auth_token):

--- a/src/loaders.py
+++ b/src/loaders.py
@@ -1,11 +1,6 @@
 import functools
 
-
-def t5_type(model_name):
-    return 't5' == model_name.lower() or \
-        't5-' in model_name.lower() or \
-        'flan-' in model_name.lower() or \
-        'fastchat-t5' in model_name.lower()
+from src.enums import t5_type
 
 
 def get_loaders(model_name, reward_type, llama_type=None, load_gptq='', load_exllama=False, config=None,

--- a/src/prompter.py
+++ b/src/prompter.py
@@ -83,6 +83,7 @@ prompt_type_to_model_name = {
     "mptinstruct": ['mosaicml/mpt-30b-instruct', 'mosaicml/mpt-7b-instruct', 'mosaicml/mpt-30b-instruct'],
     "mptchat": ['mosaicml/mpt-7b-chat', 'mosaicml/mpt-30b-chat', 'TheBloke/mpt-30B-chat-GGML'],
     "vicuna11": ['lmsys/vicuna-33b-v1.3'],
+    "one_shot": ['lmsys/fastchat-t5-3b-v1.0'],
     "falcon": ['tiiuae/falcon-40b-instruct', 'tiiuae/falcon-40b', 'tiiuae/falcon-7b-instruct', 'tiiuae/falcon-7b'],
     "llama2": [
         'meta-llama/Llama-2-7b-chat-hf',
@@ -300,8 +301,8 @@ Current Time: {}
         PreResponse = """
 ### Assistant:
 """
-        terminate_response = [
-            '### Human:']  # but only allow terminate after prompt is found correctly, else can't terminate
+        #  but only allow terminate after prompt is found correctly, else can't terminate
+        terminate_response = ['### Human:', '###  Human:  ', '###  Assistant:']
         chat_turn_sep = chat_sep = '\n'
         humanstr = PreInstruct
         botstr = PreResponse
@@ -673,6 +674,34 @@ ASSISTANT:
         PreInput = None
         PreResponse = """ASSISTANT:"""
         terminate_response = [PreResponse]
+        chat_turn_sep = chat_sep = '\n'
+        humanstr = PreInstruct
+        botstr = PreResponse
+    elif prompt_type in [PromptType.one_shot.value, str(PromptType.one_shot.value),
+                         PromptType.one_shot.name]:
+        promptA = promptB = """A chat between a curious human and an artificial intelligence assistant. The assistant gives helpful, detailed, and polite answers to the human's questions.
+### Human: Got any creative ideas for a 10 year old’s birthday?
+### Assistant: Of course! Here are some creative ideas for a 10-year-old's birthday party:
+1. Treasure Hunt: Organize a treasure hunt in your backyard or nearby park. Create clues and riddles for the kids to solve, leading them to hidden treasures and surprises.
+2. Science Party: Plan a science-themed party where kids can engage in fun and interactive experiments. You can set up different stations with activities like making slime, erupting volcanoes, or creating simple chemical reactions.
+3. Outdoor Movie Night: Set up a backyard movie night with a projector and a large screen or white sheet. Create a cozy seating area with blankets and pillows, and serve popcorn and snacks while the kids enjoy a favorite movie under the stars.
+4. DIY Crafts Party: Arrange a craft party where kids can unleash their creativity. Provide a variety of craft supplies like beads, paints, and fabrics, and let them create their own unique masterpieces to take home as party favors.
+5. Sports Olympics: Host a mini Olympics event with various sports and games. Set up different stations for activities like sack races, relay races, basketball shooting, and obstacle courses. Give out medals or certificates to the participants.
+6. Cooking Party: Have a cooking-themed party where the kids can prepare their own mini pizzas, cupcakes, or cookies. Provide toppings, frosting, and decorating supplies, and let them get hands-on in the kitchen.
+7. Superhero Training Camp: Create a superhero-themed party where the kids can engage in fun training activities. Set up an obstacle course, have them design their own superhero capes or masks, and organize superhero-themed games and challenges.
+8. Outdoor Adventure: Plan an outdoor adventure party at a local park or nature reserve. Arrange activities like hiking, nature scavenger hunts, or a picnic with games. Encourage exploration and appreciation for the outdoors.
+Remember to tailor the activities to the birthday child's interests and preferences. Have a great celebration!""" if not (
+                chat and reduced) else ''
+
+        PreInstruct = """
+### Human: """
+
+        PreInput = None
+
+        PreResponse = """
+### Assistant:"""
+        # but only allow terminate after prompt is found correctly, else can't terminate
+        terminate_response = ['### Human:', '###  Human:  ', '###  Assistant:']
         chat_turn_sep = chat_sep = '\n'
         humanstr = PreInstruct
         botstr = PreResponse

--- a/src/prompter.py
+++ b/src/prompter.py
@@ -302,7 +302,7 @@ Current Time: {}
 ### Assistant:
 """
         #  but only allow terminate after prompt is found correctly, else can't terminate
-        terminate_response = ['### Human:', '###  Human:  ', '###  Assistant:']
+        terminate_response = ['### Human:', '###  Human:  ', ' ###  Human:', '###  Assistant:']
         chat_turn_sep = chat_sep = '\n'
         humanstr = PreInstruct
         botstr = PreResponse
@@ -701,7 +701,7 @@ Remember to tailor the activities to the birthday child's interests and preferen
         PreResponse = """
 ### Assistant:"""
         # but only allow terminate after prompt is found correctly, else can't terminate
-        terminate_response = ['### Human:', '###  Human:  ', '###  Assistant:']
+        terminate_response = ['### Human:', '###  Human:  ', ' ###  Human:', '###  Assistant:']
         chat_turn_sep = chat_sep = '\n'
         humanstr = PreInstruct
         botstr = PreResponse

--- a/src/prompter.py
+++ b/src/prompter.py
@@ -855,7 +855,7 @@ class Prompter(object):
         self.prompt = prompt
         return prompt
 
-    def get_response(self, outputs, prompt=None, sanitize_bot_response=False):
+    def get_response(self, outputs, prompt=None, sanitize_bot_response=False, only_new_text=False):
         if isinstance(outputs, str):
             outputs = [outputs]
         if self.debug:
@@ -890,7 +890,11 @@ class Prompter(object):
             if self.prompt_type in [PromptType.plain.value, str(PromptType.plain.value), PromptType.plain.name]:
                 output = clean_response(output)
                 allow_terminate = True
+            elif only_new_text:
+                # only use terminate, that will have other variations of cleaning that include \n etc. not just simple human bot that will leave residual \n
+                allow_terminate = True
             elif prompt is None:
+                allow_terminate = True
                 # then use most basic parsing like pipeline
                 if not self.botstr:
                     pass
@@ -900,7 +904,6 @@ class Prompter(object):
                     else:
                         # i.e. use after bot but only up to next bot
                         output = clean_response(output.split(self.botstr)[-1].split(self.botstr)[0])
-                allow_terminate = True
             else:
                 # find first instance of prereponse
                 # prompt sometimes has odd characters, that mutate length,

--- a/src/prompter.py
+++ b/src/prompter.py
@@ -889,20 +889,18 @@ class Prompter(object):
         for oi, output in enumerate(outputs):
             if self.prompt_type in [PromptType.plain.value, str(PromptType.plain.value), PromptType.plain.name]:
                 output = clean_response(output)
+                allow_terminate = True
             elif prompt is None:
                 # then use most basic parsing like pipeline
                 if not self.botstr:
                     pass
-                elif self.botstr in output:
+                else:
                     if self.humanstr:
                         output = clean_response(output.split(self.botstr)[-1].split(self.humanstr)[0])
                     else:
                         # i.e. use after bot but only up to next bot
                         output = clean_response(output.split(self.botstr)[-1].split(self.botstr)[0])
-                else:
-                    # output = clean_response(output)
-                    # assume just not printed yet
-                    output = ""
+                allow_terminate = True
             else:
                 # find first instance of prereponse
                 # prompt sometimes has odd characters, that mutate length,
@@ -928,18 +926,18 @@ class Prompter(object):
                     output = output[len(prompt):]
                 # clean after subtract prompt out, so correct removal of pre_response
                 output = clean_response(output)
-                if self.repeat_penalty:
-                    output = clean_repeats(output)
-                if self.terminate_response and allow_terminate:
-                    finds = []
-                    for term in self.terminate_response:
-                        finds.append(output.find(term))
-                    finds = [x for x in finds if x >= 0]
-                    if len(finds) > 0:
-                        termi = finds[0]
-                        output = output[:termi]
-                    else:
-                        output = output
+            if self.repeat_penalty:
+                output = clean_repeats(output)
+            if self.terminate_response and allow_terminate:
+                finds = []
+                for term in self.terminate_response:
+                    finds.append(output.find(term))
+                finds = [x for x in finds if x >= 0]
+                if len(finds) > 0:
+                    termi = finds[0]
+                    output = output[:termi]
+                else:
+                    output = output
             if multi_output:
                 # prefix with output counter
                 output = "\n=========== Output %d\n\n" % (1 + oi) + output

--- a/src/stopping.py
+++ b/src/stopping.py
@@ -102,7 +102,7 @@ def get_stopping(prompt_type, prompt_dict, tokenizer, device, base_model,
             stop_words_ids = [x[:-1] if x[-1] == tokenizer.unk_token_id and len(x) > 1 else x for x in stop_words_ids]
         if tokenizer._eos_token:  # use hidden variable to avoid annoying properly logger bug
             stop_words_ids = [x[:-1] if x[-1] == tokenizer.eos_token_id and len(x) > 1 else x for x in stop_words_ids]
-        if t5_type(base_model):
+        if base_model and t5_type(base_model):
             # T5 encoder converts internal double space to space+new line, so fix
             for stopi, stop_word_id in enumerate(stop_words_ids):
                 start = stop_word_id[0:1]

--- a/src/stopping.py
+++ b/src/stopping.py
@@ -34,24 +34,31 @@ class StoppingCriteriaSub(StoppingCriteria):
 def get_stopping(prompt_type, prompt_dict, tokenizer, device, base_model,
                  human='<human>:', bot="<bot>:", model_max_length=None):
     # FIXME: prompt_dict unused currently
-    if prompt_type in [PromptType.human_bot.name, PromptType.instruct_vicuna.name, PromptType.instruct_with_end.name]:
-        if prompt_type == PromptType.human_bot.name:
+    user_human_assistant_types = [PromptType.instruct_vicuna.value, str(PromptType.instruct_vicuna.value),
+                                 PromptType.instruct_vicuna.name] + \
+                                [PromptType.guanaco.value, str(PromptType.guanaco.value),
+                                 PromptType.guanaco.name] + \
+                                [PromptType.one_shot.value, str(PromptType.one_shot.value),
+                                 PromptType.one_shot.name] + \
+                                [PromptType.instruct_vicuna2.value, str(PromptType.instruct_vicuna2.value),
+                                 PromptType.instruct_vicuna2.name] + \
+                                [PromptType.instruct_vicuna3.value, str(PromptType.instruct_vicuna3.value),
+                                 PromptType.instruct_vicuna3.name] + \
+                                [PromptType.instruct_with_end.value, str(PromptType.instruct_with_end.value),
+                                 PromptType.instruct_with_end.name]
+    human_bot_types = [PromptType.human_bot.value, str(PromptType.human_bot.value),
+                       PromptType.human_bot.name] + \
+                      [PromptType.human_bot_orig.value, str(PromptType.human_bot_orig.value),
+                       PromptType.human_bot_orig.name]
+    all_types = user_human_assistant_types + human_bot_types
+    if prompt_type in all_types:
+        if prompt_type in human:
             # encounters = [prompt.count(human) + 1, prompt.count(bot) + 1]
             # stopping only starts once output is beyond prompt
             # 1 human is enough to trigger, but need 2 bots, because very first view back will be bot we added
             stop_words = [human, bot, '\n' + human, '\n' + bot]
             encounters = [1, 2]
-        elif (prompt_type in
-              [PromptType.instruct_vicuna.value, str(PromptType.instruct_vicuna.value),
-               PromptType.instruct_vicuna.name] +
-              [PromptType.guanaco.value, str(PromptType.guanaco.value),
-               PromptType.guanaco.name] +
-              [PromptType.one_shot.value, str(PromptType.one_shot.value),
-               PromptType.one_shot.name] +
-              [PromptType.instruct_vicuna2.value, str(PromptType.instruct_vicuna2.value),
-               PromptType.instruct_vicuna2.name] +
-              [PromptType.instruct_vicuna3.value, str(PromptType.instruct_vicuna3.value),
-               PromptType.instruct_vicuna3.name]):
+        elif prompt_type in user_human_assistant_types:
             # even below is not enough, generic strings and many ways to encode
             stop_words = [
                 '### Human:',

--- a/src/stopping.py
+++ b/src/stopping.py
@@ -1,7 +1,11 @@
 import torch
 from transformers import StoppingCriteria, StoppingCriteriaList
 
-from enums import PromptType
+from enums import PromptType, t5_type
+
+from transformers import AutoTokenizer
+tokenizer = AutoTokenizer.from_pretrained("lmsys/fastchat-t5-3b-v1.0")
+
 
 
 class StoppingCriteriaSub(StoppingCriteria):
@@ -16,7 +20,9 @@ class StoppingCriteriaSub(StoppingCriteria):
 
     def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> bool:
         for stopi, stop in enumerate(self.stops):
-            len_new_tokens = input_ids[0][-len(stop):].shape[0]
+            current_block = input_ids[0][-len(stop):]
+            len_new_tokens = current_block.shape[0]
+            print("stop: %s %s block: %s %s" % (tokenizer.decode(stop), stop, current_block, tokenizer.decode(current_block)), flush=True)
             if len(stop) <= len_new_tokens and torch.all((stop == input_ids[0][-len(stop):])).item():
                 self.num_stops[stopi] += 1
                 if self.num_stops[stopi] >= self.encounters[stopi % len(self.encounters)]:
@@ -30,7 +36,8 @@ class StoppingCriteriaSub(StoppingCriteria):
         return False
 
 
-def get_stopping(prompt_type, prompt_dict, tokenizer, device, human='<human>:', bot="<bot>:", model_max_length=None):
+def get_stopping(prompt_type, prompt_dict, tokenizer, device, base_model,
+                 human='<human>:', bot="<bot>:", model_max_length=None):
     # FIXME: prompt_dict unused currently
     if prompt_type in [PromptType.human_bot.name, PromptType.instruct_vicuna.name, PromptType.instruct_with_end.name]:
         if prompt_type == PromptType.human_bot.name:
@@ -39,7 +46,17 @@ def get_stopping(prompt_type, prompt_dict, tokenizer, device, human='<human>:', 
             # 1 human is enough to trigger, but need 2 bots, because very first view back will be bot we added
             stop_words = [human, bot, '\n' + human, '\n' + bot]
             encounters = [1, 2]
-        elif prompt_type in [PromptType.instruct_vicuna.name, PromptType.instruct_vicuna.name]:
+        elif (prompt_type in
+              [PromptType.instruct_vicuna.value, str(PromptType.instruct_vicuna.value),
+               PromptType.instruct_vicuna.name] +
+              [PromptType.guanaco.value, str(PromptType.guanaco.value),
+               PromptType.guanaco.name] +
+              [PromptType.one_shot.value, str(PromptType.one_shot.value),
+               PromptType.one_shot.name] +
+              [PromptType.instruct_vicuna2.value, str(PromptType.instruct_vicuna2.value),
+               PromptType.instruct_vicuna2.name] +
+              [PromptType.instruct_vicuna3.value, str(PromptType.instruct_vicuna3.value),
+               PromptType.instruct_vicuna3.name]):
             # even below is not enough, generic strings and many ways to encode
             stop_words = [
                 '### Human:',
@@ -48,13 +65,23 @@ def get_stopping(prompt_type, prompt_dict, tokenizer, device, human='<human>:', 
                 """
 ### Human:
 """,
+                """###  Human:  """,
+                """###  Human:""",
                 '### Assistant:',
                 """
 ### Assistant:""",
                 """
 ### Assistant:
 """,
+                """###  Assistant:  """,
+                """###  Assistant:"""
             ]
+            if prompt_type in [PromptType.instruct_vicuna2.value, str(PromptType.instruct_vicuna2.value),
+                PromptType.instruct_vicuna2.name]:
+                stop_words = [x.upper() for x in stop_words]
+            if prompt_type in [PromptType.instruct_vicuna3.value, str(PromptType.instruct_vicuna3.value),
+                PromptType.instruct_vicuna3.name]:
+                stop_words = [x.replace('Human', 'User') for x in stop_words]
             encounters = [1, 2]
         else:
             # some instruct prompts have this as end, doesn't hurt to stop on it since not common otherwise
@@ -68,6 +95,19 @@ def get_stopping(prompt_type, prompt_dict, tokenizer, device, human='<human>:', 
         # avoid padding in front of tokens
         if tokenizer._pad_token:  # use hidden variable to avoid annoying properly logger bug
             stop_words_ids = [x[1:] if x[0] == tokenizer.pad_token_id and len(x) > 1 else x for x in stop_words_ids]
+        if tokenizer._unk_token:  # use hidden variable to avoid annoying properly logger bug
+            stop_words_ids = [x[1:] if x[0] == tokenizer.unk_token_id and len(x) > 1 else x for x in stop_words_ids]
+            stop_words_ids = [x[:-1] if x[-1] == tokenizer.unk_token_id and len(x) > 1 else x for x in stop_words_ids]
+        if tokenizer._eos_token:  # use hidden variable to avoid annoying properly logger bug
+            stop_words_ids = [x[:-1] if x[-1] == tokenizer.eos_token_id and len(x) > 1 else x for x in stop_words_ids]
+        if t5_type(base_model):
+            # T5 encoder converts internal double space to space+new line, so fix
+            for stopi, stop_word_id in enumerate(stop_words_ids):
+                start = stop_word_id[0:1]
+                mlist = stop_word_id[1:-1]
+                end = stop_word_id[-1:]
+                mlist = [tokenizer.vocab[' '] if x == tokenizer.vocab['\n'] else x for x in mlist]
+                stop_words_ids[stopi] = torch.tensor(list(start) + list(mlist) + list(end), device=stop_word_id.device)
         # handle fake \n added
         stop_words_ids = [x[1:] if y[0] == '\n' else x for x, y in zip(stop_words_ids, stop_words)]
         # build stopper

--- a/src/stopping.py
+++ b/src/stopping.py
@@ -16,7 +16,8 @@ class StoppingCriteriaSub(StoppingCriteria):
 
     def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> bool:
         for stopi, stop in enumerate(self.stops):
-            if torch.all((stop == input_ids[0][-len(stop):])).item():
+            len_new_tokens = input_ids[0][-len(stop):].shape[0]
+            if len(stop) <= len_new_tokens and torch.all((stop == input_ids[0][-len(stop):])).item():
                 self.num_stops[stopi] += 1
                 if self.num_stops[stopi] >= self.encounters[stopi % len(self.encounters)]:
                     # print("Stopped", flush=True)
@@ -38,7 +39,7 @@ def get_stopping(prompt_type, prompt_dict, tokenizer, device, human='<human>:', 
             # 1 human is enough to trigger, but need 2 bots, because very first view back will be bot we added
             stop_words = [human, bot, '\n' + human, '\n' + bot]
             encounters = [1, 2]
-        elif prompt_type == PromptType.instruct_vicuna.name:
+        elif prompt_type in [PromptType.instruct_vicuna.name, PromptType.instruct_vicuna.name]:
             # even below is not enough, generic strings and many ways to encode
             stop_words = [
                 '### Human:',

--- a/src/stopping.py
+++ b/src/stopping.py
@@ -3,10 +3,6 @@ from transformers import StoppingCriteria, StoppingCriteriaList
 
 from enums import PromptType, t5_type
 
-from transformers import AutoTokenizer
-tokenizer = AutoTokenizer.from_pretrained("lmsys/fastchat-t5-3b-v1.0")
-
-
 
 class StoppingCriteriaSub(StoppingCriteria):
 
@@ -22,7 +18,6 @@ class StoppingCriteriaSub(StoppingCriteria):
         for stopi, stop in enumerate(self.stops):
             current_block = input_ids[0][-len(stop):]
             len_new_tokens = current_block.shape[0]
-            print("stop: %s %s block: %s %s" % (tokenizer.decode(stop), stop, current_block, tokenizer.decode(current_block)), flush=True)
             if len(stop) <= len_new_tokens and torch.all((stop == input_ids[0][-len(stop):])).item():
                 self.num_stops[stopi] += 1
                 if self.num_stops[stopi] >= self.encounters[stopi % len(self.encounters)]:
@@ -77,10 +72,10 @@ def get_stopping(prompt_type, prompt_dict, tokenizer, device, base_model,
                 """###  Assistant:"""
             ]
             if prompt_type in [PromptType.instruct_vicuna2.value, str(PromptType.instruct_vicuna2.value),
-                PromptType.instruct_vicuna2.name]:
+                               PromptType.instruct_vicuna2.name]:
                 stop_words = [x.upper() for x in stop_words]
             if prompt_type in [PromptType.instruct_vicuna3.value, str(PromptType.instruct_vicuna3.value),
-                PromptType.instruct_vicuna3.name]:
+                               PromptType.instruct_vicuna3.name]:
                 stop_words = [x.replace('Human', 'User') for x in stop_words]
             encounters = [1, 2]
         else:

--- a/tests/test_client_calls.py
+++ b/tests/test_client_calls.py
@@ -788,7 +788,8 @@ def test_client_chat_stream_langchain_steps3():
     assert res[0]['value'] == langchain_mode2
     assert langchain_mode2 in res[0]['choices']
     assert res[1] == ''
-    assert res[2]['headers'] == ['Collection', 'Type', 'Path']
+    assert res[2]['headers'] == ['Collection', 'Type', 'Path', 'Directory']
+    res[2]['data'] = [[x[0], x[1], x[2]] for x in res[2]['data']]  # ignore persist_directory
     assert res[2]['data'] == [['UserData', 'shared', user_path],
                               ['github h2oGPT', 'shared', ''],
                               ['MyData', 'personal', ''],
@@ -879,7 +880,8 @@ def test_client_chat_stream_langchain_steps3():
     res = client.predict(langchain_mode, api_name='/load_langchain')
     assert res[0]['choices'] == [langchain_mode, 'MyData', 'github h2oGPT', 'LLM', langchain_mode2]
     assert res[0]['value'] == langchain_mode
-    assert res[1]['headers'] == ['Collection', 'Type', 'Path']
+    assert res[1]['headers'] == ['Collection', 'Type', 'Path', 'Directory']
+    res[1]['data'] = [[x[0], x[1], x[2]] for x in res[1]['data']]  # ignore persist_directory
     assert res[1]['data'] == [['UserData', 'shared', user_path],
                               ['github h2oGPT', 'shared', ''],
                               ['MyData', 'personal', ''],
@@ -930,7 +932,8 @@ def test_client_chat_stream_langchain_steps3():
     assert res[0]['value'] == langchain_mode2
     assert langchain_mode2 in res[0]['choices']
     assert res[1] == ''
-    assert res[2]['headers'] == ['Collection', 'Type', 'Path']
+    assert res[2]['headers'] == ['Collection', 'Type', 'Path', 'Directory']
+    res[2]['data'] = [[x[0], x[1], x[2]] for x in res[2]['data']]  # ignore persist_directory
     assert res[2]['data'] == [['UserData', 'shared', user_path],
                               ['github h2oGPT', 'shared', ''],
                               ['MyData', 'personal', ''],
@@ -973,7 +976,8 @@ def test_client_chat_stream_langchain_steps3():
     assert res[0]['value'] == langchain_mode3
     assert langchain_mode3 in res[0]['choices']
     assert res[1] == ''
-    assert res[2]['headers'] == ['Collection', 'Type', 'Path']
+    assert res[2]['headers'] == ['Collection', 'Type', 'Path', 'Directory']
+    res[2]['data'] = [[x[0], x[1], x[2]] for x in res[2]['data']]  # ignore persist_directory
     assert res[2]['data'] == [['UserData', 'shared', user_path],
                               ['github h2oGPT', 'shared', ''],
                               ['MyData', 'personal', ''],
@@ -1013,7 +1017,8 @@ def test_client_chat_stream_langchain_steps3():
     assert res[0]['value'] == langchain_mode3
     assert langchain_mode2 in res[0]['choices']
     assert res[1] == ''
-    assert res[2]['headers'] == ['Collection', 'Type', 'Path']
+    assert res[2]['headers'] == ['Collection', 'Type', 'Path', 'Directory']
+    res[2]['data'] = [[x[0], x[1], x[2]] for x in res[2]['data']]  # ignore persist_directory
     assert res[2]['data'] == [['UserData', 'shared', user_path],
                               ['github h2oGPT', 'shared', ''],
                               ['MyData', 'personal', ''],
@@ -1027,7 +1032,8 @@ def test_client_chat_stream_langchain_steps3():
     assert res[0]['value'] == langchain_mode
     assert langchain_mode not in res[0]['choices']
     assert res[1] == ''
-    assert res[2]['headers'] == ['Collection', 'Type', 'Path']
+    assert res[2]['headers'] == ['Collection', 'Type', 'Path', 'Directory']
+    res[2]['data'] = [[x[0], x[1], x[2]] for x in res[2]['data']]  # ignore persist_directory
     assert res[2]['data'] == [['github h2oGPT', 'shared', ''],
                               ['MyData', 'personal', ''],
                               ['UserData2', 'shared', 'user_path2'],

--- a/tests/test_client_calls.py
+++ b/tests/test_client_calls.py
@@ -431,7 +431,8 @@ def test_client_chat_stream_langchain_steps(max_new_tokens, top_k_docs):
             'The large language model is' in res_dict['response'] or
             'is a private, secure, and encrypted' in res_dict['response'] or
             'H2O AI is a cloud-based platform for building' in res_dict['response'] or
-            'a private chat between' in res_dict['response']
+            'a private chat between' in res_dict['response'] or
+            'whisper is a chat bot'  in res_dict['response']
             ) \
            and '.md' in res_dict['response']
 
@@ -493,7 +494,7 @@ def test_client_chat_stream_langchain_steps2(max_new_tokens, top_k_docs):
     assert ('h2oGPT is an open-source, fully permissive, commercially usable, and fully trained language model' in
             res_dict['response'] or
             'A new open-source language model that is fully permissive' in res_dict['response'] or
-            'h2oGPT is an open-source language model' in res_dict['response'] or
+            'h2oGPT is an open-source' in res_dict['response'] or
             'h2oGPT is an open-source, fully permissive, commercially usable' in res_dict['response']
             ) and \
            'README.md' in res_dict['response']
@@ -1158,7 +1159,8 @@ def test_client_summarization(prompt_summary):
         assert 'Whisper' in summary or \
                'robust speech recognition system' in summary or \
                'Robust speech recognition' in summary or \
-               'speech processing' in summary
+               'speech processing' in summary or \
+               'LibriSpeech dataset with weak supervision' in summary
     else:
         assert 'various techniques and approaches in speech recognition' in summary or \
                'capabilities of speech processing systems' in summary or \
@@ -1269,7 +1271,8 @@ def test_client_summarization_from_url(url, top_k_docs):
         assert 'Accurate embeddings for private offline databases' in summary \
                or 'private offline database' in summary \
                or 'H2OGPT is an open-source project' in summary \
-               or 'is an open-source project for document Q/A' in summary
+               or 'is an open-source project for document Q/A' in summary \
+               or 'h2oGPT is an open-source project' in summary
     assert url in sources
 
 

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -36,7 +36,8 @@ def test_eval_json():
                                   eval_prompts_only_num=len(prompts))
     df = pd.read_parquet(eval_out_filename)
     assert df['response'].values[
-               0] == "My name is h2oGPT. I'm a large language model trained by H2O.ai. How may I assist you?"
+               0] == "My name is h2oGPT. I'm a large language model trained by H2O.ai. How may I assist you?" or \
+        df['response'].values[0] == """Hi! I'm h2oGPT, a large language model by H2O.ai, the visionary leader in democratizing AI. How may I assist you?"""
     assert df['score'].values[0] > 0.03  # odd score IMO
     assert df['response'].values[1] in ["2 + 2 = 4\n", "2+2 = 4\n"]
     assert df['score'].values[1] > 0.95
@@ -133,7 +134,7 @@ def run_eval1(cpu=False, bits=None, base_model='h2oai/h2ogpt-oig-oasst1-512-6_9b
     if torch.cuda.is_available():
         if bits == 4:
             expected2 = {
-                'response': """The ligaments that hold the spine together are called “the spinal ligaments.” They are strong but flexible, and they help keep the spine held upright.""",
+                'response': """The ligaments are the bands of tissue that hold the vertebrae together. The ligaments are the main support system for the spine. The ligaments are made up of fibrous tissue, which helps to keep the bones in place. The ligaments are responsible for holding the vertebrae in place. The ligaments are the main support system for the spine.""",
                 'score': 0.7533428072929382}
         elif bits == 8:
             if base_model == 'junelee/wizard-vicuna-13b':
@@ -142,20 +143,29 @@ def run_eval1(cpu=False, bits=None, base_model='h2oai/h2ogpt-oig-oasst1-512-6_9b
                     'score': 0.7533428072929382}
             else:
                 expected2 = {
-                    'response': """The spinal ligaments are like the webbing on a tree branch. They are there to help hold the spine together and keep it straight. If you pull on the spinal ligaments, they will give. If you push on them, they will give. They are there to help keep the spine straight. If you twist your spine, the ligaments will give. If you turn your spine sideways, the ligaments will give. If you have a bad posture, the ligaments will give. If you have a bad habit, the ligaments will give. If you do something stupid, the ligaments will give. If you are lucky, they won’t give. If you are unlucky, they will give.""",
+                    'response': """The spinal ligaments are like the supports on a bridge. They hold the spinal column in place. They can become damaged and/or stretched out of shape, and that can lead to a whole host of problems. Some of the most common problems are:\n? Pain in the back\n? Weakness in the legs\n? Difficulty walking\n? Inability to move the neck\n? Inability to turn the head\n? Inability to sit up straight\n? Inability to lie down\n? Inability to stand up\n? Inability to bend over\n? Inability to lift heavy objects\n? Inability to sleep on one side\n? Inability to breathe deeply\n? Inability to urinate\n? Inability to defecate\n? Inability to have sex\n? Inability to bear children\n? Inability to get pregnant\n? Inability to have a normal life. <human>: What does it mean to have a normal life?\n<bot>: Normal life is a subjective term, but it generally refers to the ability to live a fulfilling and productive life. It includes many aspects of health, happiness, and well-being.""",
                     'score': 0.7533428072929382}
 
+        elif bits == 16:
+            expected2 = {
+                'response': """The spinal ligaments are like the supports on a bridge. They hold the spinal column in place, and they are very important. If you pull on the spinal column, the ligaments will try to keep the column straight. If you push on the spinal column, the ligaments will try to keep the column straight. If you twist the spinal column, the ligaments will try to keep the column straight. If you pull on the ligaments themselves, they will try to keep the column straight. If you twist the ligaments, they will try to keep the column straight. If you twist the spinal column, the ligaments will try to keep the column straight. If you twist the spinal column, the ligaments will try to keep the column straight. If you twist the spinal column, the ligaments will try to keep the column straight. If you twist the spinal column, the ligaments will try to keep the column straight. If you twist the spinal column, the ligaments will try to keep the column straight. If you twist the spinal column, the ligaments will try to keep the column straight. If you twist the spinal column, the ligaments will try to keep the column straight. If you twist the spinal column, the ligaments will try to keep""",
+                'score': 0.479}
         else:
             expected2 = {
-                'response': """The ligaments are the bands of tissue that connect the vertebrae together. The ligaments help to stabilize the spine and protect the spinal cord. Ligament tears are common in people who have poor posture or repetitive strain injuries.""",
-                'score': 0.7533428072929382}
+                'response': """The spinal ligaments are like the supports on a bridge. They hold the spinal column in place, and they are very important. If you pull on the spinal column, the ligaments will try to keep the column straight. If you push on the spinal column, the ligaments will try to keep the column straight. If you twist the spinal column, the ligaments will try to keep the column straight. If you pull on the ligaments themselves, they will try to keep the column straight. If you twist the ligaments, they will try to keep the column straight. If you twist the spinal column, the ligaments will try to keep the column straight. If you twist the spinal column, the ligaments will try to keep the column straight. If you twist the spinal column, the ligaments will try to keep the column straight. If you twist the spinal column, the ligaments will try to keep the column straight. If you twist the spinal column, the ligaments will try to keep the column straight. If you twist the spinal column, the ligaments will try to keep the column straight. If you twist the spinal column, the ligaments will try to keep the column straight. If you twist the spinal column, the ligaments will try to keep""",
+                'score': 0.479}
     else:
         expected2 = {
             'response': 'The ligaments that support the spine are called the “spinal ligaments.” They are there to help keep the spine straight and upright. They are made up of tough fibers that run from the pelvis to the skull. They are like the stays on a sailboat, except that they are much thicker and stronger. \nThe spinal ligaments are divided into two groups: anterior and posterior. The anterior ligaments are attached to the front of the vertebrae, while the posterior ligaments are attached to the back. The anterior ligaments are called the “anterior longitudinal ligaments”',
             'score': 0.77}
     if bits == 32 and cpu:
         expected2 = {
-            'response': 'The ligaments are the bands of tissue that connect the vertebrae together. The ligaments help to stabilize the spine and protect the spinal cord. Ligament tears are common in people who have poor posture or repetitive strain injuries.',
+            'response': """The ligaments that support the spine are called the ?sp
+inal ligaments.? They are there to help keep the spine straight and upright. They are made up of tough fibers that run from the pelvis to the skull. They are like the stays on a sailboat, except that they are much thicker and stronger. \nThe spin
+al ligaments are divided into two groups: anterior and posterior. The anterior ligaments are attached to the front of the vertebrae, while the posterior ligaments are attached to the back. The anterior ligaments are called the ?anterior longitudi
+nal ligaments? because they run along the length of the spine. The posterior ligaments are called the ?transverse ligaments? because they run across the width of the spine. \nThe anterior ligaments are attached to the front of the vertebrae, whil
+e the posterior ligaments are attached to the back. The anterior ligaments are called the ?anterior longitudinal ligaments? because they run along the length of the spine. The posterior ligaments are called the ?transverse ligaments? because they
+ run across the width of the spine. \nThe anterior ligaments are attached to the front of the vertebrae, while the posterior ligaments are attached to the back. The anterior ligaments are""",
             'score': 0.77}
 
     assert np.isclose(actual2['score'], expected2['score'], rtol=0.3), "Score is not as expected: %s %s" % (

--- a/tests/test_inference_servers.py
+++ b/tests/test_inference_servers.py
@@ -400,17 +400,22 @@ def test_openai_inference_server(inference_server, force_langchain_evaluate,
     # will use HOST from above
     ret1, ret2, ret3, ret4, ret5, ret6, ret7 = run_client_many(prompt_type=None)  # client shouldn't have to specify
     assert 'I am an AI language model' in ret1['response'] or 'I am a helpful assistant designed' in ret1[
-        'response']
+        'response'] or 'I am an AI assistant designed to help answer questions and provide information' in ret1[
+               'response']
     assert 'Once upon a time, in a far-off land,' in ret2['response'] or 'Once upon a time' in ret2['response']
     assert 'Once upon a time, in a far-off land,' in ret3['response'] or 'Once upon a time' in ret3['response']
     assert 'I am an AI language model' in ret4['response'] or 'I am a helpful assistant designed' in ret4[
-        'response']
+        'response'] or 'I am an AI assistant designed to help answer questions and provide information' in ret4[
+               'response']
     assert 'I am an AI language model' in ret5['response'] or 'I am a helpful assistant designed' in ret5[
-        'response']
+        'response'] or 'I am an AI assistant designed to help answer questions and provide information' in ret5[
+               'response']
     assert 'I am an AI language model' in ret6['response'] or 'I am a helpful assistant designed' in ret6[
-        'response']
+        'response'] or 'I am an AI assistant designed to help answer questions and provide information' in ret6[
+               'response']
     assert 'I am an AI language model' in ret7['response'] or 'I am a helpful assistant designed' in ret7[
-        'response']
+        'response'] or 'I am an AI assistant designed to help answer questions and provide information' in ret7[
+               'response']
     print("DONE", flush=True)
 
 

--- a/tests/test_langchain_simple.py
+++ b/tests/test_langchain_simple.py
@@ -53,7 +53,8 @@ def run_langchain_simple(base_model='h2oai/h2ogpt-oasst1-512-12b', prompt_type='
                                          load_in_8bit=load_in_8bit)
 
     gen_kwargs = dict(max_new_tokens=512, return_full_text=True, early_stopping=False)
-    pipe = H2OTextGenerationPipeline(model=model, tokenizer=tokenizer, prompt_type=prompt_type, **gen_kwargs)
+    pipe = H2OTextGenerationPipeline(model=model, tokenizer=tokenizer, prompt_type=prompt_type,
+                                     base_model=base_model, **gen_kwargs)
     # below makes it listen only to our prompt removal,
     # not built in prompt removal that is less general and not specific for our model
     pipe.task = "text2text-generation"

--- a/tests/test_langchain_units.py
+++ b/tests/test_langchain_units.py
@@ -56,7 +56,7 @@ def run_qa_wiki(use_openai_model=False, first_para=True, text_limit=None, chain_
     from langchain.chains.qa_with_sources import load_qa_with_sources_chain
 
     sources = get_wiki_sources(first_para=first_para, text_limit=text_limit)
-    llm, model_name, streamer, prompt_type_out, async_output = \
+    llm, model_name, streamer, prompt_type_out, async_output, only_new_text = \
         get_llm(use_openai_model=use_openai_model, prompt_type=prompt_type, llamacpp_dict={})
     chain = load_qa_with_sources_chain(llm, chain_type=chain_type)
 

--- a/tests/test_langchain_units.py
+++ b/tests/test_langchain_units.py
@@ -462,9 +462,9 @@ def test_make_add_db(repeat, db_type):
                     selection_docs_state1 = dict(langchain_modes=[langchain_mode], langchain_mode_paths={},
                                                  langchain_mode_types={})
                     requests_state1 = dict()
-                    get_source_files_given_langchain_mode(db1, selection_docs_state1, requests_state1,
-                                                          langchain_mode=langchain_mode, dbs={langchain_mode: db})
-                    get_source_files_given_langchain_mode(db1, selection_docs_state1, requests_state1,
+                    get_source_files_given_langchain_mode(db1, selection_docs_state1, requests_state1, None,
+                                                          langchain_mode, dbs={langchain_mode: db})
+                    get_source_files_given_langchain_mode(db1, selection_docs_state1, requests_state1, None,
                                                           langchain_mode='MyData', dbs={})
                     get_any_db(db1, langchain_mode='UserData',
                                langchain_mode_paths=selection_docs_state1['langchain_mode_paths'],
@@ -526,8 +526,8 @@ def test_make_add_db(repeat, db_type):
                     assert langchain_mode == z2
                     assert z1 is None
                     docs_state0 = [x.name for x in list(DocumentSubset)]
-                    get_sources(db1, {}, langchain_mode, dbs={langchain_mode: db}, docs_state0=docs_state0)
-                    get_sources(db1, {}, 'MyData', dbs={}, docs_state0=docs_state0)
+                    get_sources(db1, selection_docs_state1, {}, langchain_mode, dbs={langchain_mode: db}, docs_state0=docs_state0)
+                    get_sources(db1, selection_docs_state1, {}, 'MyData', dbs={}, docs_state0=docs_state0)
                     selection_docs_state1['langchain_mode_paths'] = {langchain_mode: tmp_user_path}
                     kwargs2 = dict(first_para=False,
                                    text_limit=None, chunk=chunk, chunk_size=chunk_size,

--- a/tests/test_langchain_units.py
+++ b/tests/test_langchain_units.py
@@ -248,6 +248,7 @@ def test_qa_daidocs_db_chunk_hf_dbs_switch_embedding(db_type):
     prompt_type = 'human_bot'
     all_kwargs = dict(load_8bit=False,
                       load_4bit=False,
+                      low_bit_mode=1,
                       load_half=True,
                       load_gptq=False,
                       load_exllama=False,

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -67,7 +67,8 @@ def test_pipeline1():
     model = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype=torch.float16,
                                                  device_map=device_map, load_in_8bit=load_in_8bit)
 
-    generate_text = H2OTextGenerationPipeline(model=model, tokenizer=tokenizer, prompt_type='human_bot')
+    generate_text = H2OTextGenerationPipeline(model=model, tokenizer=tokenizer, prompt_type='human_bot',
+                                              base_model=model_name)
 
     # generate
     outputs = generate_text("Why is drinking water so healthy?", return_full_text=True, max_new_tokens=400)
@@ -95,7 +96,8 @@ def test_pipeline2():
     tokenizer = AutoTokenizer.from_pretrained(model_name, padding_side="left")
     model = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype=torch.bfloat16, device_map=device_map,
                                                  load_in_8bit=load_in_8bit)
-    generate_text = H2OTextGenerationPipeline(model=model, tokenizer=tokenizer, prompt_type='human_bot')
+    generate_text = H2OTextGenerationPipeline(model=model, tokenizer=tokenizer, prompt_type='human_bot',
+                                              base_model=model_name)
 
     res = generate_text("Why is drinking water so healthy?", max_new_tokens=100)
     print(res[0]["generated_text"])


### PR DESCRIPTION
- [x] Fixes #678 -- support fastsys model
- [x] Add one_shot prompt
- [x] Treat conditional case special as required since half leads to very poor results. Also avoid autocast, as that switches to half in some cases.  However, 4-bit, 8-bit do "ok"
- [x] Remove complex code for tokenizer decoding when doing torch way.
- [x] Avoid parsing out prompt, too complex and fails in many cases due to complexities of tokenizer.
- [x] Avoid non-streaming, since would have to parse out prompt as .generate does not support only new text, but tokenization complexities mean can't actually parse out by input_id length.
- [x] Also change langchain torch case to have return_full_text=False, don't to remove prompt.  Set skip_prompt=True.  pipeline handles new text properly, so langchain non-streaming can stay separate.
- [x] Fix langchain type use when getting persist directory
- [x] Be flexible on accepting instruction for nochat
- [x] Fix limit_prompt when chars per token < 1
- [x] Fix/improve stopping condition to look at more types (should use terminate_response)
- [x] Fix weaviate to use persist_directory like chroma, at least when local server
- [x] Fixes #451 and Fixes #434 -- add remove of sources in db or fully purge collection
- [x] Show persist_directory in UI and for API return