### PR TITLE
Add `client.server` API to the Client

### DIFF
--- a/client/h2ogpt_client/_core.py
+++ b/client/h2ogpt_client/_core.py
@@ -12,6 +12,7 @@ from h2ogpt_client._h2ogpt_enums import (
     PromptType,
 )
 from h2ogpt_client._models import Model, Models
+from h2ogpt_client._server import Server
 
 
 class Client:
@@ -38,6 +39,7 @@ class Client:
         self._text_completion = TextCompletionCreator(self)
         self._chat_completion = ChatCompletionCreator(self)
         self._models = Models(self)
+        self._server = Server(self)
 
     @property
     def text_completion(self) -> "TextCompletionCreator":
@@ -53,6 +55,11 @@ class Client:
     def models(self) -> "Models":
         """LL models"""
         return self._models
+
+    @property
+    def server(self) -> Server:
+        """h2oGPT server."""
+        return self._server
 
     def _predict(self, *args, api_name: str) -> Any:
         return self._client.submit(*args, api_name=api_name).result()

--- a/client/h2ogpt_client/_core.py
+++ b/client/h2ogpt_client/_core.py
@@ -52,8 +52,8 @@ class Client:
         return self._chat_completion
 
     @property
-    def models(self) -> "Models":
-        """LL models"""
+    def models(self) -> Models:
+        """LL models."""
         return self._models
 
     @property

--- a/client/h2ogpt_client/_server.py
+++ b/client/h2ogpt_client/_server.py
@@ -1,0 +1,18 @@
+from h2ogpt_client import _core
+
+
+class Server:
+    """h2oGPT server."""
+
+    def __init__(self, client: "_core.Client"):
+        self._client = client
+
+    @property
+    def address(self) -> str:
+        """h2oGPT server address."""
+        return self._client._client.src
+
+    @property
+    def hash(self) -> str:
+        """h2oGPT server system hash."""
+        return str(self._client._predict(api_name="/system_hash"))

--- a/client/tests/test_client.py
+++ b/client/tests/test_client.py
@@ -84,6 +84,11 @@ def test_available_models(client):
     print(models)
 
 
+def test_server_properties(client, server_url):
+    assert client.server.address.startswith(server_url)
+    assert client.server.hash
+
+
 def test_parameters_order(client, eval_func_param_names):
     text_completion = client.text_completion.create()
     assert eval_func_param_names == list(text_completion._parameters.keys())


### PR DESCRIPTION
Adds following APIs to the Client
- Returns the address of the connected h2oGPT server
```py
client.server.address
```
- Returns the system hash of the connected h2oGPT server
```py
client.server.hash
```