### PR TITLE
Update MacOS doc with information related to BFloat16 error

### DIFF
--- a/docs/README_MACOS.md
+++ b/docs/README_MACOS.md
@@ -122,3 +122,11 @@ and run `sh run.sh` from the terminal placed in the parent folder of `run.sh`
       ```
 
 * If you encounter an error while building a wheel during the `pip install` process, you may need to install a C++ compiler on your computer.
+* If you see the error `TypeError: Trying to convert BFloat16 to the MPS backend but it does not have support for that dtype.`:
+  ```bash
+  pip install -U torch==2.3.0.dev20240229 --extra-index https://download.pytorch.org/whl/nightly/cpu --pre
+  pip install -U torchvision==0.18.0.dev20240229 --extra-index https://download.pytorch.org/whl/nightly/cpu --pre
+  ```
+  * Support for BFloat16 is added to MacOS from Sonama (14.0)
+  * Based on that a fix is added to torch with PR https://github.com/pytorch/pytorch/pull/119641 and it is still only available in nighlty. Expecting the feature with release `torch-2.3.0`
+  * **Note:** Updating torch to nighlty is experimental and it might break features in h2ogpt


### PR DESCRIPTION

![Screenshot 2024-02-29 at 11 15 41 PM](https://github.com/h2oai/h2ogpt/assets/30664910/c2e74ef4-b223-440c-a5ca-99c98b8e81da)


```python
  ~/Desktop/h2ogpt on   main ?6 ❯ python3 generate.py --base_model=openchat/openchat-3.5-1210 --hf_embedding_model=sentence-transformers/all-MiniLM-L6-v2 --score_model=None --load_4bit=True --langchain_mode='UserData' --enable_tts=False --enable_stt=False --enable_transcriptions=False --max_seq_len=2048                
