### PR TITLE
visible models don't have the remove-all button

### DIFF
--- a/gradio_utils/css.py
+++ b/gradio_utils/css.py
@@ -155,4 +155,13 @@ def make_css_base() -> str:
     #visible-models > label > div.wrap > div.wrap-inner > div.secondary-wrap > div.remove-all {
         display: none !important;
     }
+    
+    #visible-models > label > div.wrap > div.wrap-inner > div.secondary-wrap::before {
+        content: "Select: ";
+        border: 1px solid var(--primary-500);
+        border-radius: var(--block-label-radius);
+        background-color: var(--primary-500);
+        padding: 0 4px;
+        margin-right: 2px;
+    }
     """

--- a/gradio_utils/css.py
+++ b/gradio_utils/css.py
@@ -151,4 +151,8 @@ def make_css_base() -> str:
           display: none;
         }
     }
+
+    #visible-models > label > div.wrap > div.wrap-inner > div.secondary-wrap > div.remove-all {
+        display: none !important;
+    }
     """

--- a/gradio_utils/css.py
+++ b/gradio_utils/css.py
@@ -156,11 +156,12 @@ def make_css_base() -> str:
         display: none !important;
     }
     
+    #visible-models > label > div.wrap > div.wrap-inner > div.token {
+        display: none !important;
+    }
+    
     #visible-models > label > div.wrap > div.wrap-inner > div.secondary-wrap::before {
         content: "Select: ";
-        border: 1px solid var(--primary-500);
-        border-radius: var(--block-label-radius);
-        background-color: var(--primary-500);
         padding: 0 4px;
         margin-right: 2px;
     }

--- a/src/gradio_runner.py
+++ b/src/gradio_runner.py
@@ -741,17 +741,14 @@ def go_gradio(**kwargs):
                                                    len(model_states) > 1 and \
                                                    kwargs['visible_visible_models']
                             with gr.Row(visible=visible_model_choice):
-                                with gr.Column(scale=1):
-                                    with gr.Accordion("Select Visible Models", open=False):
-                                        visible_models = gr.Dropdown(kwargs['all_models'],
-                                                                     label="Visible Models",
-                                                                     value=visible_models_state0,
-                                                                     interactive=True,
-                                                                     multiselect=True,
-                                                                     visible=visible_model_choice,
-                                                                     )
-                                with gr.Column(scale=3):
-                                    pass
+                                visible_models = gr.Dropdown(kwargs['all_models'],
+                                                             label="Visible Models",
+                                                             value=visible_models_state0,
+                                                             interactive=True,
+                                                             multiselect=True,
+                                                             visible=visible_model_choice,
+                                                             elem_id="visible-models",
+                                                             )
 
                             text_output, text_output2, text_outputs = make_chatbots(output_label0, output_label0_model2,
                                                                                     **kwargs)


### PR DESCRIPTION
- visible models:
  - are no longer in the accordion
  - don't have the remove-all button
  - contain "Select: " before the input part

<img width="1101" alt="image" src="https://github.com/h2oai/h2ogpt/assets/18228330/dbef1401-2fbb-49c0-9914-67407eb9041e">

