### PR TITLE
Improve offline caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ EXPOSE 8888
 EXPOSE 7860
 
 ENV TRANSFORMERS_CACHE=/workspace/.cache/huggingface/hub/
+ENV TIKTOKEN_CACHE_DIR=/workspace/.cache/
 
 COPY build_info.txt* /build_info.txt
 RUN touch /build_info.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,4 +65,8 @@ RUN chmod -R a+rwx /h2ogpt_conda
 
 USER h2ogpt
 
+# preload encodings (add more as needed)
+RUN python -c "import tiktoken; tiktoken.get_encoding('cl100k_base')"
+RUN chmod -R a+rwx /workspace
+
 ENTRYPOINT ["python3.10"]


### PR DESCRIPTION
![image](https://github.com/h2oai/h2ogpt/assets/51244975/999ab8a8-a913-4aae-b1f4-f546f765eb38)

Because of https://github.com/openai/tiktoken/blob/5d970c1100d3210b42497203d6b5c1e30cfda6cb/tiktoken/load.py#L30-L35

so set the cache to under h2oGPT cache dir, and pre-load at least the default encoding to things work in offline mode.
