### PR TITLE
Improve timeout via max_time in UI/API

### DIFF
--- a/gradio_utils/grclient.py
+++ b/gradio_utils/grclient.py
@@ -1,11 +1,23 @@
+from __future__ import annotations
 import traceback
-from typing import Callable
+import concurrent.futures
 import os
-
-from gradio_client.client import Job
+import concurrent.futures
+import time
+import urllib.parse
+import uuid
+from pathlib import Path
+from typing import Callable
 
 os.environ['HF_HUB_DISABLE_TELEMETRY'] = '1'
 
+from huggingface_hub import SpaceStage
+from huggingface_hub.utils import (
+    build_hf_headers,
+)
+
+from gradio_client import utils
+from gradio_client.client import Job, DEFAULT_TEMP_DIR, Endpoint
 from gradio_client import Client
 
 
@@ -15,13 +27,108 @@ class GradioClient(Client):
     To handle automatically refreshing client if detect gradio server changed
     """
 
-    def __init__(self, *args, **kwargs):
-        self.args = args
-        self.kwargs = kwargs
-        super().__init__(*args, **kwargs)
+    def __init__(
+            self,
+            src: str,
+            hf_token: str | None = None,
+            max_workers: int = 40,
+            serialize: bool = True,
+            output_dir: str | Path | None = DEFAULT_TEMP_DIR,
+            verbose: bool = True,
+    ):
+        """
+        Parameters:
+            src: Either the name of the Hugging Face Space to load, (e.g. "abidlabs/whisper-large-v2") or the full URL (including "http" or "https") of the hosted Gradio app to load (e.g. "http://mydomain.com/app" or "https://bec81a83-5b5c-471e.gradio.live/").
+            hf_token: The Hugging Face token to use to access private Spaces. Automatically fetched if you are logged in via the Hugging Face Hub CLI. Obtain from: https://huggingface.co/settings/token
+            max_workers: The maximum number of thread workers that can be used to make requests to the remote Gradio app simultaneously.
+            serialize: Whether the client should serialize the inputs and deserialize the outputs of the remote API. If set to False, the client will pass the inputs and outputs as-is, without serializing/deserializing them. E.g. you if you set this to False, you'd submit an image in base64 format instead of a filepath, and you'd get back an image in base64 format from the remote API instead of a filepath.
+            output_dir: The directory to save files that are downloaded from the remote API. If None, reads from the GRADIO_TEMP_DIR environment variable. Defaults to a temporary directory on your machine.
+            verbose: Whether the client should print statements to the console.
+        """
+        self.args = tuple([src])
+        self.kwargs = dict(hf_token=hf_token, max_workers=max_workers, serialize=serialize, output_dir=output_dir,
+                           verbose=verbose)
+
+        self.verbose = verbose
+        self.hf_token = hf_token
+        self.serialize = serialize
+        self.space_id = None
+        self.output_dir = output_dir
+        self.max_workers = max_workers
+        self.src = src
+        self.config = None
+        self.server_hash = None
+
+    def __repr__(self):
+        if self.config:
+            return self.view_api(print_info=False, return_format="str")
+        return "Not setup for %s" % self.src
+
+    def __str__(self):
+        if self.config:
+            return self.view_api(print_info=False, return_format="str")
+        return "Not setup for %s" % self.src
+
+    def setup(self):
+        src = self.src
+
+        self.headers = build_hf_headers(
+            token=self.hf_token,
+            library_name="gradio_client",
+            library_version=utils.__version__,
+        )
+        if src.startswith("http://") or src.startswith("https://"):
+            _src = src if src.endswith("/") else src + "/"
+        else:
+            _src = self._space_name_to_src(src)
+            if _src is None:
+                raise ValueError(
+                    f"Could not find Space: {src}. If it is a private Space, please provide an hf_token."
+                )
+            self.space_id = src
+        self.src = _src
+        state = self._get_space_state()
+        if state == SpaceStage.BUILDING:
+            if self.verbose:
+                print("Space is still building. Please wait...")
+            while self._get_space_state() == SpaceStage.BUILDING:
+                time.sleep(2)  # so we don't get rate limited by the API
+                pass
+        if state in utils.INVALID_RUNTIME:
+            raise ValueError(
+                f"The current space is in the invalid state: {state}. "
+                "Please contact the owner to fix this."
+            )
+        if self.verbose:
+            print(f"Loaded as API: {self.src} ✔")
+
+        self.api_url = urllib.parse.urljoin(self.src, utils.API_URL)
+        self.ws_url = urllib.parse.urljoin(
+            self.src.replace("http", "ws", 1), utils.WS_URL
+        )
+        self.upload_url = urllib.parse.urljoin(self.src, utils.UPLOAD_URL)
+        self.reset_url = urllib.parse.urljoin(self.src, utils.RESET_URL)
+        self.config = self._get_config()
+        self.session_hash = str(uuid.uuid4())
+
+        self.endpoints = [
+            Endpoint(self, fn_index, dependency)
+            for fn_index, dependency in enumerate(self.config["dependencies"])
+        ]
+
+        # Create a pool of threads to handle the requests
+        self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.max_workers)
+
+        # Disable telemetry by setting the env variable HF_HUB_DISABLE_TELEMETRY=1
+        # threading.Thread(target=self._telemetry_thread).start()
+
         self.server_hash = self.get_server_hash()
 
+        return self
+
     def get_server_hash(self):
+        if self.config is None:
+            self.setup()
         """
         Get server hash using super without any refresh action triggered
         Returns: git hash of gradio server
