### PR TITLE
Build duckdb using manylinux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: clean dist
 
 PACKAGE_VERSION       := `cat version.txt | tr -d '\n'`
-BUILD_TAG_FILES       := docker_build_script_ubuntu.sh requirements.txt Dockerfile `ls reqs_optional/*.txt | sort`
+BUILD_TAG_FILES       := $(shell git describe --always --dirty)
 BUILD_TAG             := $(shell md5sum $(BUILD_TAG_FILES) 2> /dev/null | sort | md5sum | cut -d' ' -f1)
 DOCKER_TEST_IMAGE     := harbor.h2o.ai/h2ogpt/test-image:$(BUILD_TAG)
 PYTHON_BINARY         ?= `which python`

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ docker_build_deps:
 	@sed -i '/# Install prebuilt dependencies/,$$d' docker_build_script_ubuntu.sh
 	@docker build -t h2ogpt-deps-builder -f Dockerfile .
 	@mv docker_build_script_ubuntu.sh.back docker_build_script_ubuntu.sh
+	@mkdir -p prebuilt_deps
 	@docker run \
 		--rm \
 		-it \
@@ -69,12 +70,9 @@ docker_build_deps:
 		--rm \
 		-it \
 		--entrypoint bash \
-		--runtime nvidia \
 		-v `pwd`:/dot \
-		-v /etc/passwd:/etc/passwd:ro \
-		-v /etc/group:/etc/group:ro \
-		-u `id -u`:`id -g` \
-		h2ogpt-deps-builder -c " \
+		quay.io/pypa/manylinux2014_x86_64 -c " \
+			ln -s /usr/local/bin/python3.10 /usr/local/bin/python3 && cd /tmp && \
 			git clone https://github.com/h2oai/duckdb.git && \
 			cd duckdb && \
 			git checkout dcd8c1ffc53dd020623630efb99ba6a3a4cbc5ad && \


### PR DESCRIPTION
Address https://github.com/h2oai/h2ogpt/issues/826

![image](https://github.com/h2oai/h2ogpt/assets/51244975/315bc704-f99b-4caf-919c-9d78fd793433)

old build:
```
root@mr-0xm4:~# ldd /h2ogpt_conda/lib/python3.10/site-packages/duckdb/duckdb.cpython-310-x86_64-linux-gnu.so
	linux-vdso.so.1 (0x00007ffe587e5000)
	libstdc++.so.6 => /h2ogpt_conda/lib/libstdc++.so.6 (0x00007f6daa9e4000)
	libm.so.6 => /usr/lib/x86_64-linux-gnu/libm.so.6 (0x00007f6daa886000)
	libgcc_s.so.1 => /h2ogpt_conda/lib/libgcc_s.so.1 (0x00007f6daa86b000)
	libpthread.so.0 => /usr/lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f6daa848000)
	libc.so.6 => /usr/lib/x86_64-linux-gnu/libc.so.6 (0x00007f6daa656000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f6dad7a9000)
```
vs original lib:
```
h2ogpt@3a05129bb375:~$ ldd /h2ogpt_conda/lib/python3.10/site-packages/duckdb.cpython-310-x86_64-linux-gnu.so 
	linux-vdso.so.1 (0x00007fffe199d000)
	libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007faab8d87000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007faab8c38000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007faab8c1d000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007faab8bfa000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007faab8a08000)
	/lib64/ld-linux-x86-64.so.2 (0x00007faabba74000)
```

don't need to pin to conda's libc version, can use manylinux to pick an old compatible libc.

Notice that issue can be reproduced easily when running the below from the docker image:
```
import chromadb
import duckdb
```
but not reproducible when importing duckdb early on in the code with:
```
import duckdb
```