### PR TITLE
Added the option to create OCRed documents that are layout aware

### DIFF
--- a/reqs_optional/requirements_optional_doctr.txt
+++ b/reqs_optional/requirements_optional_doctr.txt
@@ -1,4 +1,1 @@
-# GPU only:
-# python-doctr @ git+https://github.com/h2oai/doctr.git@88142eb12b38446dc885bbce679ddc933e2cf3d3
-# CPU + GPU:
 python-doctr @ git+https://github.com/h2oai/doctr.git@aee9b1c369e37af9e18265660935bce2c4447d65

--- a/reqs_optional/requirements_optional_doctr.txt
+++ b/reqs_optional/requirements_optional_doctr.txt
@@ -1,4 +1,4 @@
 # GPU only:
 # python-doctr @ git+https://github.com/h2oai/doctr.git@88142eb12b38446dc885bbce679ddc933e2cf3d3
 # CPU + GPU:
-python-doctr @ git+https://github.com/h2oai/doctr.git@9d0b160ee80b38d8c12672bde78aed7965054567
+python-doctr @ git+https://github.com/h2oai/doctr.git@aee9b1c369e37af9e18265660935bce2c4447d65

--- a/src/image_doctr.py
+++ b/src/image_doctr.py
@@ -97,7 +97,6 @@ class H2OOCRLoader(ImageCaptionLoader):
             words = space_layout(texts=texts, boxes=text_boxes)
         else:
             words = " ".join(words)
-        # words = space_layout(texts=words, boxes=boxes)
         metadata: dict = {"image_path": path_image}
         return words, metadata
     
@@ -178,13 +177,13 @@ def space_layout(texts, boxes):
             left_char_num = max((left_char_num - len(space_line_text)), 1)
             
             #verbose layout
-            # space_line_text += " " * left_char_num
+            space_line_text += " " * left_char_num
             
             #minified layout
-            if left_char_num > 1:
-                space_line_text += f" <{left_char_num}> " 
-            else:
-                space_line_text += " "
+            # if left_char_num > 1:
+            #     space_line_text += f" <{left_char_num}> " 
+            # else:
+            #     space_line_text += " "
             
             space_line_text += line_texts[i][j]
         space_line_texts.append(space_line_text + "\n")

--- a/src/image_doctr.py
+++ b/src/image_doctr.py
@@ -95,6 +95,8 @@ class H2OOCRLoader(ImageCaptionLoader):
             texts = [words[i] for i in ids]
             text_boxes = [boxes[i] for i in ids]
             words = space_layout(texts=texts, boxes=text_boxes)
+        else:
+            words = " ".join(words)
         # words = space_layout(texts=words, boxes=boxes)
         metadata: dict = {"image_path": path_image}
         return words, metadata

--- a/src/image_doctr.py
+++ b/src/image_doctr.py
@@ -10,16 +10,16 @@ from typing import List, Union, Any, Tuple
 import requests
 from langchain.docstore.document import Document
 from langchain.document_loaders import ImageCaptionLoader
-
+import numpy as np
 from utils import get_device, NullContext
-
 
 class H2OOCRLoader(ImageCaptionLoader):
     """Loader that extracts text from images"""
 
-    def __init__(self, path_images: Union[str, List[str]] = None):
+    def __init__(self, path_images: Union[str, List[str]] = None, layout_aware = False):
         super().__init__(path_images)
         self._ocr_model = None
+        self.layout_aware = layout_aware
 
     def set_context(self):
         if get_device() == 'cuda':
@@ -82,11 +82,109 @@ class H2OOCRLoader(ImageCaptionLoader):
             raise ValueError(f"Could not get image data for {path_image}")
         ocr_output = model([image])
         words = []
+        boxes = []
         for block_num, block in enumerate(ocr_output.pages[0].blocks):
             for line_num, line in enumerate(block.lines):
                 for word_num, word in enumerate(line.words):
                     if not (word.value or "").strip():
                         continue
                     words.append(word.value)
+                    boxes.append([word.geometry[0][0], word.geometry[0][1], word.geometry[1][0], word.geometry[1][1]])
+        if self.layout_aware:
+            ids = boxes_sort(boxes)
+            texts = [words[i] for i in ids]
+            text_boxes = [boxes[i] for i in ids]
+            words = space_layout(texts=texts, boxes=text_boxes)
+        # words = space_layout(texts=words, boxes=boxes)
         metadata: dict = {"image_path": path_image}
