### PR TITLE
Update audio_langchain.py to fix Youtube on Windows

### DIFF
--- a/src/audio_langchain.py
+++ b/src/audio_langchain.py
@@ -380,7 +380,8 @@ class H2OAudioCaptionLoader(ImageCaptionLoader):
 
         # https://librosa.org/doc/main/generated/librosa.load.html
         if from_youtube:
-            save_dir = "/tmp/" + "_" + str(uuid.uuid4())[:10]
+            current_path = os.getcwd().replace(os.sep, '/') # change backslashes to forward slashes on Windows
+            save_dir = current_path+"/tmp/" + "_" + str(uuid.uuid4())[:10]
             loader = GenericLoader(YoutubeAudioLoader(self.audio_paths, save_dir), self.model)
             return loader.load()
         else:

--- a/src/audio_langchain.py
+++ b/src/audio_langchain.py
@@ -380,7 +380,9 @@ class H2OAudioCaptionLoader(ImageCaptionLoader):
 
         # https://librosa.org/doc/main/generated/librosa.load.html
         if from_youtube:
-            current_path = os.getcwd().replace(os.sep, '/') # change backslashes to forward slashes on Windows
+            current_path = ""
+            if(os.name == "nt"):
+                current_path = os.getcwd().replace(os.sep, '/') # change backslashes to forward slashes on Windows
             save_dir = current_path+"/tmp/" + "_" + str(uuid.uuid4())[:10]
             loader = GenericLoader(YoutubeAudioLoader(self.audio_paths, save_dir), self.model)
             return loader.load()


### PR DESCRIPTION
Previous code did not submit a precise directory to the transcriber on Windows. Please verify this does not break *unix environments. I interpret the previous code as placing files into linux root folder `/tmp`, however on Windows the code places it in the current directory, creating a new `tmp` folder. When the transcriber tries to load the audio file it searches on the current drive's root `/tmp` folder (if it even exists) just like on *unix systems, but will never find the file there. This edit forces a full directory string to be used that points to the current directory's `tmp` folder.

Additionally, you should know that the current code base on windows places all files, temporary or not, including databases, in the directory h2ogpt is launched from, see:
![image](https://github.com/h2oai/h2ogpt/assets/8894763/fd957732-5e28-4eac-8d72-648fc1506600)