Using Model openchat/openchat-3.5-1210
Starting get_model: openchat/openchat-3.5-1210 
Overriding max_seq_len -> 2048
Special tokens have been added in the vocabulary, make sure the associated word embeddings are fine-tuned or trained.
Overriding max_seq_len -> 2048
Special tokens have been added in the vocabulary, make sure the associated word embeddings are fine-tuned or trained.
Overriding max_seq_len -> 2048
Starting get_model: openchat/openchat-3.5-1210 
Overriding max_seq_len -> 2048
Special tokens have been added in the vocabulary, make sure the associated word embeddings are fine-tuned or trained.
Overriding max_seq_len -> 2048
Special tokens have been added in the vocabulary, make sure the associated word embeddings are fine-tuned or trained.
Overriding max_seq_len -> 2048
Loading checkpoint shards: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:11<00:00,  4.00s/it]
generation_config.json: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 179/179 [00:00<00:00, 2.45MB/s]
/Users/mathanraj/miniconda3/envs/h2ogpt/lib/python3.10/site-packages/transformers/generation/configuration_utils.py:410: UserWarning: `do_sample` is set to `False`. However, `temperature` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `temperature`. This was detected when initializing the generation config instance, which means the corresponding file may hold incorrect parameterization and should be fixed.
  warnings.warn(
/Users/mathanraj/miniconda3/envs/h2ogpt/lib/python3.10/site-packages/transformers/generation/configuration_utils.py:410: UserWarning: `do_sample` is set to `False`. However, `temperature` is set to `0.5` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `temperature`.
  warnings.warn(
WARNING:root:Some parameters are on the meta device device because they were offloaded to the disk.
Model {'base_model': 'openchat/openchat-3.5-1210', 'base_model0': 'openchat/openchat-3.5-1210', 'tokenizer_base_model': '', 'lora_weights': '', 'inference_server': '', 'prompt_type': 'open_chat_correct', 'prompt_dict': {'promptA': '', 'promptB': '', 'PreInstruct': 'GPT4 Correct User: ', 'PreInput': None, 'PreResponse': 'GPT4 Correct Assistant:', 'terminate_response': ['GPT4 Correct Assistant:', '<|end_of_turn|>'], 'chat_sep': '<|end_of_turn|>', 'chat_turn_sep': '<|end_of_turn|>', 'humanstr': 'GPT4 Correct User: ', 'botstr': 'GPT4 Correct Assistant:', 'generates_leading_space': False, 'system_prompt': '', 'can_handle_system_prompt': False}, 'visible_models': None, 'h2ogpt_key': None, 'load_8bit': False, 'load_4bit': False, 'low_bit_mode': 1, 'load_half': False, 'use_flash_attention_2': False, 'load_gptq': '', 'load_awq': '', 'load_exllama': False, 'use_safetensors': False, 'revision': None, 'use_gpu_id': False, 'gpu_id': None, 'compile_model': None, 'use_cache': None, 'llamacpp_dict': {'n_gpu_layers': 100, 'use_mlock': True, 'n_batch': 1024, 'n_gqa': 0, 'model_path_llama': '', 'model_name_gptj': '', 'model_name_gpt4all_llama': '', 'model_name_exllama_if_no_config': ''}, 'rope_scaling': {}, 'max_seq_len': 2048, 'max_output_seq_len': None, 'exllama_dict': {}, 'gptq_dict': {}, 'attention_sinks': False, 'sink_dict': {}, 'truncation_generation': False, 'hf_model_dict': {}}
Begin auto-detect HF cache text generation models
/Users/mathanraj/.cache/huggingface/modules/transformers_modules/mosaicml/mpt-7b-chat/1a1d410c70591fcc1a46486a254cd0e600e7b1b4/configuration_mpt.py:114: UserWarning: alibi or rope is turned on, setting `learned_pos_emb` to `False.`
  warnings.warn(f'alibi or rope is turned on, setting `learned_pos_emb` to `False.`')
/Users/mathanraj/.cache/huggingface/modules/transformers_modules/mosaicml/mpt-7b-chat/1a1d410c70591fcc1a46486a254cd0e600e7b1b4/configuration_mpt.py:141: UserWarning: If not using a Prefix Language Model, we recommend setting "attn_impl" to "flash" instead of "triton".
  warnings.warn(UserWarning('If not using a Prefix Language Model, we recommend setting "attn_impl" to "flash" instead of "triton".'))
End auto-detect HF cache text generation models
Begin auto-detect llama.cpp models
End auto-detect llama.cpp models
/Users/mathanraj/miniconda3/envs/h2ogpt/lib/python3.10/site-packages/gradio/components/dropdown.py:173: UserWarning: The value passed into gr.Dropdown() is not in the list of choices. Please update the list of choices to include: None or set allow_custom_value=True.
  warnings.warn(
Running on local URL:  http://0.0.0.0:7860

To create a public link, set `share=True` in `launch()`.
Started Gradio Server and/or GUI: server_name: localhost port: None
Use local URL: http://localhost:7860/
/Users/mathanraj/miniconda3/envs/h2ogpt/lib/python3.10/site-packages/pydantic/_internal/_fields.py:151: UserWarning: Field "model_name" has conflict with protected namespace "model_".

You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
  warnings.warn(
/Users/mathanraj/miniconda3/envs/h2ogpt/lib/python3.10/site-packages/pydantic/_internal/_fields.py:151: UserWarning: Field "model_names" has conflict with protected namespace "model_".

You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
  warnings.warn(
OpenAI API URL: http://0.0.0.0:5000
INFO:__name__:OpenAI API URL: http://0.0.0.0:5000
OpenAI API key: EMPTY
INFO:__name__:OpenAI API key: EMPTY
[Errno 48] error while attempting to bind on address ('0.0.0.0', 5000): address already in use
INFO:     127.0.0.1:60000 - "GET / HTTP/1.1" 200 OK
INFO:     127.0.0.1:60000 - "GET /assets/index-3aef7670.js HTTP/1.1" 200 OK
INFO:     127.0.0.1:60002 - "GET /assets/index-e657421a.css HTTP/1.1" 200 OK
INFO:     127.0.0.1:60000 - "GET /assets/svelte/svelte.js HTTP/1.1" 200 OK
INFO:     127.0.0.1:60002 - "GET /assets/Index-52a9d5ff.css HTTP/1.1" 200 OK
INFO:     127.0.0.1:60000 - "GET /assets/Index-a40ec24a.js HTTP/1.1" 200 OK
Client Connected: 11s84sajsuar
INFO:     127.0.0.1:60000 - "GET /info HTTP/1.1" 200 OK
INFO:     127.0.0.1:60002 - "GET /favicon.ico HTTP/1.1" 200 OK
INFO:     127.0.0.1:60000 - "GET /theme.css HTTP/1.1" 200 OK
```

@pseudotensor `BFloat16` support is added to MacOS 14.0 Sonama. 
PR from pytorch to add support for it https://github.com/pytorch/pytorch/pull/119641

We can only fully support it after `torch 2.3.0 ` is released and we upgrade to it. Meanwhile, h2ogpt users can use a nightly torch at their own risk.

Fix #1362 