-        return " ".join(words), metadata
+        return words, metadata
+    
+def boxes_sort(boxes):
+    """ From left top to right bottom
+    Params:
+        boxes: [[x1, y1, x2, y2], [x1, y1, x2, y2], ...]
+    """
+    sorted_id = sorted(range(len(boxes)), key=lambda x: (boxes[x][1]))
+
+    # sorted_boxes = [boxes[id] for id in sorted_id]
+
+
+    return sorted_id
+
+def is_same_line(box1, box2):
+    """
+    Params:
+        box1: [x1, y1, x2, y2]
+        box2: [x1, y1, x2, y2]
+    """
+    
+    box1_midy = (box1[1] + box1[3]) / 2
+    box2_midy = (box2[1] + box2[3]) / 2
+
+    if box1_midy < box2[3] and box1_midy > box2[1] and box2_midy < box1[3] and box2_midy > box1[1]:
+        return True
+    else:
+        return False
+    
+def union_box(box1, box2):
+    """
+    Params:
+        box1: [x1, y1, x2, y2]
+        box2: [x1, y1, x2, y2]
+    """
+    x1 = min(box1[0], box2[0])
+    y1 = min(box1[1], box2[1])
+    x2 = max(box1[2], box2[2])
+    y2 = max(box1[3], box2[3])
+
+    return [x1, y1, x2, y2]
+
+def space_layout(texts, boxes):
+    line_boxes = []
+    line_texts = []
+    max_line_char_num = 0
+    line_width = 0
+    # print(f"len_boxes: {len(boxes)}")
+    boxes = np.array(boxes)
+    texts = np.array(texts)
+    while len(boxes) > 0:
+        box = boxes[0]
+        mid = (boxes[:, 3] + boxes[:, 1])/2
+        inline_boxes = np.logical_and(mid > box[1], mid < box[3])
+        sorted_xs = np.argsort(boxes[inline_boxes][:, 0], axis = 0)
+        line_box = boxes[inline_boxes][sorted_xs]
+        line_text = texts[inline_boxes][sorted_xs]
+        boxes = boxes[~inline_boxes]
+        texts = texts[~inline_boxes]
+        
+        line_boxes.append(line_box.tolist())
+        line_texts.append(line_text.tolist())
+        if len(" ".join(line_texts[-1])) > max_line_char_num:
+            max_line_char_num = len(" ".join(line_texts[-1]))
+            line_width = np.array(line_boxes[-1])
+            line_width = line_width[:, 2].max() - line_width[:, 0].min()
+
+    char_width = (line_width / max_line_char_num)
+    if char_width == 0:
+        char_width = 1
+
+    space_line_texts = []
+    for i, line_box in enumerate(line_boxes):
+        space_line_text = ""
+        for j, box in enumerate(line_box):
+            left_char_num = int(box[0] / char_width)
+            left_char_num = max((left_char_num - len(space_line_text)), 1)
+            
+            #verbose layout
+            # space_line_text += " " * left_char_num
+            
+            #minified layout
+            if left_char_num > 1:
+                space_line_text += f" <{left_char_num}> " 
+            else:
+                space_line_text += " "
+            
+            space_line_text += line_texts[i][j]
+        space_line_texts.append(space_line_text + "\n")
+
+    return "".join(space_line_texts)


### PR DESCRIPTION
Initial formatting of OCR is quite poor for certain things like table processing and for the LLMs to understand the structure of the text. Layout aware option makes it so the text is correctly spaced out. model can understand the structure by looking at spaces and new lines. 

