### PR TITLE
Chore: Add printing Makefile variables

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -53,3 +53,6 @@ test: copy_files_from_h2ogpt
 .PHONY: build
 build: copy_files_from_h2ogpt
 	$(POETRY_BIN) build
+
+print-%:
+	@echo $($*)


### PR DESCRIPTION
- Needed for the Jenkins pipeline that pushes the nightly builds for h2ogpt client to S3