### PR TITLE
Implement HYDE

### DIFF
--- a/client/h2ogpt_client/_core.py
+++ b/client/h2ogpt_client/_core.py
@@ -90,6 +90,8 @@ class TextCompletionCreator:
         max_input_tokens: int = None,
         docs_token_handling: str = None,
         docs_joiner: str = None,
+        hyde_level: int = 0,
+        hyde_template: str = None,
     ) -> "TextCompletion":
         """
         Creates a new text completion.
@@ -132,6 +134,14 @@ class TextCompletionCreator:
                                                                          or top_k_docs original document chunks summarization
                                     None or 'split_or_merge' means same as 'chunk' for query, while for summarization merges documents to fill up to max_input_tokens or model_max_len tokens
         :param docs_joiner: string to join lists of text when doing split_or_merge.  None means '\n\n'
+        :param hyde_level: HYDE level for HYDE approach (https://arxiv.org/abs/2212.10496)
+                     0: No HYDE
+                     1: Use non-document-based LLM response and original query for embedding query
+                     2: Use document-based LLM response and original query for embedding query
+                     3+: Continue iterations of embedding prior answer and getting new response
+        :param hyde_template:
+                     None, 'None', 'auto' uses internal value and enable
+                     '{query}' is minimal template one can pass
         """
         params = _utils.to_h2ogpt_params(locals().copy())
         params["instruction"] = ""  # empty when chat_mode is False
@@ -169,6 +179,8 @@ class TextCompletionCreator:
         params["max_input_tokens"] = max_input_tokens
         params["docs_token_handling"] = docs_token_handling
         params["docs_joiner"] = docs_joiner
+        params["hyde_level"] = hyde_level
+        params["hyde_template"] = hyde_template
         return TextCompletion(self._client, params)
 
 
@@ -249,6 +261,8 @@ class ChatCompletionCreator:
         max_input_tokens: int = None,
         docs_token_handling: str = None,
         docs_joiner: str = None,
+        hyde_level: int = None,
+        hyde_template: str = None,
     ) -> "ChatCompletion":
         """
         Creates a new chat completion.
@@ -289,6 +303,14 @@ class ChatCompletionCreator:
                                                                          or top_k_docs original document chunks summarization
                                     None or 'split_or_merge' means same as 'chunk' for query, while for summarization merges documents to fill up to max_input_tokens or model_max_len tokens
         :param docs_joiner: string to join lists of text when doing split_or_merge.  None means '\n\n'
+        :param hyde_level: HYDE level for HYDE approach (https://arxiv.org/abs/2212.10496)
+                     0: No HYDE
+                     1: Use non-document-based LLM response and original query for embedding query
+                     2: Use document-based LLM response and original query for embedding query
+                     3+: Continue iterations of embedding prior answer and getting new response
+        :param hyde_template:
+                     None, 'None', 'auto' uses internal value and enable
+                     '{query}' is minimal template one can pass
         """
         params = _utils.to_h2ogpt_params(locals().copy())
         params["instruction"] = None  # future prompts
@@ -327,6 +349,8 @@ class ChatCompletionCreator:
         params["max_input_tokens"] = max_input_tokens
         params["docs_token_handling"] = docs_token_handling
         params["docs_joiner"] = docs_joiner
+        params["hyde_level"] = hyde_level
+        params["hyde_template"] = hyde_template
         params["chatbot"] = []  # chat history (FIXME: Only works if 1 model?)
         return ChatCompletion(self._client, params)
 

--- a/client/h2ogpt_client/_utils.py
+++ b/client/h2ogpt_client/_utils.py
@@ -51,6 +51,8 @@ H2OGPT_PARAMETERS_TO_CLIENT = collections.OrderedDict(
     max_input_tokens="max_input_tokens",
     docs_token_handling="docs_token_handling",
     docs_joiner="docs_joiner",
+    hyde_level="hyde_level",
+    hyde_template="hyde_template",
 )
 
 

--- a/docker_build_script_ubuntu.sh
+++ b/docker_build_script_ubuntu.sh
@@ -108,16 +108,16 @@ sp=`python3.10 -c 'import site; print(site.getsitepackages()[0])'` && \
     sed -i 's/posthog\.capture/return\n            posthog.capture/' $sp/chromadb/telemetry/posthog.py && \
     cd $sp && \
     sed -i  's/with HiddenPrints():/if True:/g' langchain/utilities/serpapi.py && \
