### PR TITLE
Add gputil python package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,9 @@ else
 	docker push $(DOCKER_TEST_IMAGE)
 endif
 
+just_docker_build: build_info.txt
+	DOCKER_BUILDKIT=1 docker build -t $(DOCKER_TEST_IMAGE) -f Dockerfile .
+
 docker_build_runner: docker_build
 	-docker pull $(DOCKER_TEST_IMAGE)
 	docker tag $(DOCKER_TEST_IMAGE) gcr.io/vorvan/h2oai/h2ogpt-runtime:$(BUILD_TAG)

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,6 +66,9 @@ text-generation==0.6.0
 # for tokenization when don't have HF tokenizer
 tiktoken==0.4.0
 
+# for rayWorker in vllm to run as non-root
+gputil==1.4.0
+
 requests>=2.31.0
 urllib3>=1.26.16
 filelock>=3.12.2


### PR DESCRIPTION
Add gputil to python requirements so vllm starts properly even when not running as root.
