### PR TITLE
[DOCS] Fix the link to offline README

### DIFF
--- a/docs/README_ui.md
+++ b/docs/README_ui.md
@@ -9,7 +9,7 @@
 * RLHF response score evaluation for every query-response
 
 
-We disable background uploads by disabling telemetry for Hugging Face, gradio, and chroma, and one can additionally avoid downloads (of fonts) by running `generate.py` with `--gradio_offline_level=2`.  See [Offline Documentation](offline.md) for details.
+We disable background uploads by disabling telemetry for Hugging Face, gradio, and chroma, and one can additionally avoid downloads (of fonts) by running `generate.py` with `--gradio_offline_level=2`.  See [Offline Documentation](README_offline.md) for details.
 
 
 


### PR DESCRIPTION
The original link is broken and results in `404 - page not found`