-    rm -rf openai_vllm* && \
-    cp -a openai openai_vllm && \
+    rm -rf openvllm* && \
+    cp -a openai openvllm && \
     file0=`ls|grep openai|grep dist-info` && \
-    file1=`echo $file0|sed 's/openai-/openai_vllm-/g'` && \
+    file1=`echo $file0|sed 's/openai-/openvllm-/g'` && \
     cp -a $file0 $file1 && \
-    find openai_vllm -name '*.py' | xargs sed -i 's/from openai /from openai_vllm /g' && \
-    find openai_vllm -name '*.py' | xargs sed -i 's/openai\./openai_vllm./g' && \
-    find openai_vllm -name '*.py' | xargs sed -i 's/from openai\./from openai_vllm./g' && \
-    find openai_vllm -name '*.py' | xargs sed -i 's/import openai/import openai_vllm/g' && \
-    find openai_vllm -name '*.py' | xargs sed -i 's/OpenAI/vLLM/g' && \
+    find openvllm -name '*.py' | xargs sed -i 's/from openai /from openvllm /g' && \
+    find openvllm -name '*.py' | xargs sed -i 's/openai\./openvllm./g' && \
+    find openvllm -name '*.py' | xargs sed -i 's/from openai\./from openvllm./g' && \
+    find openvllm -name '*.py' | xargs sed -i 's/import openai/import openvllm/g' && \
+    find openvllm -name '*.py' | xargs sed -i 's/OpenAI/vLLM/g' && \
     cd /h2ogpt_conda && \
     python -m venv vllm_env --system-site-packages && \
     /h2ogpt_conda/vllm_env/bin/python -m pip install vllm ray pandas gputil==1.4.0 --extra-index-url https://download.pytorch.org/whl/cu118 && \

--- a/docs/README_InferenceServers.md
+++ b/docs/README_InferenceServers.md
@@ -227,16 +227,16 @@ conda install python=3.10 -y
 then ensure openai global key/base are not changed in race if used together:
 ```bash
 cd $HOME/miniconda3/envs/h2ogpt/lib/python3.10/site-packages/
-rm -rf openai_vllm*
-cp -a openai openai_vllm
+rm -rf openvllm*
+cp -a openai openvllm
 file0=`ls|grep openai|grep dist-info`
-file1=`echo $file0|sed 's/openai-/openai_vllm-/g'`
+file1=`echo $file0|sed 's/openai-/openvllm-/g'`
 cp -a $file0 $file1
-find openai_vllm -name '*.py' | xargs sed -i 's/from openai /from openai_vllm /g'
-find openai_vllm -name '*.py' | xargs sed -i 's/openai\./openai_vllm./g'
-find openai_vllm -name '*.py' | xargs sed -i 's/from openai\./from openai_vllm./g'
-find openai_vllm -name '*.py' | xargs sed -i 's/import openai/import openai_vllm/g'
-find openai_vllm -name '*.py' | xargs sed -i 's/OpenAI/vLLM/g'
+find openvllm -name '*.py' | xargs sed -i 's/from openai /from openvllm /g'
+find openvllm -name '*.py' | xargs sed -i 's/openai\./openvllm./g'
+find openvllm -name '*.py' | xargs sed -i 's/from openai\./from openvllm./g'
+find openvllm -name '*.py' | xargs sed -i 's/import openai/import openvllm/g'
+find openvllm -name '*.py' | xargs sed -i 's/OpenAI/vLLM/g'
 ```
 
 Assuming torch was installed with CUDA 11.7, and you have installed cuda locally in `/usr/local/cuda-11.7`, then can start in OpenAI compliant mode.  E.g. for LLaMa 65B on 2*A100 GPUs:

