### PR TITLE
doc(macos): pin `llama-cpp-python` version for support GGML

### DIFF
--- a/docs/README_MACOS.md
+++ b/docs/README_MACOS.md
@@ -67,7 +67,7 @@ Supports CPU and MPS (Metal M1/M2).
 * Metal M1/M2 Only:  Install and setup GPU-specific dependencies to support LLaMa.cpp on GPU:
     ```bash
     pip uninstall llama-cpp-python -y
-    CMAKE_ARGS="-DLLAMA_METAL=on" FORCE_CMAKE=1 pip install -U llama-cpp-python --no-cache-dir
+    CMAKE_ARGS="-DLLAMA_METAL=on" FORCE_CMAKE=1 pip install -U llama-cpp-python==0.1.78 --no-cache-dir
     ```
     - Pass difference value of `--model_path_llama` if download a different GGML v3 model from TheBloke, or pass URL/path in UI. The default model can be [downloaded here](https://huggingface.co/TheBloke/Llama-2-7B-Chat-GGML/resolve/main/llama-2-7b-chat.ggmlv3.q8_0.bin) and placed in repo folder or give this URL.
     - **Note** Only supports v3 ggml 4 bit quantized models for MPS, so use llama models ends with `ggmlv3` & `q4_x.bin`.


### PR DESCRIPTION
Was having:

```
gguf_init_from_file: invalid magic number 67676a74
error loading model: llama_model_loader: failed to load model from llama-2-7b-chat.ggmlv3.q4_0.bin

llama_load_model_from_file: failed to load model
```

- countless hours of running into issues, not understanding this magic number error
- this works, and we have metal support

![image](https://github.com/h2oai/h2ogpt/assets/893837/bd9ec8bf-94a1-46a8-b187-d38d7c5c8159)
