### PR TITLE
Improve docker layer caching to reduce overall image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,8 +66,6 @@ COPY --from=stage0 /h2ogpt_conda/ /h2ogpt_conda/
 COPY build_info.txt* /build_info.txt
 RUN touch /build_info.txt
 
-RUN chmod -R a+rwx /workspace
-
 USER h2ogpt
 
 ENTRYPOINT ["python3.10"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,17 @@
 # devel needed for bitsandbytes requirement of libcudart.so, otherwise runtime sufficient
-FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu20.04
+FROM h2ogpt-base as stage0
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y \
-    git \
-    curl \
-    wget \
-    software-properties-common \
-    pandoc
-
 ENV PATH="/h2ogpt_conda/bin:${PATH}"
 ARG PATH="/h2ogpt_conda/bin:${PATH}"
+
+COPY . .
 
 RUN wget https://repo.anaconda.com/miniconda/Miniconda3-py310_23.1.0-1-Linux-x86_64.sh && \
     mkdir -p h2ogpt_conda && \
     bash ./Miniconda3-py310_23.1.0-1-Linux-x86_64.sh -b -u -p /h2ogpt_conda && \
     conda install python=3.10 pygobject weasyprint -c conda-forge -y
-
-WORKDIR /workspace
-
-RUN apt-get install -y libmagic-dev poppler-utils tesseract-ocr libtesseract-dev libreoffice autoconf libtool
-
-COPY requirements.txt requirements.txt
-COPY reqs_optional reqs_optional
 
 RUN python3.10 -m pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cu118
 RUN python3.10 -m pip install -r reqs_optional/requirements_optional_langchain.txt --extra-index-url https://download.pytorch.org/whl/cu118
@@ -37,8 +25,6 @@ RUN python3.10 -m pip install onnxruntime==1.15.0 onnxruntime-gpu==1.15.0 --extr
     python3.10 -m pip uninstall -y weasyprint && \
     python3.10 -m pip install weasyprint
 
-ENV CUDA_HOME=/usr/local/cuda-11.8
-
 # Install prebuilt dependencies
 
 RUN python3.10 -m nltk.downloader all
@@ -47,10 +33,10 @@ RUN python3.10 -m pip install https://github.com/jllllll/llama-cpp-python-cuBLAS
 RUN python3.10 -m pip install https://github.com/jllllll/exllama/releases/download/0.0.13/exllama-0.0.13+cu118-cp310-cp310-linux_x86_64.whl --no-cache-dir
 RUN playwright install --with-deps
 
-COPY . .
-
+# Install vllm
 ENV VLLM_CACHE=/workspace/.vllm_cache
 
+RUN cd /h2ogpt_conda && python -m venv vllm_env --system-site-packages
 RUN sp=`python3.10 -c 'import site; print(site.getsitepackages()[0])'` && \
     sed -i 's/posthog\.capture/return\n            posthog.capture/' $sp/chromadb/telemetry/posthog.py && \
     cd $sp && \
@@ -61,26 +47,24 @@ RUN sp=`python3.10 -c 'import site; print(site.getsitepackages()[0])'` && \
     find openai_vllm -name '*.py' | xargs sed -i 's/openai\./openai_vllm./g' && \
     find openai_vllm -name '*.py' | xargs sed -i 's/from openai\./from openai_vllm./g' && \
     find openai_vllm -name '*.py' | xargs sed -i 's/import openai/import openai_vllm/g' && \
-    conda create -n vllm python=3.10 -y && \
-    /h2ogpt_conda/envs/vllm/bin/python3.10 -m pip install vllm ray pandas --extra-index-url https://download.pytorch.org/whl/cu118 && \
+    cd /h2ogpt_conda && \
+    python -m venv vllm_env --system-site-packages && \
+    /h2ogpt_conda/vllm_env/bin/python -m pip install vllm ray pandas --extra-index-url https://download.pytorch.org/whl/cu118 && \
     mkdir ${VLLM_CACHE}
 
-EXPOSE 8888
-EXPOSE 7860
-EXPOSE 5000
 
-# /workspace/.cache is the equivalent to ~/.cache
-ENV HOME=/workspace
+FROM h2ogpt-base as stage1
+
+ENV VLLM_CACHE=/workspace/.vllm_cache
+ENV PATH="/h2ogpt_conda/bin:${PATH}"
+ARG PATH="/h2ogpt_conda/bin:${PATH}"
+
+COPY . .
+COPY --from=stage0 /h2ogpt_conda/ /h2ogpt_conda/
 
 COPY build_info.txt* /build_info.txt
 RUN touch /build_info.txt
 
-ARG user=h2ogpt
-ARG group=h2ogpt
-ARG uid=1000
-ARG gid=1000
-
-RUN groupadd -g ${gid} ${group} && useradd -u ${uid} -g ${group} -s /bin/bash ${user}
 RUN chmod -R a+rwx /workspace
 RUN chmod -R a+rwx /h2ogpt_conda
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ RUN sp=`python3.10 -c 'import site; print(site.getsitepackages()[0])'` && \
     /h2ogpt_conda/vllm_env/bin/python -m pip install vllm ray pandas --extra-index-url https://download.pytorch.org/whl/cu118 && \
     mkdir ${VLLM_CACHE}
 
+RUN chmod -R a+rwx /h2ogpt_conda
 
 FROM h2ogpt-base as stage1
 
@@ -66,7 +67,6 @@ COPY build_info.txt* /build_info.txt
 RUN touch /build_info.txt
 
 RUN chmod -R a+rwx /workspace
-RUN chmod -R a+rwx /h2ogpt_conda
 
 USER h2ogpt
 

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -23,6 +23,7 @@ EXPOSE 7860
 EXPOSE 5000
 
 WORKDIR /workspace
+RUN mkdir -p /workspace && chmod -R a+rwx /workspace
 
 ENV HOME=/workspace
 ENV CUDA_HOME=/usr/local/cuda-11.8

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -1,0 +1,35 @@
+# devel needed for bitsandbytes requirement of libcudart.so, otherwise runtime sufficient
+FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu20.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    wget \
+    software-properties-common \
+    pandoc \
+    vim \
+    libmagic-dev \
+    poppler-utils \
+    tesseract-ocr \
+    libtesseract-dev \
+    libreoffice \
+    autoconf \
+    libtool
+
+EXPOSE 8888
+EXPOSE 7860
+EXPOSE 5000
+
+WORKDIR /workspace
+
+ENV HOME=/workspace
+ENV CUDA_HOME=/usr/local/cuda-11.8
+
+ARG user=h2ogpt
+ARG group=h2ogpt
+ARG uid=1000
+ARG gid=1000
+
+RUN groupadd -g ${gid} ${group} && useradd -u ${uid} -g ${group} -s /bin/bash ${user}

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,8 @@ docker_build: build_info.txt
 ifeq ($(shell curl --connect-timeout 4 --write-out %{http_code} -sS --output /dev/null -X GET http://harbor.h2o.ai/api/v2.0/projects/h2ogpt/repositories/test-image/artifacts/$(BUILD_TAG)/tags),200)
 	@echo "Image already pushed to Harbor: $(DOCKER_TEST_IMAGE)"
 else
+	-docker rmi h2ogpt-base
+	DOCKER_BUILDKIT=1 docker build -t h2ogpt-base -f Dockerfile-base .
 	DOCKER_BUILDKIT=1 docker build -t $(DOCKER_TEST_IMAGE) -f Dockerfile .
 	docker push $(DOCKER_TEST_IMAGE)
 endif

--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,11 @@ build_info.txt:
 
 # Deprecated for now, no 0.4.1 on pypi, use release binary wheel that has no CUDA errors anymore
 docker_build_deps:
+	-docker rmi h2ogpt-base
+	DOCKER_BUILDKIT=1 docker build -t h2ogpt-base -f Dockerfile-base .
 	@rm -rf Dockerfile_deps
 	@sed '/# Install prebuilt dependencies/,$$d' Dockerfile > Dockerfile_deps
+	@sed -i "s/as stage0//g" Dockerfile_deps
 	@docker build -t h2ogpt-deps-builder -f Dockerfile_deps .
 	@docker run \
 		--rm -it --entrypoint bash --runtime nvidia -v `pwd`:/dot \

--- a/docs/README_DOCKER.md
+++ b/docs/README_DOCKER.md
@@ -145,7 +145,7 @@ docker run \
     -e TRANSFORMERS_CACHE="/.cache/" \
     -p 5000:5000 \
     --rm --init \
-    --entrypoint /h2ogpt_conda/envs/vllm/bin/python3.10 \
+    --entrypoint /h2ogpt_conda/vllm_env/bin/python3.10 \
     -e NCCL_IGNORE_DISABLED_P2P=1 \
     -v /etc/passwd:/etc/passwd:ro \
     -v /etc/group:/etc/group:ro \

--- a/helm/h2ogpt-chart/templates/deployment.yaml
+++ b/helm/h2ogpt-chart/templates/deployment.yaml
@@ -296,7 +296,7 @@ spec:
             {{- toYaml .Values.vllm.securityContext | nindent 12 }}
           image: "{{ .Values.vllm.image.repository }}:{{ .Values.vllm.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.vllm.image.pullPolicy }}
-          command: ["/h2ogpt_conda/envs/vllm/bin/python3.10"]
+          command: ["/h2ogpt_conda/vllm_env/bin/python3.10"]
           args: 
             - "-m" 
             - "vllm.entrypoints.openai.api_server"

--- a/tests/test_inference_servers.py
+++ b/tests/test_inference_servers.py
@@ -232,7 +232,7 @@ def run_vllm_docker(inf_port, base_model, tokenizer=None):
               '-e', 'HUGGING_FACE_HUB_TOKEN=%s' % os.environ['HUGGING_FACE_HUB_TOKEN'],
               '-e', 'TRANSFORMERS_CACHE="/.cache/"',
               '-p', '%s:5000' % inf_port,
-              '--entrypoint', '/h2ogpt_conda/envs/vllm/bin/python3.10',
+              '--entrypoint', '/h2ogpt_conda/vllm_env/bin/python3.10',
               '-e', 'NCCL_IGNORE_DISABLED_P2P=1',
               '-v', '/etc/passwd:/etc/passwd:ro',
               '-v', '/etc/group:/etc/group:ro',


### PR DESCRIPTION
new image compared to official runtime to date:
```
harbor.h2o.ai/h2ogpt/test-image                           12e2874700679bab7bda6d5ab61a1795   1af054b005e8   40 minutes ago      20.5GB
gcr.io/vorvan/h2oai/h2ogpt-runtime                        0.1.0                              4c7dac53226f   5 days ago          49.8GB

```