### PR TITLE
[HELM] Add option to run vLLM and h2oGPT on same pod

### DIFF
--- a/helm/h2ogpt-chart/templates/deployment.yaml
+++ b/helm/h2ogpt-chart/templates/deployment.yaml
@@ -1,9 +1,10 @@
 {{- if and .Values.vllm.enabled .Values.tgi.enabled }}
   {{- fail "Both TGI and vLLM cannot be enabled at the same time. Enable only one and try again" }}
 {{- end }}
-
-{{- if and (.Values.h2ogpt.stack.enabled) (not .Values.vllm.enabled) (not .Values.h2ogpt.enabled)  }}
-  {{- fail "vLLM and h2oGPT should be enabled when running as a stack" }}
+{{- if .Values.h2ogpt.stack.enabled }}
+  {{- if not (and .Values.vllm.enabled .Values.h2ogpt.enabled) }}
+    {{- fail "If h2oGPT stack is enabled, both vLLM and h2oGPT should be enabled" }}
+  {{- end }}
 {{- end }}
 ---
 {{- if .Values.h2ogpt.enabled }}

--- a/helm/h2ogpt-chart/templates/deployment.yaml
+++ b/helm/h2ogpt-chart/templates/deployment.yaml
@@ -1,6 +1,10 @@
 {{- if and .Values.vllm.enabled .Values.tgi.enabled }}
   {{- fail "Both TGI and vLLM cannot be enabled at the same time. Enable only one and try again" }}
 {{- end }}
+
+{{- if and (.Values.h2ogpt.stack.enabled) (not .Values.vllm.enabled) (not .Values.h2ogpt.enabled)  }}
+  {{- fail "vLLM and h2oGPT should be enabled when running as a stack" }}
+{{- end }}
 ---
 {{- if .Values.h2ogpt.enabled }}
 apiVersion: apps/v1
@@ -50,7 +54,7 @@ spec:
                       values:
                         - {{ include "h2ogpt.fullname" . }}
                 topologyKey: failure-domain.beta.kubernetes.io/zone
-{{- if .Values.tgi.enabled }}
+{{- if and (.Values.tgi.enabled) (not .Values.h2ogpt.stack.enabled ) }}
       initContainers:
         - name: tgi-check
           securityContext:
@@ -66,7 +70,7 @@ spec:
                 sleep 5;
               done
 {{- end }}
-{{- if .Values.vllm.enabled }}
+{{- if and (.Values.vllm.enabled) (not .Values.h2ogpt.stack.enabled ) }}
       initContainers:
         - name: vllm-check
           securityContext:
@@ -87,6 +91,65 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
+        {{- if .Values.h2ogpt.stack.enabled }}
+        - name: {{ include "h2ogpt.fullname" . }}-vllm-inference
+          securityContext:
+            {{- toYaml .Values.vllm.securityContext | nindent 12 }}
+          image: "{{ .Values.vllm.image.repository }}:{{ .Values.vllm.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.vllm.image.pullPolicy }}
+          command: ["/h2ogpt_conda/vllm_env/bin/python3.10"]
+          args: 
+            - "-m" 
+            - "vllm.entrypoints.openai.api_server"
+            - "--port"
+            - "5000"
+            - "--host"
+            - "0.0.0.0"
+            - "--download-dir"
+            - "/workspace/.cache/huggingface/hub"
+{{- range $arg := .Values.vllm.containerArgs }}
+            - "{{ $arg }}"
+{{- end }}
+          ports:
+            - name: http
+              containerPort: 5000
+              protocol: TCP
+          {{- if .Values.vllm.livenessProbe }}
+          livenessProbe:
+            httpGet:
+              path:  /
+              scheme: HTTP
+              port: http
+            {{- toYaml .Values.vllm.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.vllm.readinessProbe }}
+          readinessProbe:
+            httpGet:
+              path:  /
+              scheme: HTTP
+              port: http
+            {{- toYaml .Values.vllm.readinessProbe | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.vllm.resources | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "h2ogpt.fullname" . }}-vllm-inference-config
+          env:
+          - name: NCCL_IGNORE_DISABLED_P2P
+            value: "1"
+          {{- range $key, $value := .Values.vllm.env }}
+          - name: "{{ $key }}"
+            value: "{{ $value }}"
+          {{- end }}
+          volumeMounts:
+            - name: {{ include "h2ogpt.fullname" . }}-vllm-inference-volume
+              mountPath: /workspace/.cache
+              subPath: cache
+            - name: {{ include "h2ogpt.fullname" . }}-vllm-inference-volume
+              mountPath: /dev/shm
+              subPath: shm
+          {{- end }}
         - name: {{ include "h2ogpt.fullname" . }}
           securityContext:
             {{- toYaml .Values.h2ogpt.securityContext | nindent 12 }}
@@ -124,13 +187,17 @@ spec:
             - configMapRef:
                 name: {{ include "h2ogpt.fullname" . }}-config
           env:
-          {{- if and .Values.tgi.enabled (not .Values.h2ogpt.externalLLM.enabled) }}
+          {{- if and .Values.tgi.enabled (not .Values.h2ogpt.externalLLM.enabled) (not .Values.h2ogpt.stack.enabled ) }}
           - name: h2ogpt_inference_server
             value: "http://{{ include "h2ogpt.fullname" . }}-tgi-inference:{{ .Values.tgi.service.port }}"
           {{- end }}
