### PR TITLE
landing screens components re-ordered on mobile screens

### DIFF
--- a/gradio_utils/css.py
+++ b/gradio_utils/css.py
@@ -12,13 +12,28 @@ def get_css(kwargs) -> str:
 
 
 def make_css_base() -> str:
-    css1 = """
-        #col_container {margin-left: auto; margin-right: auto; text-align: left;}
-        """
-    return css1 + """
+    return """
+    #col_container {margin-left: auto; margin-right: auto; text-align: left;}
+
     @import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600&display=swap');
     
     body.dark{#warning {background-color: #555555};}
+    
+    #sidebar {
+        order: 1;
+        
+        @media (max-width: 463px) {
+          order: 2;
+        }
+    }
+    
+    #col-tabs {
+        order: 2;
+        
+        @media (max-width: 463px) {
+          order: 1;
+        }
+    }
     
     #small_btn {
         margin: 0.6em 0em 0.55em 0;

--- a/src/gradio_runner.py
+++ b/src/gradio_runner.py
@@ -591,9 +591,9 @@ def go_gradio(**kwargs):
                 df = pd.DataFrame(None)
             return df
 
-        normal_block = gr.Row(visible=not base_wanted, equal_height=False)
+        normal_block = gr.Row(visible=not base_wanted, equal_height=False, elem_id="col_container")
         with normal_block:
-            side_bar = gr.Column(elem_id="col_container", scale=1, min_width=100, visible=kwargs['visible_side_bar'])
+            side_bar = gr.Column(elem_id="sidebar", scale=1, min_width=100, visible=kwargs['visible_side_bar'])
             with side_bar:
                 with gr.Accordion("Chats", open=False, visible=True):
                     radio_chats = gr.Radio(value=None, label="Saved Chats", show_label=False,
@@ -664,7 +664,7 @@ def go_gradio(**kwargs):
                                                 visible=visible_doc_track)
                     text_file_last = gr.Textbox(lines=1, label="Newest Doc", value=None, visible=visible_doc_track)
                     text_viewable_doc_count = gr.Textbox(lines=2, label=None, visible=False)
-            col_tabs = gr.Column(elem_id="col_container", scale=10)
+            col_tabs = gr.Column(elem_id="col-tabs", scale=10)
             with col_tabs, gr.Tabs():
                 if kwargs['chat_tables']:
                     chat_tab = gr.Row(visible=True)


### PR DESCRIPTION
- landing screens components re-ordered on mobile screens
- the mobile screen width break point is consistent with observed gradio breakpoint - 463px
- the `col_container` element id was brought one level up so that both sidebar and tabs live inside it

### Mobile screens
<img width="513" alt="image" src="https://github.com/h2oai/h2ogpt/assets/18228330/9d0df64e-fb0f-46ba-8ca1-9190e1af81dc">

<img width="602" alt="image" src="https://github.com/h2oai/h2ogpt/assets/18228330/4e3f6e56-8a40-4ca7-9556-d5c6e6bf08db">

### Wide screens
<img width="1353" alt="image" src="https://github.com/h2oai/h2ogpt/assets/18228330/491f3c53-9182-47ed-bff2-4eb7d2ddd36c">