@@ -29,6 +136,8 @@ class GradioClient(Client):
         return super().submit(api_name='/system_hash').result()
 
     def refresh_client_if_should(self):
+        if self.config is None:
+            self.setup()
         # get current hash in order to update api_name -> fn_index map in case gradio server changed
         # FIXME: Could add cli api as hash
         server_hash = self.get_server_hash()
@@ -44,6 +153,8 @@ class GradioClient(Client):
         Also ensure map between api_name and fn_index is updated in case server changed (e.g. restarted with new code)
         Returns:
         """
+        if self.config is None:
+            self.setup()
         # need session hash to be new every time, to avoid "generator already executing"
         self.reset_session()
 
@@ -51,13 +162,24 @@ class GradioClient(Client):
         for k, v in client.__dict__.items():
             setattr(self, k, v)
 
+    def clone(self):
+        if self.config is None:
+            self.setup()
+        client = GradioClient('')
+        for k, v in self.__dict__.items():
+            setattr(client, k, v)
+        client.reset_session()
+        return client
+
     def submit(
-        self,
-        *args,
-        api_name: str | None = None,
-        fn_index: int | None = None,
-        result_callbacks: Callable | list[Callable] | None = None,
+            self,
+            *args,
+            api_name: str | None = None,
+            fn_index: int | None = None,
+            result_callbacks: Callable | list[Callable] | None = None,
     ) -> Job:
+        if self.config is None:
+            self.setup()
         # Note predict calls submit
         try:
             self.refresh_client_if_should()
@@ -77,6 +199,7 @@ class GradioClient(Client):
             job = super().submit(*args, api_name=api_name, fn_index=fn_index)
             e2 = job.future._exception
             if e2 is not None:
-                print("GR job failed again: %s\n%s" % (str(e2), ''.join(traceback.format_tb(e2.__traceback__))), flush=True)
+                print("GR job failed again: %s\n%s" % (str(e2), ''.join(traceback.format_tb(e2.__traceback__))),
+                      flush=True)
 
         return job

--- a/src/gen.py
+++ b/src/gen.py
@@ -2731,11 +2731,14 @@ def evaluate(
                         text += event_text  # append the text
                         response = prompter.get_response(prompt + text, prompt=prompt,
                                                          sanitize_bot_response=sanitize_bot_response)
+                        print(response, flush=True)
                         yield dict(response=response, sources=sources, save_dict=dict())
+                        print("time %s for %s" % (time.time() - tgen0, response), flush=True)
                         if time.time() - tgen0 > max_time:
                             if verbose:
                                 print("Took too long for OpenAI or VLLM: %s" % (time.time() - tgen0), flush=True)
                             break
+                    print("DONE time %s for %s" % (time.time() - tgen0, response), flush=True)
             elif inf_type == 'vllm_chat' or inference_server == 'openai_chat':
                 if system_prompt in [None, 'None', 'auto']:
                     openai_system_prompt = "You are a helpful assistant."

--- a/src/gen.py
+++ b/src/gen.py
@@ -2731,14 +2731,11 @@ def evaluate(
                         text += event_text  # append the text
                         response = prompter.get_response(prompt + text, prompt=prompt,
                                                          sanitize_bot_response=sanitize_bot_response)
-                        print(response, flush=True)
                         yield dict(response=response, sources=sources, save_dict=dict())
-                        print("time %s for %s" % (time.time() - tgen0, response), flush=True)
                         if time.time() - tgen0 > max_time:
                             if verbose:
                                 print("Took too long for OpenAI or VLLM: %s" % (time.time() - tgen0), flush=True)
                             break
-                    print("DONE time %s for %s" % (time.time() - tgen0, response), flush=True)
             elif inf_type == 'vllm_chat' or inference_server == 'openai_chat':
                 if system_prompt in [None, 'None', 'auto']:
                     openai_system_prompt = "You are a helpful assistant."

--- a/src/gen.py
+++ b/src/gen.py
@@ -2446,6 +2446,12 @@ def evaluate(
     if not context:
         context = ''
 
+    if num_beams == 1:
+        # NOTE!!!!!!!!!!  Choice of developer.  But only possible to force stream if num_beams=1
+        # stream if can, so can control task iteration and time of iteration
+        # not required, but helpful for max_time control etc.
+        stream_output = True
+
     # get prompter
     prompter = Prompter(prompt_type, prompt_dict, debug=debug, chat=chat, stream_output=stream_output,
                         system_prompt=system_prompt)
@@ -2718,6 +2724,7 @@ def evaluate(
                     yield dict(response=response, sources=sources, save_dict=dict())
                 else:
                     collected_events = []
+                    tgen0 = time.time()
                     for event in responses:
                         collected_events.append(event)  # save the event response
                         event_text = event['choices'][0]['text']  # extract the text
@@ -2725,6 +2732,10 @@ def evaluate(
                         response = prompter.get_response(prompt + text, prompt=prompt,
                                                          sanitize_bot_response=sanitize_bot_response)
                         yield dict(response=response, sources=sources, save_dict=dict())
+                        if time.time() - tgen0 > max_time:
+                            if verbose:
+                                print("Took too long for OpenAI or VLLM: %s" % (time.time() - tgen0), flush=True)
+                            break
             elif inf_type == 'vllm_chat' or inference_server == 'openai_chat':
                 if system_prompt in [None, 'None', 'auto']:
                     openai_system_prompt = "You are a helpful assistant."
@@ -2758,6 +2769,7 @@ def evaluate(
                                                      sanitize_bot_response=sanitize_bot_response)
                     yield dict(response=response, sources=sources, save_dict=dict())
                 else:
+                    tgen0 = time.time()
                     for chunk in responses:
                         delta = chunk["choices"][0]["delta"]
                         if 'content' in delta:
@@ -2765,6 +2777,10 @@ def evaluate(
                             response = prompter.get_response(prompt + text, prompt=prompt,
                                                              sanitize_bot_response=sanitize_bot_response)
                             yield dict(response=response, sources=sources, save_dict=dict())
+                        if time.time() - tgen0 > max_time:
+                            if verbose:
+                                print("Took too long for OpenAI or VLLM Chat: %s" % (time.time() - tgen0), flush=True)
+                            break
             else:
                 raise RuntimeError("No such OpenAI mode: %s" % inference_server)
         elif inference_server.startswith('http'):
@@ -2888,6 +2904,7 @@ def evaluate(
                     job = gr_client.submit(str(dict(client_kwargs)), api_name=api_name)
                     res_dict = dict(response=text, sources=sources, save_dict=dict())
                     text0 = ''
+                    tgen0 = time.time()
                     while not job.done():
                         if job.communicator.job.latest_status.code.name == 'FINISHED':
                             break
@@ -2915,6 +2932,10 @@ def evaluate(
                             # save old
                             text0 = response
                             yield dict(response=response, sources=sources, save_dict=dict())
+                            if time.time() - tgen0 > max_time:
+                                if verbose:
+                                    print("Took too long for Gradio: %s" % (time.time() - tgen0), flush=True)
+                                break
                         time.sleep(0.01)
                     # ensure get last output to avoid race
                     res_all = job.outputs()
@@ -2981,6 +3002,7 @@ def evaluate(
                                                      sanitize_bot_response=sanitize_bot_response)
                     yield dict(response=response, sources=sources, save_dict=dict())
                 else:
+                    tgen0 = time.time()
                     text = ""
                     for responses in hf_client.generate_stream(prompt, **gen_server_kwargs):
                         if not responses.token.special:
@@ -2991,6 +3013,10 @@ def evaluate(
                                                              sanitize_bot_response=sanitize_bot_response)
                             sources = ''
                             yield dict(response=response, sources=sources, save_dict=dict())
+                        if time.time() - tgen0 > max_time:
+                            if verbose:
+                                print("Took too long for TGI or VLLM: %s" % (time.time() - tgen0), flush=True)
+                            break
             else:
                 raise RuntimeError("Failed to get client: %s" % inference_server)
         else:
@@ -3137,6 +3163,7 @@ def evaluate(
                     ret = dict(response='', sources='', save_dict=dict())
                     outputs = ""
                     sources = ''
+                    tgen0 = time.time()
                     try:
                         for new_text in streamer:
                             if bucket.qsize() > 0 or thread.exc:
@@ -3148,6 +3175,10 @@ def evaluate(
                             ret = dict(response=response, sources=sources, save_dict=dict())
                             if stream_output:
                                 yield ret
+                            if time.time() - tgen0 > max_time:
+                                if verbose:
+                                    print("Took too long for Torch: %s" % (time.time() - tgen0), flush=True)
+                                break
                         if not stream_output:
                             yield ret
                     except BaseException:

--- a/src/gen.py
+++ b/src/gen.py
@@ -1553,7 +1553,7 @@ def get_client_from_inference_server(inference_server, base_model=None, raise_co
             print("GR Client Begin: %s %s" % (inference_server, base_model), flush=True)
             # first do sanity check if alive, else gradio client takes too long by default
             requests.get(inference_server, timeout=int(os.getenv('REQUEST_TIMEOUT', '30')))
-            gr_client = GradioClient(inference_server)
+            gr_client = GradioClient(inference_server).setup()
             print("GR Client End: %s" % inference_server, flush=True)
         except (OSError, ValueError) as e:
             # Occurs when wrong endpoint and should have been HF client, so don't hard raise, just move to HF
@@ -2788,7 +2788,7 @@ def evaluate(
             from gradio_utils.grclient import GradioClient
             from text_generation import Client as HFClient
             if isinstance(model, GradioClient):
-                gr_client = model
+                gr_client = model.clone()
                 hf_client = None
             elif isinstance(model, HFClient):
                 gr_client = None

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -1595,7 +1595,7 @@ def get_llm(use_openai_model=False,
         async_output = False  # FIXME: not implemented yet
         if model is None:
             # only used if didn't pass model in
-            assert tokenizer is None
+            assert tokenizer is None or isinstance(tokenizer, FakeTokenizer)
             prompt_type = 'human_bot'
             if model_name is None:
                 model_name = 'h2oai/h2ogpt-oasst1-512-12b'

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -3970,6 +3970,7 @@ Respond to prompt of Final Answer with your final high-quality bullet list answe
                 thread.start()
                 outputs = ""
                 output1_old = ''
+                res_dict = dict(prompt=query, response='', sources='', num_prompt_tokens=0)
                 try:
                     tgen0 = time.time()
                     for new_text in streamer:
@@ -3996,7 +3997,7 @@ Respond to prompt of Final Answer with your final high-quality bullet list answe
                                                             sanitize_bot_response=sanitize_bot_response)
                         else:
                             output1 = outputs
-                        res_dict = dict(prompt=prompt, response=output1, sources='', num_prompt_tokens=0)
+                        res_dict = dict(prompt=query, response=output1, sources='', num_prompt_tokens=0)
                         if output1 != output1_old:
                             yield res_dict
                             output1_old = output1
@@ -4004,6 +4005,8 @@ Respond to prompt of Final Answer with your final high-quality bullet list answe
                             if verbose:
                                 print("Took too long ETHread for %s %s: %s" % (model_name, langchain_action, time.time() - tgen0), flush=True)
                             break
+                    # yield if anything left over as can happen (FIXME: Understand better)
+                    yield res_dict
                 except BaseException:
                     # if any exception, raise that exception if was from thread, first
                     if thread.exc:

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -4003,7 +4003,7 @@ Respond to prompt of Final Answer with your final high-quality bullet list answe
                             output1_old = output1
                         if time.time() - tgen0 > max_time:
                             if verbose:
-                                print("Took too long ETHread for %s %s: %s" % (model_name, langchain_action, time.time() - tgen0), flush=True)
+                                print("Took too long EThread for %s %s: %s" % (model_name, langchain_action, time.time() - tgen0), flush=True)
                             break
                     # yield if anything left over as can happen (FIXME: Understand better)
                     yield res_dict

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -535,7 +535,7 @@ class GradioInference(H2Oagenerate, LLM):
                 from gradio_utils.grclient import GradioClient
                 values["client"] = GradioClient(
                     values["inference_server_url"]
-                )
+                ).setup()
         except ImportError:
             raise ImportError(
                 "Could not import gradio_client python package. "
@@ -1446,7 +1446,7 @@ def get_llm(use_openai_model=False,
         from gradio_utils.grclient import GradioClient
         from text_generation import Client as HFClient
         if isinstance(model, GradioClient):
-            gr_client = model
+            gr_client = model.clone()
             hf_client = None
         else:
             gr_client = None

--- a/src/gradio_runner.py
+++ b/src/gradio_runner.py
@@ -3245,7 +3245,6 @@ def go_gradio(**kwargs):
                             yield tuple(bots + [exceptions_str])
                         else:
                             yield bots[0], exceptions_str
-                    print("all_bot: %s %s" % (time.time() - tgen0, bots), flush=True)
                     if time.time() - tgen0 > max_time1 + 10:  # don't use actual, so inner has chance to complete
                         if verbose:
                             print("Took too long all_bot: %s" % (time.time() - tgen0), flush=True)
@@ -3271,7 +3270,6 @@ def go_gradio(**kwargs):
                 save_dict['h2ogpt_key'] = h2ogpt_key1
                 save_generate_output(**save_dict)
             # yield if anything left over as can happen (FIXME: Understand better)
-            print("DONE all_bot: %s %s" % (time.time() - tgen0, bots), flush=True)
             if len(bots) > 1:
                 yield tuple(bots + [exceptions_str])
             else:

--- a/src/gradio_runner.py
+++ b/src/gradio_runner.py
@@ -2661,13 +2661,14 @@ def go_gradio(**kwargs):
                             print("Took too long evaluate_nochat: %s" % (time.time() - tgen0), flush=True)
                         break
 
+                # yield if anything left over as can happen (FIXME: Understand better)
+                # return back last ret
+                yield ret
+
             finally:
                 clear_torch_cache()
                 clear_embeddings(user_kwargs['langchain_mode'], my_db_state1)
             save_generate_output(**save_dict)
-            # yield if anything left over as can happen (FIXME: Understand better)
-            # return back last ret
-            yield ret
 
         kwargs_evaluate_nochat = kwargs_evaluate.copy()
         # nominally never want sources appended for API calls, which is what nochat used for primarily

--- a/src/gradio_runner.py
+++ b/src/gradio_runner.py
@@ -3245,6 +3245,7 @@ def go_gradio(**kwargs):
                             yield tuple(bots + [exceptions_str])
                         else:
                             yield bots[0], exceptions_str
+                    print("all_bot: %s %s" % (time.time() - tgen0, bots), flush=True)
                     if time.time() - tgen0 > max_time1 + 10:  # don't use actual, so inner has chance to complete
                         if verbose:
                             print("Took too long all_bot: %s" % (time.time() - tgen0), flush=True)
@@ -3270,6 +3271,7 @@ def go_gradio(**kwargs):
                 save_dict['h2ogpt_key'] = h2ogpt_key1
                 save_generate_output(**save_dict)
             # yield if anything left over as can happen (FIXME: Understand better)
+            print("DONE all_bot: %s %s" % (time.time() - tgen0, bots), flush=True)
             if len(bots) > 1:
                 yield tuple(bots + [exceptions_str])
             else:

--- a/src/utils_langchain.py
+++ b/src/utils_langchain.py
@@ -52,7 +52,7 @@ class StreamingGradioCallbackHandler(BaseCallbackHandler):
 
     def on_llm_new_token(self, token: str, **kwargs: Any) -> None:
         """Run on new LLM token. Only available when streaming is enabled."""
-        if self.tgen0 is not None and (time.time() - self.tgen0) > self.max_time:
+        if self.tgen0 is not None and self.max_time is not None and (time.time() - self.tgen0) > self.max_time:
             if self.verbose:
                 print("Took too long in StreamingGradioCallbackHandler: %s" % (time.time() - self.tgen0), flush=True)
             self.text_queue.put(self.stop_signal)

--- a/tests/test_client_calls.py
+++ b/tests/test_client_calls.py
@@ -1551,6 +1551,29 @@ def test_client_chat_stream_langchain_openai_embeddings():
     assert got_embedding
 
 
+@pytest.mark.parametrize("stream_output", [True, False])
+@pytest.mark.need_tokens
+@wrap_test_forked
+def test_client_clone(stream_output):
+    base_model = 'h2oai/h2ogpt-4096-llama2-7b-chat'
+    from src.gen import main
+    main(base_model=base_model, block_gradio_exit=False, verbose=True)
+
+    from gradio_utils.grclient import GradioClient
+    client1 = GradioClient(get_inf_server())
+    client1.setup()
+    client2 = client1.clone()
+
+    for client in [client1, client2]:
+        prompt = "Who are you?"
+        kwargs = dict(stream_output=stream_output, instruction=prompt)
+        res_dict, client = run_client_gen(client, prompt, None, kwargs)
+        response = res_dict['response']
+        assert len(response) > 0
+        sources = res_dict['sources']
+        assert sources == ''
+
+
 @pytest.mark.parametrize("max_time", [1, 5])
 @pytest.mark.parametrize("stream_output", [True, False])
 @pytest.mark.need_tokens

--- a/tests/test_client_calls.py
+++ b/tests/test_client_calls.py
@@ -1551,6 +1551,81 @@ def test_client_chat_stream_langchain_openai_embeddings():
     assert got_embedding
 
 
+@pytest.mark.parametrize("max_time", [1, 5])
+@pytest.mark.parametrize("stream_output", [True, False])
+@pytest.mark.need_tokens
+@wrap_test_forked
+def test_client_timeout(stream_output, max_time):
+    base_model = 'h2oai/h2ogpt-4096-llama2-7b-chat'
+    from src.gen import main
+    main(base_model=base_model, block_gradio_exit=False, verbose=True)
+
+    # PURE client code
+    from gradio_client import Client
+    client = Client(get_inf_server())
+
+    prompt = "Tell a very long kid's story about birds"
+    kwargs = dict(stream_output=stream_output, instruction=prompt, max_time=max_time)
+    t0 = time.time()
+    res_dict, client = run_client_gen(client, prompt, None, kwargs)
+    response = res_dict['response']
+    assert len(response) > 0
+    assert time.time() - t0 < max_time * 2
+    sources = res_dict['sources']
+    assert sources == ''
+
+    # get file for client to upload
+    url = 'https://cdn.openai.com/papers/whisper.pdf'
+    test_file1 = os.path.join('/tmp/', 'my_test_pdf.pdf')
+    download_simple(url, dest=test_file1)
+
+    # PURE client code
+    from gradio_client import Client
+    client = Client(get_inf_server())
+
+    # upload file(s).  Can be list or single file
+    test_file_local, test_file_server = client.predict(test_file1, api_name='/upload_api')
+
+    chunk = True
+    chunk_size = 512
+    langchain_mode = 'MyData'
+    h2ogpt_key = ''
+    res = client.predict(test_file_server,
+                         langchain_mode, chunk, chunk_size, True,
+                         None, None, None, None,
+                         h2ogpt_key,
+                         api_name='/add_file_api')
+    assert res[0] is None
+    assert res[1] == langchain_mode
+    assert os.path.basename(test_file_server) in res[2]
+    assert res[3] == ''
+
+    # ask for summary, need to use same client if using MyData
+    api_name = '/submit_nochat_api'  # NOTE: like submit_nochat but stable API for string dict passing
+    instruction = "Give a very long detailed step-by-step description of what is Whisper paper about."
+    kwargs = dict(langchain_mode=langchain_mode,
+                  langchain_action="Query",
+                  top_k_docs=4,
+                  document_subset='Relevant',
+                  document_choice=DocumentChoice.ALL.value,
+                  max_new_tokens=1024,
+                  max_time=max_time,
+                  do_sample=False,
+                  stream_output=stream_output,
+                  )
+    t0 = time.time()
+    res_dict, client = run_client_gen(client, instruction, None, kwargs)
+    response = res_dict['response']
+    assert len(response) > 0
+    # assert len(response) < max_time * 20  # 20 tokens/sec
+    assert time.time() - t0 < max_time * 2
+    sources = [x['source'] for x in res_dict['sources']]
+    # only get source not empty list if break in inner loop, not gradio_runner loop, so good test of that too
+    # this is why gradio timeout adds 10 seconds, to give inner a chance to produce references or other final info
+    assert 'my_test_pdf.pdf' in sources[0]
+
+
+
 # pip install pytest-timeout
 # HOST=http://192.168.1.46:9999 STRESS=1 pytest -s -v -n 8 --timeout=1000 tests/test_client_calls.py::test_client_chat_stream_langchain_fake_embeddings_stress 2> stress1.log
 @pytest.mark.skipif(not os.getenv('STRESS'), reason="Only for stress testing already-running server")


### PR DESCRIPTION
- [x] Improve timeout via max_time in UI/API, but give inner non-gradio part chance by 10s to can complete meta stuff like references if can.
- [x] Force streaming if num_beams=1 always, so can control timeout and handling of yields
- [x] Avoid gradio hash race by starting with setup'ed version, but every use is a clone() with new hash, so ensure not racing in same object when streaming etc.  Required avoiding heavy setup in gradio client, moved to setup(), but now have more work to maintain when gradio_client itself updates.  But only __init__ needs work.
- [x] Speed-up streaming if all_bot() only has 1 model.  Timeoutiterator, required for multi-view, leads to slower results due to thread switching.  Unable to resolve to make faster
- [x] Noticed slower than could be for 7b llama-2 due to https://github.com/gradio-app/gradio/issues/5914 even for bot() and evaluate_nochat()
- [x] More improvements for streaming, don't yield if nothing there, had bug in comparison.  Also, ensure yield at end in case got one last part in final check of generator but happen to also include stop in it too.
- [x] yield before finally that does clear torch cache etc.
- [x] test timeout and clone client