### PR TITLE
Update README_MACOS.md

### DIFF
--- a/docs/README_MACOS.md
+++ b/docs/README_MACOS.md
@@ -40,6 +40,7 @@ Supports CPU and MPS (Metal M1/M2).
     # Optional: Selenium/PlayWright:
     pip install -r reqs_optional/requirements_optional_langchain.urls.txt
     # Optional: DocTR OCR:
+    conda install weasyprint pygobject -c conda-forge -y
     pip install -r reqs_optional/requirements_optional_doctr.txt                     
     # Optional: for supporting unstructured package
     python -m nltk.downloader all


### PR DESCRIPTION
I realized that I was getting these errors :
`Must install DocTR and LangChain installed if enabled DocTR, disabling`

The instruction in Linux made it stop. I tried the same line in Mac and it worked too