-          {{- if and .Values.vllm.enabled (not .Values.h2ogpt.externalLLM.enabled) }}
+          {{- if and .Values.vllm.enabled (not .Values.h2ogpt.externalLLM.enabled) (not .Values.h2ogpt.stack.enabled ) }}
           - name: h2ogpt_inference_server
             value: "vllm:{{ include "h2ogpt.fullname" . }}-vllm-inference:{{ .Values.vllm.service.port }}"
+          {{- end }}
+          {{- if and .Values.h2ogpt.stack.enabled (not .Values.h2ogpt.externalLLM.enabled)  }}
+          - name: h2ogpt_inference_server
+            value: "vllm:localhost:5000"
           {{- end }}
           {{- range $key, $value := .Values.h2ogpt.env }}
           - name: "{{ $key }}"
@@ -191,6 +258,23 @@ spec:
                     storage: {{ .Values.h2ogpt.storage.size | quote }}
                 storageClassName: {{ .Values.h2ogpt.storage.class }}
           {{- end }}
+        {{- if .Values.h2ogpt.stack.enabled }}
+        - name: {{ include "h2ogpt.fullname" . }}-vllm-inference-volume
+          {{- if not .Values.vllm.storage.useEphemeral }}
+          persistentVolumeClaim:
+            claimName: {{ include "h2ogpt.fullname" . }}-vllm-inference-volume
+          {{- else }}
+          ephemeral:
+            volumeClaimTemplate:
+              spec:
+                accessModes: 
+                  - ReadWriteOnce
+                resources:
+                  requests: 
+                    storage: {{ .Values.vllm.storage.size | quote }}
+                storageClassName: {{ .Values.vllm.storage.class }}
+          {{- end }}
+        {{- end }}
 {{- end }}
 ---
 {{- if and (.Values.h2ogpt.enabled) (not .Values.h2ogpt.storage.useEphemeral) }}
@@ -209,7 +293,7 @@ spec:
 {{- end }}
 
 ---
-{{- if .Values.tgi.enabled }}
+{{- if and (.Values.tgi.enabled) (not .Values.h2ogpt.stack.enabled ) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -315,6 +399,23 @@ spec:
               mountPath: /dev/shm
               subPath: shm
       volumes:
+        {{- if .Values.h2ogpt.stack.enabled }}
+        - name: {{ include "h2ogpt.fullname" . }}-vllm-inference-volume
+          {{- if not .Values.vllm.storage.useEphemeral }}
+          persistentVolumeClaim:
+            claimName: {{ include "h2ogpt.fullname" . }}-vllm-inference-volume
+          {{- else }}
+          ephemeral:
+            volumeClaimTemplate:
+              spec:
+                accessModes: 
+                  - ReadWriteOnce
+                resources:
+                  requests: 
+                    storage: {{ .Values.vllm.storage.size | quote }}
+                storageClassName: {{ .Values.vllm.storage.class }}
+          {{- end }}
+        {{- end }}
         - name: {{ include "h2ogpt.fullname" . }}-tgi-inference-volume
         {{- if not .Values.tgi.storage.useEphemeral}}
           persistentVolumeClaim:
@@ -332,7 +433,7 @@ spec:
           {{- end }}
 {{- end }}
 ---
-{{- if and (.Values.tgi.enabled) (not .Values.tgi.storage.useEphemeral) }}
+{{- if and (.Values.tgi.enabled) (not .Values.tgi.storage.useEphemeral)}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -347,7 +448,7 @@ spec:
       storage: {{ .Values.tgi.storage.size | quote }}
 {{- end }}
 ---
-{{- if .Values.vllm.enabled }}
+{{- if and (.Values.vllm.enabled) (not .Values.h2ogpt.stack.enabled )}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/h2ogpt-chart/templates/service.yaml
+++ b/helm/h2ogpt-chart/templates/service.yaml
@@ -35,7 +35,7 @@ spec:
   type: {{ .Values.h2ogpt.service.type }}
 {{- end }}
 ---
-{{- if .Values.tgi.enabled }}
+{{- if and (.Values.tgi.enabled) (not .Values.h2ogpt.stack.enabled ) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -51,7 +51,7 @@ spec:
   type: {{ .Values.tgi.service.type }}
 {{- end }}
 ---
-{{- if .Values.vllm.enabled }}
+{{- if and (.Values.vllm.enabled) (not .Values.h2ogpt.stack.enabled ) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/h2ogpt-chart/values.yaml
+++ b/helm/h2ogpt-chart/values.yaml
@@ -3,6 +3,9 @@ fullnameOverride: ""
 
 h2ogpt:
   enabled: true
+  stack:
+    # -- Run h2oGPT and vLLM on same pod.
+    enabled: false 
   replicaCount: 1
   image:
     repository: gcr.io/vorvan/h2oai/h2ogpt-runtime


### PR DESCRIPTION
# Description 

This PR will add an option `h2ogpt.stack.enabled`, once enabled both vLLM and h2oGPT will be launched on the same pod instead of separate two. 