### PR TITLE
[HELM] Remove default values from overrideConfig 

### DIFF
--- a/helm/h2ogpt-chart/Chart.yaml
+++ b/helm/h2ogpt-chart/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0-168
+version: 0.1.0-194
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.1.0-168
+appVersion: 0.1.0-194

--- a/helm/h2ogpt-chart/values.yaml
+++ b/helm/h2ogpt-chart/values.yaml
@@ -31,7 +31,7 @@ h2ogpt:
     replicate: 
       enabled: false
 
-# -- Example configs to when not using Model Lock and External LLM
+# -- Example configs to use when not using Model Lock and External LLM
   # overrideConfig:
   #   base_model: h2oai/h2ogpt-4096-llama2-7b-chat
   #   use_safetensors: True

--- a/helm/h2ogpt-chart/values.yaml
+++ b/helm/h2ogpt-chart/values.yaml
@@ -43,14 +43,6 @@ h2ogpt:
   #   max_new_tokens: 1024
 
   overrideConfig:
-    base_model: 
-    use_safetensors: 
-    prompt_type: 
-    save_dir: 
-    use_gpu_id: 
-    score_model: 
-    max_max_new_tokens: 
-    max_new_tokens: 
 
   service:
     type: NodePort

--- a/helm/h2ogpt-chart/values.yaml
+++ b/helm/h2ogpt-chart/values.yaml
@@ -31,15 +31,26 @@ h2ogpt:
     replicate: 
       enabled: false
 
+# -- Example configs to when not using Model Lock and External LLM
+  # overrideConfig:
+  #   base_model: h2oai/h2ogpt-4096-llama2-7b-chat
+  #   use_safetensors: True
+  #   prompt_type: llama2
+  #   save_dir: /workspace/save/
+  #   use_gpu_id: False
+  #   score_model: None
+  #   max_max_new_tokens: 2048
+  #   max_new_tokens: 1024
+
   overrideConfig:
-    base_model: h2oai/h2ogpt-4096-llama2-7b-chat
-    use_safetensors: True
-    prompt_type: llama2
-    save_dir: /workspace/save/
-    use_gpu_id: False
-    score_model: None
-    max_max_new_tokens: 2048
-    max_new_tokens: 1024
+    base_model: 
+    use_safetensors: 
+    prompt_type: 
+    save_dir: 
+    use_gpu_id: 
+    score_model: 
+    max_max_new_tokens: 
+    max_new_tokens: 
 
   service:
     type: NodePort


### PR DESCRIPTION
The default values in `overrideConfig` is causing h2oGPT to break when using external LLMs with MODEL_LOCK. This PR removes the default values and add it as a comment