### PR TITLE
[Client] Add streaming support for the text completion API

### DIFF
--- a/client/h2ogpt_client/_completion.py
+++ b/client/h2ogpt_client/_completion.py
@@ -1,6 +1,16 @@
+import abc
 import ast
 import collections
-from typing import Any, Dict, List, Optional, OrderedDict, Union
+from typing import (
+    Any,
+    AsyncGenerator,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    OrderedDict,
+    Union,
+)
 
 from h2ogpt_client._gradio_client import GradioClientWrapper
 from h2ogpt_client._h2ogpt_enums import (
@@ -133,6 +143,60 @@ _DEFAULT_PARAMETERS: Dict[str, Any] = dict(
 )
 
 
+class _Completion(abc.ABC):
+    _API_NAME = "/submit_nochat_api"
+
+    def __init__(self, client: GradioClientWrapper, parameters: OrderedDict[str, Any]):
+        self._client = client
+        self._parameters = dict(parameters)
+
+    def _get_parameters(self, prompt: str) -> Dict[str, Any]:
+        self._parameters["instruction_nochat"] = prompt
+        return self._parameters
+
+    @staticmethod
+    def _get_reply(response: str) -> str:
+        return ast.literal_eval(response)["response"]
+
+    def _predict(self, prompt: str) -> str:
+        response = self._client.predict(
+            str(self._get_parameters(prompt)), api_name=self._API_NAME
+        )
+        return self._get_reply(response)
+
+    def _predict_and_stream(self, prompt: str) -> Generator[str, None, None]:
+        generator = self._client.predict_and_stream(
+            str(self._get_parameters(prompt)), api_name=self._API_NAME
+        )
+        reply_size_so_far = 0
+        for response in generator:
+            current_reply = self._get_reply(response)
+            new_reply_chunk = current_reply[reply_size_so_far:]
+            if not new_reply_chunk:
+                continue
+            reply_size_so_far += len(new_reply_chunk)
+            yield new_reply_chunk
+
+    async def _submit(self, prompt: str) -> str:
+        response = await self._client.submit(
+            str(self._get_parameters(prompt)), api_name=self._API_NAME
+        )
+        return self._get_reply(response)
+
+    async def _submit_and_stream(self, prompt: str) -> AsyncGenerator[str, None]:
+        generator = self._client.submit_and_stream(
+            str(self._get_parameters(prompt)), api_name=self._API_NAME
+        )
+        reply_size_so_far = 0
+        async for response in generator:
+            current_reply = self._get_reply(response)
+            new_reply_chunk = current_reply[reply_size_so_far:]
+            if not new_reply_chunk:
+                continue
+            reply_size_so_far += len(new_reply_chunk)
+            yield new_reply_chunk
+
+
 class TextCompletionCreator:
     """Builder that can create text completions."""
 
@@ -228,47 +292,42 @@ class TextCompletionCreator:
         return TextCompletion(self._client, params)
 
 
-class TextCompletion:
+class TextCompletion(_Completion):
     """Text completion."""
 
-    _API_NAME = "/submit_nochat_api"
-
-    def __init__(self, client: GradioClientWrapper, parameters: OrderedDict[str, Any]):
-        self._client = client
-        self._parameters = dict(parameters)
-
-    def _get_parameters(self, prompt: str) -> Dict[str, Any]:
-        self._parameters["instruction_nochat"] = prompt
-        return self._parameters
-
-    @staticmethod
-    def _get_reply(response: str) -> str:
-        return ast.literal_eval(response)["response"]
-
-    async def complete(self, prompt: str) -> str:
+    async def complete(
+        self, prompt: str, enable_streaming: bool = False
+    ) -> Union[str, AsyncGenerator[str, None]]:
         """
         Complete this text completion.
 
         :param prompt: text prompt to generate completion for
+        :param enable_streaming: whether to enable or disable streaming the response
         :return: response from the model
         """
+        if enable_streaming:
+            params = self._get_parameters(prompt)
+            params["stream_output"] = True
+            return self._submit_and_stream(prompt)
+        else:
+            return await self._submit(prompt)
 
-        response = await self._client.submit(
-            str(self._get_parameters(prompt)), api_name=self._API_NAME
-        )
-        return self._get_reply(response)
-
-    def complete_sync(self, prompt: str) -> str:
+    def complete_sync(
+        self, prompt: str, enable_streaming: bool = False
+    ) -> Union[str, Generator[str, None, None]]:
         """
         Complete this text completion synchronously.
 
         :param prompt: text prompt to generate completion for
+        :param enable_streaming: whether to enable or disable streaming the response
         :return: response from the model
         """
-        response = self._client.predict(
-            str(self._get_parameters(prompt)), api_name=self._API_NAME
-        )
-        return self._get_reply(response)
+        if enable_streaming:
+            params = self._get_parameters(prompt)
+            params["stream_output"] = True
+            return self._predict_and_stream(prompt)
+        else:
+            return self._predict(prompt)
 
 
 class ChatCompletionCreator:
@@ -367,25 +426,11 @@ class ChatCompletionCreator:
         return ChatCompletion(self._client, params)
 
 
-class ChatCompletion:
+class ChatCompletion(_Completion):
     """Chat completion."""
 
-    _API_NAME = "/submit_nochat_api"
-
-    def __init__(self, client: GradioClientWrapper, parameters: OrderedDict[str, Any]):
-        self._client = client
-        self._parameters = dict(parameters)
-
-    def _get_parameters(self, prompt: str) -> Dict[str, Any]:
-        self._parameters["instruction_nochat"] = prompt
-        return self._parameters
-
-    def _update_history_and_get_reply(
-        self, prompt: str, response: str
-    ) -> Dict[str, str]:
-        reply = ast.literal_eval(response)["response"]
+    def _update_history(self, prompt: str, reply: str) -> None:
         self._parameters["chat_conversation"].append((prompt, reply))
-        return {"user": prompt, "gpt": reply}
 
     async def chat(self, prompt: str) -> Dict[str, str]:
         """
@@ -394,10 +439,9 @@ class ChatCompletion:
         :param prompt: text prompt to generate completions for
         :returns chat reply
         """
-        response = await self._client.submit(
-            str(self._get_parameters(prompt)), api_name=self._API_NAME
-        )
-        return self._update_history_and_get_reply(prompt, response)
+        reply = await self._submit(prompt)
+        self._update_history(prompt, reply)
+        return {"user": prompt, "gpt": reply}
 
     def chat_sync(self, prompt: str) -> Dict[str, str]:
         """
@@ -406,10 +450,9 @@ class ChatCompletion:
         :param prompt: text prompt to generate completions for
         :returns chat reply
         """
-        response = self._client.predict(
-            str(self._get_parameters(prompt)), api_name=self._API_NAME
-        )
-        return self._update_history_and_get_reply(prompt, response)
+        reply = self._predict(prompt)
+        self._update_history(prompt, reply)
+        return {"user": prompt, "gpt": reply}
 
     def chat_history(self) -> List[Dict[str, str]]:
         """Returns the full chat history."""

--- a/client/h2ogpt_client/_gradio_client.py
+++ b/client/h2ogpt_client/_gradio_client.py
@@ -1,0 +1,23 @@
+import asyncio
+from typing import Any, Optional
+
+import gradio_client  # type: ignore
+
+
+class GradioClientWrapper:
+    def __init__(
+        self,
+        src: str,
+        h2ogpt_key: Optional[str] = None,
+        huggingface_token: Optional[str] = None,
+    ):
+        self._client = gradio_client.Client(
+            src=src, hf_token=huggingface_token, serialize=False, verbose=False
+        )
+        self.h2ogpt_key = h2ogpt_key
+
+    def predict(self, *args, api_name: str) -> Any:
+        return self._client.predict(*args, api_name=api_name)
+
+    async def submit(self, *args, api_name: str) -> Any:
+        return await asyncio.wrap_future(self._client.submit(*args, api_name=api_name))

--- a/client/h2ogpt_client/_gradio_client.py
+++ b/client/h2ogpt_client/_gradio_client.py
@@ -1,5 +1,6 @@
 import asyncio
-from typing import Any, Optional
+import time
+from typing import Any, AsyncGenerator, Generator, List, Optional
 
 import gradio_client  # type: ignore
 
@@ -19,5 +20,35 @@ class GradioClientWrapper:
     def predict(self, *args, api_name: str) -> Any:
         return self._client.predict(*args, api_name=api_name)
 
+    def predict_and_stream(self, *args, api_name: str) -> Generator[str, None, None]:
+        job = self._client.submit(*args, api_name=api_name)
+        while not job.done():
+            outputs: List[str] = job.outputs()
+            if not len(outputs):
+                time.sleep(0.1)
+                continue
+            newest_response = outputs[-1]
+            yield newest_response
+
+        e = job.exception()
+        if e and isinstance(e, BaseException):
+            raise RuntimeError from e
+
     async def submit(self, *args, api_name: str) -> Any:
         return await asyncio.wrap_future(self._client.submit(*args, api_name=api_name))
+
+    async def submit_and_stream(
+        self, *args, api_name: str
+    ) -> AsyncGenerator[Any, None]:
+        job = self._client.submit(*args, api_name=api_name)
+        while not job.done():
+            outputs: List[str] = job.outputs()
+            if not len(outputs):
+                await asyncio.sleep(0.1)
+                continue
+            newest_response = outputs[-1]
+            yield newest_response
+
+        e = job.exception()
+        if e and isinstance(e, BaseException):
+            raise RuntimeError from e

--- a/client/h2ogpt_client/_models.py
+++ b/client/h2ogpt_client/_models.py
@@ -1,7 +1,7 @@
 import ast
 from typing import Any, Dict, List
 
-from h2ogpt_client import _core
+from h2ogpt_client._gradio_client import GradioClientWrapper
 
 
 class Model:
@@ -26,10 +26,10 @@ class Model:
 class Models:
     """Interact with LL Models in h2oGPT."""
 
-    def __init__(self, client: "_core.Client"):
+    def __init__(self, client: GradioClientWrapper):
         self._client = client
 
     def list(self) -> List[Model]:
         """List all models available in the h2oGPT server."""
-        models = ast.literal_eval(self._client._predict(api_name="/model_names"))
+        models = ast.literal_eval(self._client.predict(api_name="/model_names"))
         return [Model(m) for m in models]

--- a/client/h2ogpt_client/_server.py
+++ b/client/h2ogpt_client/_server.py
@@ -1,10 +1,10 @@
-from h2ogpt_client import _core
+from h2ogpt_client._gradio_client import GradioClientWrapper
 
 
 class Server:
     """h2oGPT server."""
 
-    def __init__(self, client: "_core.Client"):
+    def __init__(self, client: GradioClientWrapper):
         self._client = client
 
     @property
@@ -15,4 +15,4 @@ class Server:
     @property
     def hash(self) -> str:
         """h2oGPT server system hash."""
-        return str(self._client._predict(api_name="/system_hash"))
+        return str(self._client.predict(api_name="/system_hash"))

--- a/client/tests/test_client.py
+++ b/client/tests/test_client.py
@@ -25,11 +25,34 @@ async def test_text_completion(client):
     print(response)
 
 
+@pytest.mark.asyncio
+async def test_text_completion_stream(client):
+    text_completion = _create_text_completion(client)
+    response = await text_completion.complete(
+        prompt="Write a poem about the Amazon rainforest. End it with an emoji.",
+        enable_streaming=True,
+    )
+    async for token in response:
+        assert token
+        print(token, end="")
+
+
 def test_text_completion_sync(client):
     text_completion = _create_text_completion(client)
     response = text_completion.complete_sync(prompt="Hello world")
     assert response
     print(response)
+
+
+def test_text_completion_sync_stream(client):
+    text_completion = _create_text_completion(client)
+    response = text_completion.complete_sync(
+        prompt="Write a poem about the Amazon rainforest. End it with an emoji.",
+        enable_streaming=True,
+    )
+    for token in response:
+        assert token
+        print(token, end="")
 
 
 def _create_chat_completion(client):


### PR DESCRIPTION
```py
client = Client("https://llama.h2o.ai", h2ogpt_key=h2ogpt_key)
text_completion = client.text_completion.create()
```
### Async
```py
async def test_async():
    response = await text_completion.complete(
        prompt="Write a poem about the Amazon rainforest. End it with an emoji.",
        enable_streaming=True,
    )
    async for token in response:
        assert token
        print(token, end="")
```
### Sync
```py
def test_sync():
    response = text_completion.complete_sync(
        prompt="Write a poem about the Amazon rainforest. End it with an emoji.",
        enable_streaming=True,
    )
    for token in response:
        assert token
        print(token, end="")
```