--- a/src/cli.py
+++ b/src/cli.py
@@ -44,6 +44,8 @@ def run_cli(  # for local function:
         max_input_tokens=None,
         docs_token_handling=None,
         docs_joiner=None,
+        hyde_level=None,
+        hyde_template=None,
         # for evaluate kwargs
         captions_model=None,
         caption_loader=None,

--- a/src/client_test.py
+++ b/src/client_test.py
@@ -141,7 +141,7 @@ def get_args(prompt, prompt_type=None, chat=False, stream_output=False,
                          max_input_tokens=None,
                          docs_token_handling=None,
                          docs_joiner=None,
-                         hyde_level=None,
+                         hyde_level=0,
                          hyde_template=None,
                          )
     diff = 0

--- a/src/client_test.py
+++ b/src/client_test.py
@@ -461,15 +461,16 @@ def run_client_nochat_gen(prompt, prompt_type, stream_output, max_new_tokens,
                             max_new_tokens=max_new_tokens, langchain_mode=langchain_mode,
                             langchain_action=langchain_action, langchain_agents=langchain_agents,
                             version=version, h2ogpt_key=h2ogpt_key)
-    return run_client_gen(client, prompt, args, kwargs)
+    return run_client_gen(client, kwargs)
 
 
-def run_client_gen(client, prompt, args, kwargs, do_md_to_text=True, verbose=False):
+def run_client_gen(client, kwargs, do_md_to_text=True):
     res_dict = kwargs
-    res_dict['prompt'] = prompt
+    res_dict['prompt'] = kwargs['instruction'] or kwargs['instruction_nochat']
     if not kwargs['stream_output']:
         res = client.predict(str(dict(kwargs)), api_name='/submit_nochat_api')
-        res_dict.update(ast.literal_eval(res))
+        res_dict1 = ast.literal_eval(res)
+        res_dict.update(res_dict1)
         print(md_to_text(res_dict['response'], do_md_to_text=do_md_to_text))
         return res_dict, client
     else:
@@ -478,14 +479,15 @@ def run_client_gen(client, prompt, args, kwargs, do_md_to_text=True, verbose=Fal
             outputs_list = job.communicator.job.outputs
             if outputs_list:
                 res = job.communicator.job.outputs[-1]
-                res_dict = ast.literal_eval(res)
-                print('Stream: %s' % res_dict['response'])
+                res_dict1 = ast.literal_eval(res)
+                print('Stream: %s' % res_dict1['response'])
             time.sleep(0.1)
         res_list = job.outputs()
         assert len(res_list) > 0, "No response, check server"
         res = res_list[-1]
-        res_dict = ast.literal_eval(res)
-        print('Final: %s' % res_dict['response'])
+        res_dict1 = ast.literal_eval(res)
+        print('Final: %s' % res_dict1['response'])
+        res_dict.update(res_dict1)
         return res_dict, client
 
 

--- a/src/client_test.py
+++ b/src/client_test.py
@@ -141,6 +141,8 @@ def get_args(prompt, prompt_type=None, chat=False, stream_output=False,
                          max_input_tokens=None,
                          docs_token_handling=None,
                          docs_joiner=None,
+                         hyde_level=None,
+                         hyde_template=None,
                          )
     diff = 0
     if version is None:

--- a/src/enums.py
+++ b/src/enums.py
@@ -260,3 +260,5 @@ docs_joiner_default = '\n\n'
 
 db_types = ['chroma', 'weaviate']
 db_types_full = ['chroma', 'weaviate', 'faiss']
+
+auto_choices = [None, 'None', 'auto']

--- a/src/eval.py
+++ b/src/eval.py
@@ -63,6 +63,8 @@ def run_eval(  # for local function:
         max_input_tokens=None,
         docs_token_handling=None,
         docs_joiner=None,
+        hyde_level=None,
+        hyde_template=None,
         # for evaluate kwargs:
         captions_model=None,
         caption_loader=None,

--- a/src/evaluate_params.py
+++ b/src/evaluate_params.py
@@ -59,6 +59,8 @@ eval_func_param_names = ['instruction',
                          'max_input_tokens',
                          'docs_token_handling',
                          'docs_joiner',
+                         'hyde_level',
+                         'hyde_template',
                          ]
 
 # form evaluate defaults for submit_nochat_api

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -4503,7 +4503,7 @@ def run_hyde(*args, **kwargs):
     if hyde_template in auto_choices:
         hyde_template = auto_hyde
     elif isinstance(hyde_template, str):
-        pass
+        assert '{query}' in hyde_template, "Require at least {query} in HYDE template, but got: %s" % hyde_template
     else:
         raise TypeError("Bad Type hyde_template=%s" % hyde_template)
 

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -4066,7 +4066,7 @@ Respond to prompt of Final Answer with your final high-quality bullet list answe
     assert not missing_kwargs, "Missing: %s" % missing_kwargs
 
     llm_answers = {}
-    if hyde_level > 0 and query_action and document_subset not in non_query_commands:
+    if hyde_level is not None and hyde_level > 0 and query_action and document_subset not in non_query_commands:
         query_embedding, llm_answers = yield from run_hyde(**locals())
         sim_kwargs['query_embedding'] = query_embedding
 

--- a/src/gradio_runner.py
+++ b/src/gradio_runner.py
@@ -1108,7 +1108,8 @@ def go_gradio(**kwargs):
                             visible=True)
                         docs_joiner = gr.Textbox(label="String to join lists and documents",
                                                  value=kwargs['docs_joiner'] or docs_joiner_default)
-                        hyde_level = gr.Slider(minimum=0, maximum=3, step=1,
+                        max_hyde_level = 0 if is_public else 5
+                        hyde_level = gr.Slider(minimum=0, maximum=max_hyde_level, step=1,
                                                value=kwargs['hyde_level'],
                                                label='HYDE level',
                                                info="Whether to use HYDE approach for LLM getting answer to embed (0=disabled, 1=non-doc LLM answer, 2=doc-based LLM answer)",

--- a/src/utils.py
+++ b/src/utils.py
@@ -1164,17 +1164,17 @@ only_playwright = os.environ.get("ONLY_PLAYWRIGHT", "0") == "1"
 
 def set_openai(inference_server):
     if inference_server.startswith('vllm'):
-        import openai_vllm
-        openai_vllm.api_key = "EMPTY"
+        import openvllm
+        openvllm.api_key = "EMPTY"
         inf_type = inference_server.split(':')[0].strip()
         ip_port_vllm = ':'.join(inference_server.split(':')[1:])
         if ip_port_vllm.startswith('https://') or ip_port_vllm.startswith('http://'):
-            openai_vllm.api_base = ip_port_vllm
+            openvllm.api_base = ip_port_vllm
         else:
             ip_vllm = inference_server.split(':')[1].strip()
             port_vllm = inference_server.split(':')[2].strip()
-            openai_vllm.api_base = f"http://{ip_vllm}:{port_vllm}/v1"
-        return openai_vllm, inf_type, None, None, None, openai_vllm.api_key
+            openvllm.api_base = f"http://{ip_vllm}:{port_vllm}/v1"
+        return openvllm, inf_type, None, None, None, openvllm.api_key
     else:
         import openai
         openai.api_key = os.getenv("OPENAI_API_KEY")

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -139,6 +139,8 @@ def run_eval1(cpu=False, bits=None, base_model='h2oai/h2ogpt-oig-oasst1-512-6_9b
                  'max_input_tokens': -1,
                  'docs_token_handling': None,
                  'docs_joiner': docs_joiner_default,
+                 'hyde_level': 0,
+                 'hyde_template': None,
                  }
     if cpu and bits == 32:
         expected1.update({'image_loaders': np.array([], dtype=object)})


### PR DESCRIPTION
Improves queries by embedding query + answer from LLM, iteratively any number of depths.  Helps especially when user query is vague or weakly detailed.

- [x] Add HYDE https://arxiv.org/abs/2212.10496
- [x] Return each iteration (pure LLM response and each HYDE iteration) in streaming in new entry llm_responses that is dict of each iteration as `'llm_answers_hyde_level_%d' % hyde_level` and lastly `llm_answer_final`.  So once consumer gets that item, it can show immediately while work is still progressing on follow-up iterations.
- [x] Refactor langchain streaming to be more isolated and re-usable
- [x] Add HYDE tests for FEMSA
- [x] Hit gradio bug that can repro for streaming that seen before spuriously recently: https://github.com/gradio-app/gradio/issues/6100

![image](https://github.com/h2oai/h2ogpt/assets/2249614/78d80cd1-a29d-4241-8883-0bacada1ed1d)
