### PR TITLE
prompt area and upload button adjusted for mobile screens

### DIFF
--- a/gradio_utils/css.py
+++ b/gradio_utils/css.py
@@ -110,15 +110,11 @@ def make_css_base() -> str:
     }
     
     #prompt-form > label > textarea {
-        padding-right: 100px;
+        padding-right: 104px;
         
         @media (max-width: 463px) {
-          height: 94px;
+          min-height: 94px;
           padding-right: 70px;
-        }
-        
-        @media (max-width: 1040px) {
-          height: 58px;
         }
     }
     

--- a/gradio_utils/css.py
+++ b/gradio_utils/css.py
@@ -99,6 +99,10 @@ def make_css_base() -> str:
         display: flex;
         justify-content: center;
         border: 1px solid var(--primary-500) !important;
+        
+        @media (max-width: 463px) {
+          width: 56px;
+        }
     }
     
     #attach-button > img {
@@ -106,7 +110,16 @@ def make_css_base() -> str:
     }
     
     #prompt-form > label > textarea {
-        padding-right: 40px;
+        padding-right: 100px;
+        
+        @media (max-width: 463px) {
+          height: 94px;
+          padding-right: 70px;
+        }
+        
+        @media (max-width: 1040px) {
+          height: 58px;
+        }
     }
     
     #header-links {


### PR DESCRIPTION
- prompt area and upload button adjusted for mobile screens
- upload button is smaller on mobile screens
- default prompt textarea padding increased so that the text does not flow under the upload button

### mobile - 0px - 463px
<img width="422" alt="image" src="https://github.com/h2oai/h2ogpt/assets/18228330/249f73d2-150c-4877-9f5e-12b2ed3628fa">

<img width="408" alt="image" src="https://github.com/h2oai/h2ogpt/assets/18228330/9cb1a108-d14b-401a-9b85-5a67bc2f6f7b">

### wide screens
<img width="1716" alt="image" src="https://github.com/h2oai/h2ogpt/assets/18228330/41e0a842-437b-473f-abcb-6d2cec348640">

