### PR TITLE
Make Helm work with external and local LLM's

### DIFF
--- a/helm/h2ogpt-chart/Chart.yaml
+++ b/helm/h2ogpt-chart/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0-128
+version: 0.1.0-168
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.1.0-128
+appVersion: 0.1.0-168

--- a/helm/h2ogpt-chart/templates/config-map.yaml
+++ b/helm/h2ogpt-chart/templates/config-map.yaml
@@ -1,5 +1,4 @@
 
-{{- if not .Values.h2ogpt.externalLLM.enabled }}
 {{- if .Values.h2ogpt.enabled }}
 apiVersion: v1
 kind: ConfigMap
@@ -39,6 +38,5 @@ metadata:
 data:
 {{- range $key, $value := .Values.vllm.overrideConfig }}
   {{ printf "%s" $key | upper }}: {{ $value | quote }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/h2ogpt-chart/templates/deployment.yaml
+++ b/helm/h2ogpt-chart/templates/deployment.yaml
@@ -120,11 +120,9 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.h2ogpt.resources | nindent 12 }}
-          {{- if not .Values.h2ogpt.externalLLM.enabled }}
           envFrom:
             - configMapRef:
                 name: {{ include "h2ogpt.fullname" . }}-config
-          {{- end }}
           env:
           {{- if and .Values.tgi.enabled (not .Values.h2ogpt.externalLLM.enabled) }}
           - name: h2ogpt_inference_server

--- a/helm/h2ogpt-chart/templates/deployment.yaml
+++ b/helm/h2ogpt-chart/templates/deployment.yaml
@@ -126,11 +126,11 @@ spec:
                 name: {{ include "h2ogpt.fullname" . }}-config
           {{- end }}
           env:
-          {{- if .Values.tgi.enabled }}
+          {{- if and .Values.tgi.enabled (not .Values.h2ogpt.externalLLM.enabled) }}
           - name: h2ogpt_inference_server
             value: "http://{{ include "h2ogpt.fullname" . }}-tgi-inference:{{ .Values.tgi.service.port }}"
           {{- end }}
-          {{- if .Values.vllm.enabled }}
+          {{- if and .Values.vllm.enabled (not .Values.h2ogpt.externalLLM.enabled) }}
           - name: h2ogpt_inference_server
             value: "vllm:{{ include "h2ogpt.fullname" . }}-vllm-inference:{{ .Values.vllm.service.port }}"
           {{- end }}


### PR DESCRIPTION
# Description

Make Helm work with external and local LLM's. When both are enabled we should not add `inference_server` to env vars instead use `MODEL_LOCK`. This PR fixes that