### PR TITLE
improve streaming and error logging

### DIFF
--- a/src/gen.py
+++ b/src/gen.py
@@ -143,7 +143,7 @@ def main(
         compile_model: bool = None,
         use_cache: bool = None,
         inference_server: str = "",
-        regenerate_clients: bool = True,
+        regenerate_clients: bool = False,
 
         prompt_type: Union[int, str] = None,
         prompt_dict: typing.Dict = None,
@@ -525,7 +525,6 @@ def main(
 
     :param regenerate_clients: Whether to regenerate client every LLM call or use start-up version
            Benefit of doing each LLM call is timeout can be controlled to max_time in expert settings, else we use default of 600s.
-           But downside is if something bad happens to the client, it messes it up forever, e.g. even timeout.  So not really safe.
 
     :param prompt_type: type of prompt, usually matched to fine-tuned model or plain for foundational model
     :param prompt_dict: If prompt_type=custom, then expects (some) items returned by get_prompt(..., return_dict=True)

--- a/src/gen.py
+++ b/src/gen.py
@@ -143,7 +143,7 @@ def main(
         compile_model: bool = None,
         use_cache: bool = None,
         inference_server: str = "",
-        regenerate_clients: bool = False,
+        regenerate_clients: bool = True,
 
         prompt_type: Union[int, str] = None,
         prompt_dict: typing.Dict = None,
@@ -525,6 +525,7 @@ def main(
 
     :param regenerate_clients: Whether to regenerate client every LLM call or use start-up version
            Benefit of doing each LLM call is timeout can be controlled to max_time in expert settings, else we use default of 600s.
+           But downside is if something bad happens to the client, it messes it up forever, e.g. even timeout.  So not really safe.
 
     :param prompt_type: type of prompt, usually matched to fine-tuned model or plain for foundational model
     :param prompt_dict: If prompt_type=custom, then expects (some) items returned by get_prompt(..., return_dict=True)

--- a/src/gradio_runner.py
+++ b/src/gradio_runner.py
@@ -4228,6 +4228,9 @@ def go_gradio(**kwargs):
                 final_audio = combine_audios(audios, audio=no_audio,
                                              expect_bytes=kwargs['return_as_byte'])
                 yield history, error, final_audio
+            except BaseException as e:
+                print("evaluate_nochat exception: %s: %s" % (str(e), str(args)), flush=True)
+                raise
             finally:
                 clear_torch_cache(allow_skip=True)
                 clear_embeddings(langchain_mode1, db1)

--- a/tests/test_client_calls.py
+++ b/tests/test_client_calls.py
@@ -153,14 +153,13 @@ def test_client1api_lean(save_dir, admin_pass):
         # pass string of dict.  All entries are optional, but expect at least instruction_nochat to be filled
         res = client.predict(str(dict(kwargs)), api_name=api_name)
         res = ast.literal_eval(res)
-        if save_dir:
-            assert 'base_model' in res['save_dict']
-            assert res['save_dict']['base_model'] == base_model
-            assert res['save_dict']['error'] in [None, '']
-            assert 'extra_dict' in res['save_dict']
-            assert res['save_dict']['extra_dict']['ntokens'] > 0
-            assert res['save_dict']['extra_dict']['t_generate'] > 0
-            assert res['save_dict']['extra_dict']['tokens_persecond'] > 0
+        assert 'base_model' in res['save_dict']
+        assert res['save_dict']['base_model'] == base_model
+        assert res['save_dict']['error'] in [None, '']
+        assert 'extra_dict' in res['save_dict']
+        assert res['save_dict']['extra_dict']['ntokens'] > 0
+        assert res['save_dict']['extra_dict']['t_generate'] > 0
+        assert res['save_dict']['extra_dict']['tokens_persecond'] > 0
 
         print("Raw client result: %s" % res, flush=True)
         response = res['response']

--- a/tests/test_client_readme.py
+++ b/tests/test_client_readme.py
@@ -1,7 +1,10 @@
 import pytest
 
+from tests.utils import wrap_test_forked
+
 
 @pytest.mark.parametrize("local_server", [True, False])
+@wrap_test_forked
 def test_readme_example(local_server):
     if local_server:
         from src.gen import main

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -106,9 +106,9 @@ def test_change_image():
 
 @wrap_test_forked
 def test_video_extraction():
-    # urls = ["https://www.youtube.com/watch?v=cwjs1WAG9CM"]
+    urls = ["https://www.youtube.com/shorts/fRkZCriQQNU"]
     from src.vision.extract_movie import extract_unique_frames
-    export_dir = extract_unique_frames(urls=None, download_dir=None)
+    export_dir = extract_unique_frames(urls=urls, download_dir=None)
     image_files = [f for f in os.listdir(export_dir) if os.path.isfile(os.path.join(export_dir, f))]
     assert len(image_files) > 10
     assert image_files[0].endswith('.jpg')


### PR DESCRIPTION
* Undo 4b1b5e0c22671512266915521f150ac5dbe4e6cc a bit
* Don't stream back save_dict or prompt_raw or sources until end, so internally more efficient.
* Only have other methods in gen.py update save_dict or extra_dict, not overwrite, so more consistent returns in general
* Show error details in logs when evaluate_nochat fails due to vLLM server, since otherwise don't see which LLM etc from logs.