```                                                                         QUARTERLY-     VOLUME,     TRANSACTIONS     &  REVENUES
                Volume
                                                                               1Q 2023                                                             1Q  2022                                   YoY
                                                     Sparkling    Water  (5)    Bulk (2)      Stills      Total            Sparkling   Water  BI    Bulk (2)     Stills      Total            4%
                   Mexico  RO                          309.5         26.4         87.6         35.2        458.8             301.9        21.3        67.5        32.7       423.5            8.3%
                    Guatemala                           35.6         1.4                       2.3         39.2               30.6        1.1                     1.9         33.7           16.3%
                    CAMS South                          31.4         2.0          0.4          5.6         39.4              29.8         1.9         0.2         4.9         36.9            6.9%
                Mexico  and Central. America           376.4         29.8         88.0         43.1        537.4             362.4        24.4        67.7        39.5       494.0            8.8%
                    Colombia                            61.4         8.8           3.3         7.1         80.5              62.1         7.7         3.1         7.4         80.4            0.1%
                   Brazil ()                           218.3         19.4         2.7          20.5        260.9             212.2        17.1        2.4         19.1       250.9            4.0%
                    Argentina                           35.9         5.5          1.4          4.9         47.7               35.8        4.1         1.2         3.9         44.9            6.2%
                    Uruguay                             10.4         2.1                       0.7         13.1               9.4         1.7                     0.3         11.4           14.8%
                South America                          325.9         35.8         7.4          33.1        402.2             319.6        30.6        6.7         30.8       387.6            3.8%
                TOTAL                                  702.4        65.6          95.4         76.2        939.6             681.9        55.0        74.4        70.3       881.6            6.6%
               B  Excludes water presentations larger than 5.0Lt;includesf flavored water.
               1a. Bulk Water Stillbottled water w 5.0, 19.0and2 20.0- ster packaging presentations;/ includes flavored water
               (8 includes 15.1 million unit cases corresponding to the acqubsition ofCristol from depense
                Transactions
                                                                               1Q 2023                                                             1Q2022                                     YoY
                                                    Sparkling            Water                Stills      Total           Sparkling           Water              Stills      Total            4%
                   Mexico  R                          1,765.2             191.3               254.7       2,211.2           1,698.6            154.3             237.6      2,090.4           5.8%
                    Guatemala                          267.3               13.3                22.6        303.2             238.5             11.7               19.5       269.7           12.4%
                    CAM  South                         235.6               13.3                63.5        312.4             220.4              12.7              55.1       288.2            8.4%
                Mexico  and Central America           2,268.1             217.9               340.8       2,826.8           2,157.5            178.6             312.2      2,648.3           6.7%
                    Colombia                           448.1               91.6                77.6        617.3             429.7             82.6               81.5       593.9            3.9%
                   Brazil ()                          1,403.1             170.2               226.4       1,799.6           1,303.8            146.8             222.8      1,673.4           7.5%
                    Argentina                          183.4               34.8                41.4        259.6             178.7             25.1               29.8       233.5           11.2%
                    Uruguay                            50.3                8.0                 5.7         63.9               47.1              6.3               2.8         56.2           13.8%
                South America                         2,084.8             304.6               351.1       2,740.5           1,959.3            260.8             336.9      2,556.9           7.2%
                TOTAL                                 4,352.9             522.5               691.9       5,567.3           4,116.8            439.4             649.1      5,205.3           7.0%
                Revenues
                Expressedinmiond Mesican Pesos       1Q2023           1Q2 202     A%
                   Mexico                             27,229         23,222      17.3%
                   Guatemala                            3,017         2,775      8.7%
                   CAMS South                           3,371         2,938      14.7%
               Mexico  and  Central America            33,617        28,935      16.2%
                   Colombia                             3,744         4,276      12.5%
                   Brazil F)                           15,969        14,388      11.0%
                   Argentina                            2,900         2,672      8.5%
                   Uruguay                              1,127           925      21.9%
               South  America                         23,740         22,261      6.6%
                TOTAL                                 57,357         51,195      12.0%
               10 Volume and transactions in Brazl do noti include beer
               n. Broud& includes beer revenues ofPs.1,450n millionf for thef first quarter of 2023 and Ps1,250r mWon) fort the some perlodo ofthe previous year.
                                                VOLUME           (1)                                                            TRANSACTIONS                 (2)
                                        Argentina               Uruguay                                                   Argentina                     Uruguay
                                            5%                     1%                                                                                      1%
                                                                                                                              4%
                          Brazil( (3)                                                                              Brazil( (3).
                             28%                                                                                     30%                                             Mexico
                                                                                  Mexico
                                                                                                                                                                      44%
                                                                                   49%
                                                                                                                  Colombia
                             Colombia                                                                                10%
                                9%                                                                                     CAMSouth
                                    CAM    South                  Guatemala                                                                                   Guatemala
                                         4%                            4%                                                   5%                                     6%
                     a      Volume   s  expressed in unit cases. Unit case refers to: 192 ounces of) finished beverage  product  (24 eight-ounce  servings) and, when   applied to soda  fountains, refers to
                            the volume  of: syrup, powders, and                that is required to produce 192  ounces  of finished beverage  product.
                            Transactions  refers to the number  ofs single units (e.g., a can or a bottle): sold, regardless of their size or volume or whether they are sold individually or in multipacks,
                            except  for soda) fountains, which represent  multiple transactions  based on  as standard: 12 oz. serving.
              Coca-Cola     FEMSA      Reports    1Q23    Results                                                                                                                         Page   13 of14
```

