### PR TITLE
header styling changed on mobile screen

### DIFF
--- a/gradio_utils/css.py
+++ b/gradio_utils/css.py
@@ -108,4 +108,38 @@ def make_css_base() -> str:
     #prompt-form > label > textarea {
         padding-right: 40px;
     }
+    
+    #header-links {
+        float: left;
+        justify-content: left;
+        height: 80px;
+        width: 195px;
+        margin-top: 0px;
+    }
+    
+    #main-logo {
+        display: flex;
+        justify-content: center;
+        margin-bottom: 30px;
+        margin-right: 330px;
+        
+        @media (max-width: 463px) {
+          justify-content: flex-end;
+          margin-right: 0;
+          margin-bottom: 0;
+        }
+    }
+    
+    #qr {
+        @media (min-width: 464px) {
+            float: right;
+            height: 80px;
+            width: 80px;
+            margin-top: -100px
+        }
+        
+        @media (max-width: 463px) {
+          display: none;
+        }
+    }
     """

--- a/src/gradio_themes.py
+++ b/src/gradio_themes.py
@@ -204,17 +204,18 @@ h2o_logo = '<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/
 
 def get_h2o_title(title, description):
     # NOTE: Check full width desktop, smallest width browser desktop, iPhone browsers to ensure no overlap etc.
-    return f"""<div style="float:left; justify-content:left; height: 80px; width: 195px; margin-top:0px">
-                    {description}
-                </div>
-                <div style="display:flex; justify-content:center; margin-bottom:30px; margin-right:330px;">
-                    <div style="height: 60px; width: 60px; margin-right:20px;">{h2o_logo}</div>
-                    <h1 style="line-height:60px">{title}</h1>
-                </div>
-                <div style="float:right; height: 80px; width: 80px; margin-top:-100px">
-                    <img src="https://raw.githubusercontent.com/h2oai/h2ogpt/main/docs/h2o-qr.png">
-                </div>
-                """
+    return f"""
+    <div id="header-links">
+        {description}
+    </div>
+    <div id="main-logo">
+        <div style="height: 60px; width: 60px; margin-right:20px;">{h2o_logo}</div>
+        <h1 style="line-height:60px">{title}</h1>
+    </div>
+    <div id="qr">
+        <img src="https://raw.githubusercontent.com/h2oai/h2ogpt/main/docs/h2o-qr.png">
+    </div>
+"""
 
 
 def get_simple_title(title, description):


### PR DESCRIPTION
- header styling changed on mobile screen
- the qr code is hidden on mobile screen

### mobile screens
<img width="443" alt="image" src="https://github.com/h2oai/h2ogpt/assets/18228330/be1c8c3b-a7ec-491b-ab24-b9d8f0ca4883">


### wide screens
<img width="1714" alt="image" src="https://github.com/h2oai/h2ogpt/assets/18228330/58a203b7-cd3f-4668-8378-3f48331f6242">
