### PR TITLE
Add softlink to preserve compatibility with old commands from docs and readme(s)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,9 @@ COPY --from=stage0 /h2ogpt_conda/ /h2ogpt_conda/
 COPY build_info.txt* /build_info.txt
 RUN touch /build_info.txt
 
+RUN mkdir -p /h2ogpt_conda/envs/vllm/bin && \
+    ln -s /h2ogpt_conda/vllm_env/bin/python3.10 /h2ogpt_conda/envs/vllm/bin/python3.10
+
 USER h2ogpt
 
 ENTRYPOINT ["python3.10"]


### PR DESCRIPTION
Both commands below should work in case using old doc:

![image](https://github.com/h2oai/h2ogpt/assets/51244975/2e43e949-c04d-4963-b689-7a0ba4d021b5)