This option is defaulted to off because it adds many tokens because of the injected spaces and this messes with the embedding model with their 512 token limit. It is powerful in the LLM but yields bad performance in the embeddings.

One variation of this that seems to work is "minifying" the spaces with a run length encoding. Instead of entering each space, encode how many spaces should be there. 


```<77> QUARTERLY- <76> VOLUME, <75> TRANSACTIONS <74> & <70> REVENUES
 <16> Volume
 <79> 1Q <74> 2023 <129> 1Q <124> 2022 <152> YoY
 <53> Sparkling <51> Water <47> (5) <45> Bulk <40> (2) <40> Stills <40> Total <46> Sparkling <43> Water <39> BI <37> Bulk <32> (2) <31> Stills <31> Total <37> 4%
 <19> Mexico <15> RO <35> 309.5 <38> 26.4 <41> 87.6 <44> 35.2 <46> 458.8 <53> 301.9 <55> 21.3 <57> 67.5 <59> 32.7 <60> 423.5 <66> 8.3%
 <20> Guatemala <41> 35.6 <44> 1.4 <61> 2.3 <64> 39.2 <73> 30.6 <75> 1.1 <90> 1.9 <93> 33.7 <98> 16.3%
 <20> CAMS <15> South <35> 31.4 <38> 2.0 <42> 0.4 <46> 5.6 <49> 39.4 <57> 29.8 <60> 1.9 <63> 0.2 <66> 4.9 <69> 36.9 <75> 6.9%
 <16> Mexico <12> and <7> Central. <2> America <9> 376.4 <13> 29.8 <16> 88.0 <19> 43.1 <21> 537.4 <28> 362.4 <30> 24.4 <32> 67.7 <34> 39.5 <35> 494.0 <41> 8.8%
 <20> Colombia <42> 61.4 <45> 8.8 <50> 3.3 <53> 7.1 <56> 80.5 <64> 62.1 <67> 7.7 <70> 3.1 <73> 7.4 <76> 80.4 <82> 0.1%
 <19> Brazil <13> () <35> 218.3 <38> 19.4 <41> 2.7 <45> 20.5 <47> 260.9 <54> 212.2 <56> 17.1 <58> 2.4 <61> 19.1 <62> 250.9 <68> 4.0%
 <20> Argentina <41> 35.9 <44> 5.5 <48> 1.4 <52> 4.9 <55> 47.7 <64> 35.8 <66> 4.1 <69> 1.2 <72> 3.9 <75> 44.9 <81> 6.2%
 <20> Uruguay <43> 10.4 <46> 2.1 <63> 0.7 <66> 13.1 <75> 9.4 <78> 1.7 <93> 0.3 <96> 11.4 <101> 14.8%
 <16> South <11> America <31> 325.9 <34> 35.8 <37> 7.4 <41> 33.1 <43> 402.2 <50> 319.6 <52> 30.6 <54> 6.7 <57> 30.8 <58> 387.6 <64> 3.8%
 <16> TOTAL <44> 702.4 <46> 65.6 <50> 95.4 <53> 76.2 <55> 939.6 <62> 681.9 <64> 55.0 <66> 74.4 <68> 70.3 <69> 881.6 <75> 6.6%
 <15> B <11> Excludes <4> water presentations larger than 5.0Lt;includesf flavored water.
 <15> 1a. <9> Bulk <4> Water Stillbottled water w 5.0, 19.0and2 20.0- ster packaging presentations;/ includes flavored water
 <15> (8 <10> includes <3> 15.1 million unit cases corresponding to the acqubsition ofCristol from depense
 <16> Transactions
 <79> 1Q <74> 2023 <129> 1Q2022 <159> YoY
 <52> Sparkling <58> Water <68> Stills <68> Total <73> Sparkling <78> Water <86> Stills <86> Total <92> 4%
 <19> Mexico <15> R <35> 1,765.2 <42> 191.3 <51> 254.7 <52> 2,211.2 <57> 1,698.6 <63> 154.3 <70> 237.6 <70> 2,090.4 <75> 5.8%
 <20> Guatemala <40> 267.3 <49> 13.3 <59> 22.6 <61> 303.2 <68> 238.5 <75> 11.7 <84> 19.5 <85> 269.7 <90> 12.4%
 <20> CAM <16> South <35> 235.6 <44> 13.3 <54> 63.5 <56> 312.4 <63> 220.4 <71> 12.7 <79> 55.1 <80> 288.2 <86> 8.4%
 <16> Mexico <12> and <7> Central <3> America <9> 2,268.1 <17> 217.9 <26> 340.8 <27> 2,826.8 <32> 2,157.5 <38> 178.6 <45> 312.2 <45> 2,648.3 <50> 6.7%
 <20> Colombia <41> 448.1 <50> 91.6 <60> 77.6 <62> 617.3 <69> 429.7 <76> 82.6 <85> 81.5 <86> 593.9 <92> 3.9%
 <19> Brazil <13> () <34> 1,403.1 <41> 170.2 <50> 226.4 <51> 1,799.6 <56> 1,303.8 <62> 146.8 <69> 222.8 <69> 1,673.4 <74> 7.5%
 <20> Argentina <40> 183.4 <49> 34.8 <59> 41.4 <61> 259.6 <68> 178.7 <75> 25.1 <84> 29.8 <85> 233.5 <90> 11.2%
 <20> Uruguay <42> 50.3 <52> 8.0 <63> 5.7 <66> 63.9 <75> 47.1 <83> 6.3 <92> 2.8 <95> 56.2 <100> 13.8%
 <16> South <11> America <30> 2,084.8 <37> 304.6 <46> 351.1 <47> 2,740.5 <52> 1,959.3 <58> 260.8 <65> 336.9 <65> 2,556.9 <70> 7.2%
 <16> TOTAL <43> 4,352.9 <50> 522.5 <59> 691.9 <60> 5,567.3 <65> 4,116.8 <71> 439.4 <78> 649.1 <78> 5,205.3 <83> 7.0%
 <16> Revenues
 <16> Expressedinmiond <9> Mesican <4> Pesos <9> 1Q2023 <15> 1Q2 <9> 202 <10> A%
 <19> Mexico <42> 27,229 <45> 23,222 <45> 17.3%
 <19> Guatemala <41> 3,017 <44> 2,775 <44> 8.7%
 <19> CAMS <14> South <35> 3,371 <38> 2,938 <38> 14.7%
 <15> Mexico <11> and <7> Central <2> America <10> 33,617 <12> 28,935 <12> 16.2%
 <19> Colombia <42> 3,744 <45> 4,276 <45> 12.5%
 <19> Brazil <13> F) <35> 15,969 <37> 14,388 <37> 11.0%
 <19> Argentina <41> 2,900 <44> 2,672 <44> 8.5%
 <19> Uruguay <43> 1,127 <48> 925 <48> 21.9%
 <15> South <11> America <30> 23,740 <33> 22,261 <33> 6.6%
 <16> TOTAL <43> 57,357 <46> 51,195 <46> 12.0%
 <15> 10 <10> Volume <4> and transactions in Brazl do noti include beer
 <15> n. <10> Broud& <2> includes beer revenues ofPs.1,450n millionf for thef first quarter of 2023 and Ps1,250r mWon) fort the some perlodo ofthe previous year.
 <48> VOLUME <53> (1) <107> TRANSACTIONS <117> (2)
 <40> Argentina <49> Uruguay <94> Argentina <109> Uruguay
 <44> 5% <59> 1% <139> 1%
 <126> 4%
 <26> Brazil( <21> (3) <93> Brazil( <87> (3).
 <29> 28% <108> 30% <146> Mexico
 <82> Mexico
 <166> 44%
 <83> 49%
 <114> Colombia
 <29> Colombia <103> 10%
 <32> 9% <111> CAMSouth
 <36> CAM <34> South <46> Guatemala <123> Guatemala
 <41> 4% <63> 4% <108> 5% <138> 6%
 <21> a <21> Volume <18> s <14> expressed <9> in <5> unit cases. Unit case refers to: 192 ounces of) finished beverage <2> product (24 eight-ounce servings) and, when <2> applied to soda fountains, refers to
 <28> the <23> volume <19> of: <13> syrup, <8> powders, <5> and <16> that <10> is <5> required to produce <2> 192 ounces of finished beverage product.
 <28> Transactions <24> refers <19> to <14> the <9> number <6> ofs single units (e.g., a can or a bottle): sold, regardless of their size or volume or whether they are sold individually or in multipacks,
 <28> except <24> for <18> soda) <13> fountains, <8> which <5> represent <2> multiple transactions based on as standard: 12 oz. serving.
 <14> Coca-Cola <13> FEMSA <13> Reports <11> 1Q23 <9> Results <125> Page <121> 13 <115> of14
 <14> April <9> 26, <5> 2023
```

Doesnt look as good visually but the models seem to be able to parse this pretty well.