### PR TITLE
Add `client.list_models()` method

### DIFF
--- a/client/h2ogpt_client/_core.py
+++ b/client/h2ogpt_client/_core.py
@@ -53,6 +53,11 @@ class Client:
     async def _predict_async(self, *args, api_name: str) -> Any:
         return await asyncio.wrap_future(self._client.submit(*args, api_name=api_name))
 
+    def list_models(self) -> List[str]:
+        """Returns available models in the h2oGPT server."""
+        models = ast.literal_eval(self._predict(api_name="/model_names"))
+        return [m["base_model"] for m in models]
+
 
 _DEFAULT_PARAMETERS: Dict[str, Any] = dict(
     instruction="",

--- a/client/tests/test_client.py
+++ b/client/tests/test_client.py
@@ -68,6 +68,12 @@ def test_chat_completion_sync(client):
     print(chat_history)
 
 
+def test_available_models(client):
+    models = client.list_models()
+    assert len(models)
+    print(models)
+
+
 def test_parameters_order(client, eval_func_param_names):
     text_completion = client.text_completion.create()
     assert eval_func_param_names == list(text_completion._parameters.keys())


### PR DESCRIPTION
`client.list_models()` method returns the available models in the h2oGPT server