### PR TITLE
Add the missing dependency `python-doctr`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -54,6 +54,7 @@ python-magic-bin==0.4.14; sys_platform == "win32"
 openpyxl==3.1.2
 lm_dataformat==0.0.20
 bioc==2.0
+python-doctr==0.7.0
 
 # falcon
 einops==0.6.1


### PR DESCRIPTION
This PR fixes the error below when uploading PDFs in the web interface.

```
back (most recent call last):
  File "/Users/la/Dev/h2ogpt/src/gpt_langchain.py", line 3231, in path_to_doc1
    res = file_to_doc(file,
  File "/Users/la/Dev/h2ogpt/src/gpt_langchain.py", line 3034, in file_to_doc
    from image_doctr import H2OOCRLoader
  File "/Users/la/Dev/h2ogpt/src/image_doctr.py", line 16, in <module>
    from doctr.utils.common_types import AbstractFile
ModuleNotFoundError: No module named 'doctr.utils'
```

