### PR TITLE
h2ogpt support namespaceOverride

### DIFF
--- a/helm/h2ogpt-chart/templates/_helpers.tpl
+++ b/helm/h2ogpt-chart/templates/_helpers.tpl
@@ -24,6 +24,14 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Allow the release namespace to be overridden.
+*/}}
+{{- define "h2ogpt.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "h2ogpt.chart" -}}

--- a/helm/h2ogpt-chart/templates/config-map.yaml
+++ b/helm/h2ogpt-chart/templates/config-map.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "h2ogpt.fullname" . }}-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "h2ogpt.namespace" . | quote }}
   labels:
     {{- include "h2ogpt.labels" . | nindent 4 }}
 data:
@@ -18,7 +18,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "h2ogpt.fullname" . }}-tgi-inference-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "h2ogpt.namespace" . | quote }}
   labels:
     {{- include "h2ogpt.labels" . | nindent 4 }}
 data:
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "h2ogpt.fullname" . }}-vllm-inference-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "h2ogpt.namespace" . | quote }}
   labels:
     {{- include "h2ogpt.labels" . | nindent 4 }}
 data:

--- a/helm/h2ogpt-chart/templates/deployment.yaml
+++ b/helm/h2ogpt-chart/templates/deployment.yaml
@@ -12,6 +12,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "h2ogpt.fullname" . }}
+  namespace: {{ include "h2ogpt.namespace" . | quote }}
   labels:
     app: {{ include "h2ogpt.fullname" . }}
 spec:
@@ -300,6 +301,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "h2ogpt.fullname" . }}-volume
+  namespace: {{ include "h2ogpt.namespace" . | quote }}
 spec:
   accessModes:
     - ReadWriteOnce
@@ -316,6 +318,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "h2ogpt.fullname" . }}-tgi-inference
+  namespace: {{ include "h2ogpt.namespace" . | quote }}
   labels:
     app: {{ include "h2ogpt.fullname" . }}-tgi-inference
 spec:
@@ -459,6 +462,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "h2ogpt.fullname" . }}-tgi-inference-volume
+  namespace: {{ include "h2ogpt.namespace" . | quote }}
 spec:
   accessModes:
     - ReadWriteOnce
@@ -474,6 +478,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "h2ogpt.fullname" . }}-vllm-inference
+  namespace: {{ include "h2ogpt.namespace" . | quote }}
   labels:
     app: {{ include "h2ogpt.fullname" . }}-vllm-inference
 spec:
@@ -605,6 +610,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "h2ogpt.fullname" . }}-vllm-inference-volume
+  namespace: {{ include "h2ogpt.namespace" . | quote }}
 spec:
   accessModes:
     - ReadWriteOnce

--- a/helm/h2ogpt-chart/templates/service.yaml
+++ b/helm/h2ogpt-chart/templates/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "h2ogpt.fullname" . }}-web
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "h2ogpt.namespace" . | quote }}
 
   {{- with .Values.h2ogpt.service.webServiceAnnotations }}
   annotations:
@@ -24,7 +24,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "h2ogpt.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "h2ogpt.namespace" . | quote }}
 spec:
   selector:
     app: {{ include "h2ogpt.fullname" . }}
@@ -40,7 +40,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "h2ogpt.fullname" . }}-tgi-inference
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "h2ogpt.namespace" . | quote }}
 spec:
   selector:
     app: {{ include "h2ogpt.fullname" . }}-tgi-inference
@@ -56,7 +56,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "h2ogpt.fullname" . }}-vllm-inference
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "h2ogpt.namespace" . | quote }}
 spec:
   selector:
     app: {{ include "h2ogpt.fullname" . }}-vllm-inference

--- a/helm/h2ogpt-chart/values.yaml
+++ b/helm/h2ogpt-chart/values.yaml
@@ -1,5 +1,6 @@
 nameOverride: ""
 fullnameOverride: ""
+namespaceOverride: 
 
 h2ogpt:
   enabled: true


### PR DESCRIPTION
this is needed for HAIC/genai Uber helm chart, if user need to decide which namespace h2ogpt will be running in.