### PR TITLE
Fixes #1270

### DIFF
--- a/gradio_utils/grclient.py
+++ b/gradio_utils/grclient.py
@@ -559,6 +559,7 @@ class GradioClient(Client):
                                       hyde_template: str = None,
                                       hyde_show_only_final: bool = True,
                                       doc_json_mode: bool = False,
+                                      metadata_in_context: list = [],
 
                                       asserts: bool = False,
                                       ) -> Generator[tuple[str | list[str], list[str]], None, None]:
@@ -663,6 +664,7 @@ class GradioClient(Client):
             hyde_template: see src/gen.py
             hyde_show_only_final: see src/gen.py
             doc_json_mode: see src/gen.py
+            metadata_in_context: see src/gen.py
 
             asserts: whether to do asserts to ensure handling is correct
 
@@ -793,6 +795,7 @@ class GradioClient(Client):
             hyde_template=hyde_template,
             hyde_show_only_final=hyde_show_only_final,
             doc_json_mode=doc_json_mode,
+            metadata_in_context=metadata_in_context,
         )
 
         # in case server changed, update in case clone()

--- a/src/cli.py
+++ b/src/cli.py
@@ -59,6 +59,7 @@ def run_cli(  # for local function:
         hyde_show_only_final=None,
         hyde_show_intermediate_in_accordion=None,
         doc_json_mode=None,
+        metadata_in_context=None,
         chatbot_role=None,
         speaker=None,
         tts_language=None,

--- a/src/client_test.py
+++ b/src/client_test.py
@@ -159,6 +159,7 @@ def get_args(prompt, prompt_type=None, chat=False, stream_output=False,
                          hyde_template=None,
                          hyde_show_only_final=False,
                          doc_json_mode=False,
+                         metadata_in_context=[],
 
                          chatbot_role='None',
                          speaker='None',

--- a/src/eval.py
+++ b/src/eval.py
@@ -77,6 +77,7 @@ def run_eval(  # for local function:
         hyde_show_only_final=None,
         hyde_show_intermediate_in_accordion=None,
         doc_json_mode=None,
+        metadata_in_context=None,
         chatbot_role=None,
         speaker=None,
         tts_language=None,

--- a/src/evaluate_params.py
+++ b/src/evaluate_params.py
@@ -72,6 +72,7 @@ eval_func_param_names = ['instruction',
                          'hyde_template',
                          'hyde_show_only_final',
                          'doc_json_mode',
+                         'metadata_in_context',
 
                          'chatbot_role',
                          'speaker',

--- a/src/gen.py
+++ b/src/gen.py
@@ -405,6 +405,7 @@ def main(
         hyde_show_only_final: bool = False,
         hyde_show_intermediate_in_accordion: bool = True,
         doc_json_mode: bool = False,
+        metadata_in_context: Union[str, list] = 'auto',
 
         auto_reduce_chunks: bool = True,
         max_chunks: int = 100,
@@ -1000,6 +1001,36 @@ def main(
 
     :param hyde_llm_prompt: hyde prompt for first step when using LLM
     :param doc_json_mode: Use system prompting approach with JSON input and output, e.g. for codellama or GPT-4
+    :param metadata_in_context: Keys of metadata to include in LLM context for Query
+           'all': Include all metadata
+           'auto': Includes these keys: ['date', 'file_path', 'input_type', 'keywords', 'chunk_id', 'page', 'source', 'title', 'total_pages']
+           ['key1', 'key2', ...]: Include only these keys
+            NOTE: not all parsers have all keys, only keys that exist are added to each document chunk.
+           Example key-values that some PDF parsers make:
+                author = Zane Durante, Bidipta Sarkar, Ran Gong, Rohan Taori, Yusuke Noda, Paul Tang, Ehsan Adeli, Shrinidhi Kowshika Lakshmikanth, Kevin Schulman, Arnold Milstein, Demetri Terzopoulos, Ade Famoti, Noboru Kuno, Ashley Llorens, Hoi Vo, Katsu Ikeuchi, Li Fei-Fei, Jianfeng Gao, Naoki Wake, Qiuyuan Huang
+                chunk_id = 21
+                creationDate = D:20240209020045Z
+                creator = LaTeX with hyperref
+                date = 2024-02-11 23:58:11.929155
+                doc_hash = 5db1d548-7
+                file_path = /tmp/gradio/15ac25af8610f21b9ab55252f1944841727ba157/2402.05929.pdf
+                format = PDF 1.5
+                hashid = 3cfb31cea127c745c72554f4714105dd
+                head = An Interactive Agent Foundation Model
+                Figure 2. We
+                input_type = .pdf
+                keywords = Machine Learning, ICML
+                modDate = D:20240209020045Z
+                order_id = 2
+                page = 2
+                parser = PyMuPDFLoader
+                producer = pdfTeX-1.40.25
+                source = /tmp/gradio/15ac25af8610f21b9ab55252f1944841727ba157/2402.05929.pdf
+                subject = Proceedings of the International Conference on Machine Learning 2024
+                time = 1707724691.929157
+                title = An Interactive Agent Foundation Model
+                total_pages = 22
+
     :param add_chat_history_to_context: Include chat context when performing action
            Not supported when using CLI mode
     :param add_search_to_context: Include web search in context as augmented prompt
@@ -1669,6 +1700,7 @@ def main(
                             hyde_template,
                             hyde_show_only_final,
                             doc_json_mode,
+                            metadata_in_context,
                             chatbot_role,
                             speaker,
                             tts_language,
@@ -3312,6 +3344,7 @@ def evaluate(
         hyde_template,
         hyde_show_only_final,
         doc_json_mode,
+        metadata_in_context,
 
         chatbot_role,
         speaker,
@@ -3867,6 +3900,7 @@ def evaluate(
                 hyde_template=hyde_template,
                 hyde_show_only_final=hyde_show_only_final,
                 doc_json_mode=doc_json_mode,
+                metadata_in_context=metadata_in_context,
 
                 **gen_hyper_dict,
 
@@ -4269,6 +4303,7 @@ def evaluate(
                                      hyde_template=hyde_template,
                                      hyde_show_only_final=hyde_show_only_final,
                                      doc_json_mode=doc_json_mode,
+                                     metadata_in_context=metadata_in_context,
 
                                      image_file=img_file,
                                      image_control=None,  # already stuffed into image_file
@@ -4776,6 +4811,8 @@ def get_generate_params(model_lower,
                         hyde_template,
                         hyde_show_only_final,
                         doc_json_mode,
+                        metadata_in_context,
+
                         chatbot_role,
                         speaker,
                         tts_language,
@@ -4987,6 +5024,7 @@ y = np.random.randint(0, 1, 100)
                     hyde_template,
                     hyde_show_only_final,
                     doc_json_mode,
+                    metadata_in_context,
 
                     chatbot_role,
                     speaker,

--- a/src/gradio_runner.py
+++ b/src/gradio_runner.py
@@ -1626,6 +1626,9 @@ def go_gradio(**kwargs):
                                                                label="JSON docs mode",
                                                                info="Whether to pass JSON to and get JSON back from LLM",
                                                                visible=True)
+                        metadata_in_context = gr.components.Textbox(value='[]',
+                                                              label="Metadata keys to include in LLM context (all, auto, or [key1, key2, ...] where strings are quoted)",
+                                                              visible=True)
 
                         embed = gr.components.Checkbox(value=True,
                                                        label="Embed text",

--- a/src/utils.py
+++ b/src/utils.py
@@ -1966,3 +1966,8 @@ def get_test_name_core():
     tn = os.environ['PYTEST_CURRENT_TEST'].split(':')[-1]
     tn = "_".join(tn.split(' ')[:-1])  # skip (call) at end
     return sanitize_filename(tn)
+
+
+class FullSet(set):
+    def __contains__(self, item):
+        return True

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -158,6 +158,7 @@ def run_eval1(cpu=False, bits=None, base_model='h2oai/h2ogpt-oig-oasst1-512-6_9b
                  'hyde_template': None,
                  'hyde_show_only_final': False,
                  'doc_json_mode': False,
+                 'metadata_in_context': [],
                  'chatbot_role': 'None',
                  'speaker': 'None',
                  'tts_language': 'autodetect',


### PR DESCRIPTION
without meta:

![image](https://github.com/h2oai/h2ogpt/assets/2249614/c9dc15c7-d217-4c43-8310-151c367afa02)

with all meta:

![image](https://github.com/h2oai/h2ogpt/assets/2249614/4cfb8b9f-a472-4b68-adc9-7c505a972bfb)


So for good models, e.g. here Nous Capybara 200k context based upon Yi 34B, meta doesn't cause issues, but of course there's less context for content.