### PR TITLE
Stream in async for summary/extract

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -113,7 +113,7 @@ def run_cli(  # for local function:
         answer_with_sources=None,
         append_sources_to_answer=None,
         append_sources_to_chat=None,
-        show_accordions=None,
+        sources_show_in_accordion=None,
         top_k_docs_max_show=None,
         show_link_in_sources=None,
         langchain_instruct_mode=None,

--- a/src/cli.py
+++ b/src/cli.py
@@ -113,7 +113,7 @@ def run_cli(  # for local function:
         answer_with_sources=None,
         append_sources_to_answer=None,
         append_sources_to_chat=None,
-        sources_show_in_accordion=None,
+        sources_show_text_in_accordion=None,
         top_k_docs_max_show=None,
         show_link_in_sources=None,
         langchain_instruct_mode=None,

--- a/src/cli.py
+++ b/src/cli.py
@@ -65,6 +65,7 @@ def run_cli(  # for local function:
         hyde_template=None,
         hyde_show_only_final=None,
         hyde_show_intermediate_in_accordion=None,
+        map_reduce_show_intermediate_in_accordion=None,
         doc_json_mode=None,
         metadata_in_context=None,
         chatbot_role=None,

--- a/src/client_test.py
+++ b/src/client_test.py
@@ -454,7 +454,7 @@ def run_client_chat(prompt='',
 def run_client(client, prompt, args, kwargs, do_md_to_text=True, verbose=False):
     if is_gradio_version4:
         kwargs['answer_with_sources'] = True
-        kwargs['show_accordions'] = True
+        kwargs['sources_show_in_accordion'] = True
         kwargs['append_sources_to_answer'] = True
         kwargs['append_sources_to_chat'] = False
         kwargs['show_link_in_sources'] = True

--- a/src/client_test.py
+++ b/src/client_test.py
@@ -454,7 +454,7 @@ def run_client_chat(prompt='',
 def run_client(client, prompt, args, kwargs, do_md_to_text=True, verbose=False):
     if is_gradio_version4:
         kwargs['answer_with_sources'] = True
-        kwargs['sources_show_in_accordion'] = True
+        kwargs['sources_show_text_in_accordion'] = True
         kwargs['append_sources_to_answer'] = True
         kwargs['append_sources_to_chat'] = False
         kwargs['show_link_in_sources'] = True

--- a/src/eval.py
+++ b/src/eval.py
@@ -133,7 +133,7 @@ def run_eval(  # for local function:
         answer_with_sources=None,
         append_sources_to_answer=None,
         append_sources_to_chat=None,
-        show_accordions=None,
+        sources_show_in_accordion=None,
         top_k_docs_max_show=None,
         show_link_in_sources=None,
         langchain_instruct_mode=None,

--- a/src/eval.py
+++ b/src/eval.py
@@ -84,6 +84,7 @@ def run_eval(  # for local function:
         hyde_template=None,
         hyde_show_only_final=None,
         hyde_show_intermediate_in_accordion=None,
+        map_reduce_show_intermediate_in_accordion=None,
         doc_json_mode=None,
         metadata_in_context=None,
         chatbot_role=None,

--- a/src/eval.py
+++ b/src/eval.py
@@ -133,7 +133,7 @@ def run_eval(  # for local function:
         answer_with_sources=None,
         append_sources_to_answer=None,
         append_sources_to_chat=None,
-        sources_show_in_accordion=None,
+        sources_show_text_in_accordion=None,
         top_k_docs_max_show=None,
         show_link_in_sources=None,
         langchain_instruct_mode=None,

--- a/src/gen.py
+++ b/src/gen.py
@@ -447,6 +447,7 @@ def main(
         hyde_template: str = None,
         hyde_show_only_final: bool = False,
         hyde_show_intermediate_in_accordion: bool = True,
+        map_reduce_show_intermediate_in_accordion: bool = True,
         doc_json_mode: bool = False,
         metadata_in_context: Union[str, list] = 'auto',
 
@@ -904,6 +905,7 @@ def main(
                  '{query}' is minimal template one can pass
     :param hyde_show_only_final:  Whether to show only last result of HYDE, not intermediate steps
     :param hyde_show_intermediate_in_accordion: Whether to show intermediate HYDE, but inside HTML accordion
+    :param map_reduce_show_intermediate_in_accordion: Whether to show intermediate map_reduce, but inside HTML accordion
 
     :param visible_models: Which models in model_lock list to show by default
            Takes integers of position in model_lock (model_states) list or strings of base_model names
@@ -3824,6 +3826,7 @@ def evaluate(
         text_limit=None,
         show_accordions=None,
         hyde_show_intermediate_in_accordion=None,
+        map_reduce_show_intermediate_in_accordion=None,
         top_k_docs_max_show=None,
         show_link_in_sources=None,
         langchain_instruct_mode=None,
@@ -4374,6 +4377,7 @@ def evaluate(
                 text_limit=text_limit,
                 show_accordions=show_accordions,
                 hyde_show_intermediate_in_accordion=hyde_show_intermediate_in_accordion,
+                map_reduce_show_intermediate_in_accordion=map_reduce_show_intermediate_in_accordion,
                 top_k_docs_max_show=top_k_docs_max_show,
                 show_link_in_sources=show_link_in_sources,
                 langchain_instruct_mode=langchain_instruct_mode,
@@ -4456,6 +4460,8 @@ def evaluate(
                 guided_grammar=guided_grammar,
 
                 json_vllm=json_vllm,
+
+                from_ui=from_ui,
         ):
             # doesn't accumulate, new answer every yield, so only save that full answer
             response = r['response']

--- a/src/gen.py
+++ b/src/gen.py
@@ -3034,12 +3034,14 @@ def get_model(
                 assert api_key, "No OpenAI key detected.  Set environment for OPENAI_API_KEY or add to inference server line: %s" % inference_server
             # Don't return None, None for model, tokenizer so triggers
             if base_model in model_token_mapping:
-                max_seq_len = model_token_mapping[base_model]
+                if max_seq_len is None:
+                    max_seq_len = model_token_mapping[base_model]
             else:
                 print("Using unknown (or proxy) OpenAI model: %s for inference_server=%s" % (
                     base_model, inference_server))
             if base_model in model_token_mapping_outputs:
-                max_output_len = model_token_mapping_outputs[base_model]
+                if max_output_len is None:
+                    max_output_len = model_token_mapping_outputs[base_model]
             else:
                 if os.getenv('HARD_ASSERTS'):
                     assert max_output_seq_len is not None, "Must set max_output_seq_len"
@@ -3052,11 +3054,13 @@ def get_model(
             # Don't return None, None for model, tokenizer so triggers
             # include small token cushion
             if base_model in anthropic_mapping:
-                max_seq_len = anthropic_mapping[base_model]
+                if max_seq_len is None:
+                    max_seq_len = anthropic_mapping[base_model]
             else:
                 raise ValueError("Invalid base_model=%s for inference_server=%s" % (base_model, inference_server))
             if base_model in anthropic_mapping_outputs:
-                max_output_len = anthropic_mapping_outputs[base_model]
+                if max_output_len is None:
+                    max_output_len = anthropic_mapping_outputs[base_model]
             else:
                 if os.getenv('HARD_ASSERTS'):
                     assert max_output_seq_len is not None, "Must set max_output_seq_len"
@@ -3069,11 +3073,13 @@ def get_model(
             # Don't return None, None for model, tokenizer so triggers
             # include small token cushion
             if base_model in google_mapping:
-                max_seq_len = google_mapping[base_model]
+                if max_seq_len is None:
+                    max_seq_len = google_mapping[base_model]
             else:
                 raise ValueError("Invalid base_model=%s for inference_server=%s" % (base_model, inference_server))
             if base_model in google_mapping_outputs:
-                max_output_len = google_mapping_outputs[base_model]
+                if max_output_len is None:
+                    max_output_len = google_mapping_outputs[base_model]
             else:
                 if os.getenv('HARD_ASSERTS'):
                     assert max_output_seq_len is not None, "Must set max_output_seq_len"
@@ -3092,11 +3098,13 @@ def get_model(
             # Don't return None, None for model, tokenizer so triggers
             # include small token cushion
             if base_model in mistralai_mapping:
-                max_seq_len = mistralai_mapping[base_model]
+                if max_seq_len is None:
+                    max_seq_len = mistralai_mapping[base_model]
             else:
                 raise ValueError("Invalid base_model=%s for inference_server=%s" % (base_model, inference_server))
             if base_model in mistralai_mapping_outputs:
-                max_output_len = mistralai_mapping_outputs[base_model]
+                if max_output_len is None:
+                    max_output_len = mistralai_mapping_outputs[base_model]
             else:
                 if os.getenv('HARD_ASSERTS'):
                     assert max_output_seq_len is not None, "Must set max_output_seq_len"
@@ -3121,11 +3129,13 @@ def get_model(
             # Don't return None, None for model, tokenizer so triggers
             # include small token cushion
             if base_model in groq_mapping:
-                max_seq_len = groq_mapping[base_model]
+                if max_seq_len is None:
+                    max_seq_len = groq_mapping[base_model]
             else:
                 raise ValueError("Invalid base_model=%s for inference_server=%s" % (base_model, inference_server))
             if base_model in groq_mapping_outputs:
-                max_output_len = groq_mapping_outputs[base_model]
+                if max_output_len is None:
+                    max_output_len = groq_mapping_outputs[base_model]
             else:
                 if os.getenv('HARD_ASSERTS'):
                     assert max_output_seq_len is not None, "Must set max_output_seq_len"

--- a/src/gen.py
+++ b/src/gen.py
@@ -414,7 +414,7 @@ def main(
         answer_with_sources: bool = True,
         append_sources_to_answer: bool = False,
         append_sources_to_chat: bool = True,
-        sources_show_in_accordion: bool = True,
+        sources_show_text_in_accordion: bool = True,
         top_k_docs_max_show: int = 10,
         show_link_in_sources: bool = True,
         langchain_instruct_mode: bool = True,
@@ -1053,7 +1053,7 @@ def main(
     :param answer_with_sources: Whether to determine (and return) sources
     :param append_sources_to_answer: Whether to place source information in chat response (ignored by LLM).  Always disabled for API.
     :param append_sources_to_chat: Whether to place sources information in chat response but in separate chat turn (ignored by LLM).  Always disabled for API.
-    :param sources_show_in_accordion: whether to show accordion for document references in chatbot UI
+    :param sources_show_text_in_accordion: whether to show accordion for document references in chatbot UI
     :param top_k_docs_max_show: Max number of docs to show in UI for sources
            If web search is enabled, then this is modified to be max(top_k_docs_max_show, number of links used in search)
     :param show_link_in_sources: Whether to show URL link to source document in references
@@ -3824,7 +3824,7 @@ def evaluate(
         n_jobs=None,
         first_para=None,
         text_limit=None,
-        sources_show_in_accordion=None,
+        sources_show_text_in_accordion=None,
         hyde_show_intermediate_in_accordion=None,
         map_reduce_show_intermediate_in_accordion=None,
         top_k_docs_max_show=None,
@@ -4375,7 +4375,7 @@ def evaluate(
                 auto_migrate_db=auto_migrate_db,
                 first_para=first_para,
                 text_limit=text_limit,
-                sources_show_in_accordion=sources_show_in_accordion,
+                sources_show_text_in_accordion=sources_show_text_in_accordion,
                 hyde_show_intermediate_in_accordion=hyde_show_intermediate_in_accordion,
                 map_reduce_show_intermediate_in_accordion=map_reduce_show_intermediate_in_accordion,
                 top_k_docs_max_show=top_k_docs_max_show,

--- a/src/gen.py
+++ b/src/gen.py
@@ -414,7 +414,7 @@ def main(
         answer_with_sources: bool = True,
         append_sources_to_answer: bool = False,
         append_sources_to_chat: bool = True,
-        show_accordions: bool = True,
+        sources_show_in_accordion: bool = True,
         top_k_docs_max_show: int = 10,
         show_link_in_sources: bool = True,
         langchain_instruct_mode: bool = True,
@@ -1053,7 +1053,7 @@ def main(
     :param answer_with_sources: Whether to determine (and return) sources
     :param append_sources_to_answer: Whether to place source information in chat response (ignored by LLM).  Always disabled for API.
     :param append_sources_to_chat: Whether to place sources information in chat response but in separate chat turn (ignored by LLM).  Always disabled for API.
-    :param show_accordions: whether to show accordion for document references in chatbot UI
+    :param sources_show_in_accordion: whether to show accordion for document references in chatbot UI
     :param top_k_docs_max_show: Max number of docs to show in UI for sources
            If web search is enabled, then this is modified to be max(top_k_docs_max_show, number of links used in search)
     :param show_link_in_sources: Whether to show URL link to source document in references
@@ -3824,7 +3824,7 @@ def evaluate(
         n_jobs=None,
         first_para=None,
         text_limit=None,
-        show_accordions=None,
+        sources_show_in_accordion=None,
         hyde_show_intermediate_in_accordion=None,
         map_reduce_show_intermediate_in_accordion=None,
         top_k_docs_max_show=None,
@@ -4375,7 +4375,7 @@ def evaluate(
                 auto_migrate_db=auto_migrate_db,
                 first_para=first_para,
                 text_limit=text_limit,
-                show_accordions=show_accordions,
+                sources_show_in_accordion=sources_show_in_accordion,
                 hyde_show_intermediate_in_accordion=hyde_show_intermediate_in_accordion,
                 map_reduce_show_intermediate_in_accordion=map_reduce_show_intermediate_in_accordion,
                 top_k_docs_max_show=top_k_docs_max_show,

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -627,7 +627,11 @@ class AGenerateStreamFirst:
         **kwargs: Any,
     ) -> LLMResult:
         # NOTE: overwrite of base class so can specify which messages will have callbacks
-        callbacks_only_first = kwargs.get('stream', False) or kwargs.get('streaming', False)
+        callbacks_only_first = kwargs.get('stream', False) or \
+                                kwargs.get('streaming', False) or \
+                                hasattr(self, 'streaming') and self.streaming or \
+                                hasattr(self, 'stream') and self.stream or \
+                                hasattr(self, 'stream_output') and self.stream_output
 
         # Create callback managers
         if isinstance(callbacks, list) and (
@@ -786,7 +790,8 @@ class ChatAGenerateStreamFirst:
         callbacks_only_first = kwargs.get('stream', False) or \
                                 kwargs.get('streaming', False) or \
                                 hasattr(self, 'streaming') and self.streaming or \
-                                hasattr(self, 'stream') and self.stream
+                                hasattr(self, 'stream') and self.stream or \
+                                hasattr(self, 'stream_output') and self.stream_output
         if self.verbose:
             print("messages: %s" % len(messages))
 

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -6343,13 +6343,13 @@ def run_target(query='',
                                     output1 = outputs
                                 # in-place change to this key so exposed outside this generator
                                 if llm_answers_key in ['map_reduce_', 'map_']:
-                                    llm_answers[llm_answers_key + '%s' % count_map_reduces] = output1
+                                    llm_answers[llm_answers_key + '%s' % (1 + count_map_reduces)] = output1
                                     if llm_answers_key == 'map_reduce_':
-                                        response_prefix = "Computing Summarize Step %d:\n------------------\n" % (
-                                                    1 + count_map_reduces)
+                                        response_prefix = "Computing Summarization Step %d:\n------------------\n" % (
+                                                1 + count_map_reduces)
                                     else:
                                         response_prefix = "Computing Extraction Step %d:\n------------------\n" % (
-                                                    1 + count_map_reduces)
+                                                1 + count_map_reduces)
                                 else:
                                     llm_answers[llm_answers_key] = output1
                                 res_dict = dict(prompt=query, response=response_prefix + output1,

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -5840,7 +5840,7 @@ def run_qa_db(**kwargs):
     # hard-coded defaults
     kwargs['answer_with_sources'] = kwargs.get('answer_with_sources', True)
     kwargs['show_rank'] = kwargs.get('show_rank', False)
-    kwargs['show_accordions'] = kwargs.get('show_accordions', True)
+    kwargs['sources_show_in_accordion'] = kwargs.get('sources_show_in_accordion', True)
     kwargs['hyde_show_intermediate_in_accordion'] = kwargs.get('hyde_show_intermediate_in_accordion', True)
     kwargs['map_reduce_show_intermediate_in_accordion'] = kwargs.get('map_reduce_show_intermediate_in_accordion', True)
     kwargs['show_link_in_sources'] = kwargs.get('show_link_in_sources', True)
@@ -5948,7 +5948,7 @@ def _run_qa_db(query=None,
                allow_chat_system_prompt=True,
                sanitize_bot_response=False,
                show_rank=False,
-               show_accordions=True,
+               sources_show_in_accordion=True,
                hyde_show_intermediate_in_accordion=True,
                map_reduce_show_intermediate_in_accordion=True,
                show_link_in_sources=True,
@@ -6284,7 +6284,7 @@ Respond to prompt of Final Answer with your final well-structured%s answer to th
     if isinstance(document_content_substrings, str):
         document_content_substrings = [document_content_substrings]
 
-    get_answer_kwargs = dict(show_accordions=show_accordions,
+    get_answer_kwargs = dict(sources_show_in_accordion=sources_show_in_accordion,
                              hyde_show_intermediate_in_accordion=hyde_show_intermediate_in_accordion,
                              map_reduce_show_intermediate_in_accordion=map_reduce_show_intermediate_in_accordion,
                              show_link_in_sources=show_link_in_sources,
@@ -8370,7 +8370,7 @@ def get_sources_answer(query, docs, answer,
                        answer_with_sources,
                        append_sources_to_answer,
                        append_sources_to_chat,
-                       show_accordions=True,
+                       sources_show_in_accordion=True,
                        hyde_show_intermediate_in_accordion=True,
                        map_reduce_show_intermediate_in_accordion=True,
                        show_link_in_sources=True,
@@ -8412,7 +8412,7 @@ def get_sources_answer(query, docs, answer,
                        get_url(doc, font_size=font_size),
                        get_accordion(doc, font_size=font_size, head_acc=head_acc)) for score, doc in
                       zip(scores, docs)]
-    if not show_accordions:
+    if not sources_show_in_accordion:
         answer_sources_dict = defaultdict(list)
         [answer_sources_dict[url].append((score, accordion)) for score, url, accordion in answer_sources]
         answers_dict = {}
@@ -8429,7 +8429,7 @@ def get_sources_answer(query, docs, answer,
         answer_sources = answer_sources[:top_k_docs_max_show]
         sorted_sources_urls = "Ranked Sources:<br>" + "<br>".join(answer_sources)
     else:
-        if show_accordions:
+        if sources_show_in_accordion:
             if show_link_in_sources:
                 answer_sources = ['<font size="%s"><li>%.2g | %s</li>%s</font>' % (font_size, score, url, accordion)
                                   for score, url, accordion in answer_sources]
@@ -8444,7 +8444,7 @@ def get_sources_answer(query, docs, answer,
                 answer_sources = ['<font size="%s"><li>%.2g</li></font>' % (font_size, score)
                                   for score, url, accordion in answer_sources]
         answer_sources = answer_sources[:top_k_docs_max_show]
-        if show_accordions:
+        if sources_show_in_accordion:
             sorted_sources_urls = f"<font size=\"{font_size}\">{source_prefix}<ul></font>" + "".join(answer_sources)
         else:
             sorted_sources_urls = f"<font size=\"{font_size}\">{source_prefix}<p><ul></font>" + "<p>".join(

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -1796,7 +1796,7 @@ class H2OTextGenOpenAI:
             return super().get_token_ids(text)
 
 
-class H2OOpenAI(OpenAI):
+class H2OOpenAI(H2OTextGenOpenAI, OpenAI):
     """
     New class to handle vLLM's use of OpenAI, no vllm_chat supported, so only need here
     Handles prompting that OpenAI doesn't need, stopping as well

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -5756,7 +5756,9 @@ def _run_qa_db(query=None,
     else:
         if stream_output0:
             # threads and asyncio don't mix
-            async_output = True
+            # but if do asyncio inside thread, all fine
+            # async_output = True
+            pass
         else:
             # go back to not streaming for summarization/extraction to be parallel
             stream_output = stream_output0

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -2453,6 +2453,7 @@ def get_llm(use_openai_model=False,
         inference_server = ''
 
     if inference_server.startswith('replicate'):
+        async_output = False  # no real async
         model_string = ':'.join(inference_server.split(':')[1:])
         if 'meta/llama' in model_string:
             temperature = max(0.01, temperature if do_sample else 0)
@@ -2826,8 +2827,10 @@ def get_llm(use_openai_model=False,
         streamer = callbacks[0] if stream_output else None
         prompt_type = inference_server
     elif inference_server and inference_server.startswith('sagemaker'):
+        async_output = False  # no real async
         callbacks = [streaming_callback]  # FIXME
         streamer = None
+        async_output = False  # no real async
 
         endpoint_name = ':'.join(inference_server.split(':')[1:2])
         region_name = ':'.join(inference_server.split(':')[2:])
@@ -3025,7 +3028,7 @@ def get_llm(use_openai_model=False,
             raise RuntimeError("No defined client")
         streamer = callbacks[0] if stream_output else None
     elif model_name in non_hf_types:
-        async_output = False  # FIXME: not implemented yet
+        async_output = False  # FIXME: not implemented yet, and wouldn't make much sense as won't be faster
         assert langchain_only_model
         if model_name == 'llama':
             callbacks = [streaming_callback]

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -615,39 +615,39 @@ class AGenerateStreamFirst:
     # from:
     # langchain_core/language_models/llms.py
     async def agenerate(
-        self,
-        prompts: List[str],
-        stop: Optional[List[str]] = None,
-        callbacks: Optional[typing.Union[Callbacks, List[Callbacks]]] = None,
-        *,
-        tags: Optional[typing.Union[List[str], List[List[str]]]] = None,
-        metadata: Optional[typing.Union[Dict[str, Any], List[Dict[str, Any]]]] = None,
-        run_name: Optional[typing.Union[str, List[str]]] = None,
-        run_id: Optional[typing.Union[uuid.UUID, List[Optional[uuid.UUID]]]] = None,
-        **kwargs: Any,
+            self,
+            prompts: List[str],
+            stop: Optional[List[str]] = None,
+            callbacks: Optional[typing.Union[Callbacks, List[Callbacks]]] = None,
+            *,
+            tags: Optional[typing.Union[List[str], List[List[str]]]] = None,
+            metadata: Optional[typing.Union[Dict[str, Any], List[Dict[str, Any]]]] = None,
+            run_name: Optional[typing.Union[str, List[str]]] = None,
+            run_id: Optional[typing.Union[uuid.UUID, List[Optional[uuid.UUID]]]] = None,
+            **kwargs: Any,
     ) -> LLMResult:
         # NOTE: overwrite of base class so can specify which messages will have callbacks
         callbacks_only_first = kwargs.get('stream', False) or \
-                                kwargs.get('streaming', False) or \
-                                hasattr(self, 'streaming') and self.streaming or \
-                                hasattr(self, 'stream') and self.stream or \
-                                hasattr(self, 'stream_output') and self.stream_output
+                               kwargs.get('streaming', False) or \
+                               hasattr(self, 'streaming') and self.streaming or \
+                               hasattr(self, 'stream') and self.stream or \
+                               hasattr(self, 'stream_output') and self.stream_output
 
         # Create callback managers
         if isinstance(callbacks, list) and (
-            isinstance(callbacks[0], (list, BaseCallbackManager))
-            or callbacks[0] is None
+                isinstance(callbacks[0], (list, BaseCallbackManager))
+                or callbacks[0] is None
         ):
             # We've received a list of callbacks args to apply to each input
             assert len(callbacks) == len(prompts)
             assert tags is None or (
-                isinstance(tags, list) and len(tags) == len(prompts)
+                    isinstance(tags, list) and len(tags) == len(prompts)
             )
             assert metadata is None or (
-                isinstance(metadata, list) and len(metadata) == len(prompts)
+                    isinstance(metadata, list) and len(metadata) == len(prompts)
             )
             assert run_name is None or (
-                isinstance(run_name, list) and len(run_name) == len(prompts)
+                    isinstance(run_name, list) and len(run_name) == len(prompts)
             )
             callbacks = typing.cast(List[Callbacks], callbacks)
             tags_list = typing.cast(List[Optional[List[str]]], tags or ([None] * len(prompts)))
@@ -672,16 +672,16 @@ class AGenerateStreamFirst:
         else:
             # We've received a single callbacks arg to apply to all inputs
             callback_managers = [
-                AsyncCallbackManager.configure(
-                    typing.cast(Callbacks, callbacks),
-                    self.callbacks,
-                    self.verbose,
-                    typing.cast(List[str], tags),
-                    self.tags,
-                    typing.cast(Dict[str, Any], metadata),
-                    self.metadata,
-                )
-            ] * len(prompts)
+                                    AsyncCallbackManager.configure(
+                                        typing.cast(Callbacks, callbacks),
+                                        self.callbacks,
+                                        self.verbose,
+                                        typing.cast(List[str], tags),
+                                        self.tags,
+                                        typing.cast(Dict[str, Any], metadata),
+                                        self.metadata,
+                                    )
+                                ] * len(prompts)
             run_name_list = [typing.cast(Optional[str], run_name)] * len(prompts)
         run_ids_list = self._get_run_ids_list(run_id, prompts)
         params = self.dict()
@@ -788,10 +788,10 @@ class ChatAGenerateStreamFirst:
     ) -> LLMResult:
         # NOTE: overwrite of base class so can specify which messages will have callbacks
         callbacks_only_first = kwargs.get('stream', False) or \
-                                kwargs.get('streaming', False) or \
-                                hasattr(self, 'streaming') and self.streaming or \
-                                hasattr(self, 'stream') and self.stream or \
-                                hasattr(self, 'stream_output') and self.stream_output
+                               kwargs.get('streaming', False) or \
+                               hasattr(self, 'streaming') and self.streaming or \
+                               hasattr(self, 'stream') and self.stream or \
+                               hasattr(self, 'stream_output') and self.stream_output
         if self.verbose:
             print("messages: %s" % len(messages))
 

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -6904,7 +6904,7 @@ def run_hyde(*args, **kwargs):
             response_prefix = "Computing HYDE %d/%d response:\n------------------\n" % (1 + hyde_level1, hyde_level) \
                 if hyde_level1 < hyde_level else ''
         else:
-            response_perfix = ''
+            response_prefix = ''
         answer = ''
         for ret in run_target_func(query=query,
                                    chain=chain,

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -5842,6 +5842,7 @@ def run_qa_db(**kwargs):
     kwargs['show_rank'] = kwargs.get('show_rank', False)
     kwargs['show_accordions'] = kwargs.get('show_accordions', True)
     kwargs['hyde_show_intermediate_in_accordion'] = kwargs.get('hyde_show_intermediate_in_accordion', True)
+    kwargs['map_reduce_show_intermediate_in_accordion'] = kwargs.get('map_reduce_show_intermediate_in_accordion', True)
     kwargs['show_link_in_sources'] = kwargs.get('show_link_in_sources', True)
     kwargs['top_k_docs_max_show'] = kwargs.get('top_k_docs_max_show', 10)
     kwargs['llamacpp_dict'] = {}  # shouldn't be required unless from test using _run_qa_db

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -85,7 +85,7 @@ from prompter import non_hf_types, PromptType, Prompter, get_vllm_extra_dict, sy
     is_vision_model, is_gradio_vision_model, is_json_model
 from src.serpapi import H2OSerpAPIWrapper
 from utils_langchain import StreamingGradioCallbackHandler, _chunk_sources, _add_meta, add_parser, fix_json_meta, \
-    load_general_summarization_chain, H2OHuggingFaceHubEmbeddings
+    load_general_summarization_chain, H2OHuggingFaceHubEmbeddings, make_sources_file
 
 # to check imports
 # find ./src -name '*.py' |  xargs awk '{ if (sub(/\\$/, "")) printf "%s ", $0; else print; }' |  grep 'from langchain\.' |  sed 's/^[ \t]*//' > go.py
@@ -8621,15 +8621,6 @@ def get_sources(db1s, selection_docs_state1, requests_state1, langchain_mode,
     if DocumentChoice.ALL.value in source_list:
         source_list.remove(DocumentChoice.ALL.value)
     return sources_file, source_list, num_chunks, num_sources_str, db
-
-
-def make_sources_file(langchain_mode, source_files_added):
-    sources_dir = "sources_dir"
-    sources_dir = makedirs(sources_dir, exist_ok=True, tmp_ok=True, use_base=True)
-    sources_file = os.path.join(sources_dir, 'sources_%s_%s' % (langchain_mode, str(uuid.uuid4())))
-    with open(sources_file, "wt", encoding="utf-8") as f:
-        f.write(source_files_added)
-    return sources_file
 
 
 def update_user_db(file, db1s, selection_docs_state1, requests_state1,

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -2026,6 +2026,7 @@ class GenerateStream:
 
     def tool_string_return(self, ret, have_tool):
         if have_tool and isinstance(ret.generations[0].text, list):
+            # prior beta
             # overwrite
             if not ret.generations[0].text:
                 ret.generations[0].text = json.dumps({})
@@ -2033,6 +2034,18 @@ class GenerateStream:
                 # -1 is last, to skip first thinking step for opus/sonnet
                 # bug in claude with sonnet:
                 result = ret.generations[0].text[-1]['input']
+                if isinstance(result, dict) and len(result) == 1 and 'properties' in result:
+                    result = result['properties']
+                ret.generations[0].text = json.dumps(result)
+        elif have_tool and isinstance(ret.generations[0].message.content, list):
+            # new beta
+            # overwrite
+            if not ret.generations[0].message.content:
+                ret.generations[0].text = json.dumps({})
+            else:
+                # -1 is last, to skip first thinking step for opus/sonnet
+                # bug in claude with sonnet:
+                result = ret.generations[0].message.content[-1]['input']
                 if isinstance(result, dict) and len(result) == 1 and 'properties' in result:
                     result = result['properties']
                 ret.generations[0].text = json.dumps(result)
@@ -6267,7 +6280,7 @@ Respond to prompt of Final Answer with your final well-structured%s answer to th
             inference_server.startswith('anthropic') and \
             is_json_model(model_name, inference_server) and \
             guided_json and response_format == 'json_object':
-        extra = '\n\nUse the `JSON` tool.\n'
+        extra = '\n\nUse the `JSON` tool.  Do not respond with thinking, just use the tool right away.\n'
         if query_action:
             query += extra
         prompt_summary += extra

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -5756,7 +5756,7 @@ def _run_qa_db(query=None,
     else:
         if stream_output0:
             # threads and asyncio don't mix
-            async_output = False
+            async_output = True
         else:
             # go back to not streaming for summarization/extraction to be parallel
             stream_output = stream_output0
@@ -6171,7 +6171,7 @@ def run_target(query='',
                 answer = None
                 import queue
                 bucket = queue.Queue()
-                thread = EThread(target=chain, streamer=streamer, bucket=bucket)
+                thread = EThread(target=chain, streamer=streamer, bucket=bucket, async_output=async_output)
                 thread.start()
                 outputs = ""
                 output1_old = ''

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -1855,13 +1855,17 @@ class H2OReplicate(Replicate):
         response = super()._call(prompt, stop=stop, run_manager=run_manager, **kwargs)
         return response
 
-    def get_token_ids(self, text: str) -> List[int]:
-        return self.tokenizer.encode(text)
-        # avoid base method that is not aware of how to properly tokenize (uses GPT2)
-        # return _get_token_ids_default_method(text)
-
 
 class ExtraChat:
+    def get_token_ids(self, text: str) -> List[int]:
+        if self.tokenizer is not None:
+            if isinstance(self.tokenizer, FakeTokenizer):
+                return self.tokenizer.encode(text)['input_ids']
+            else:
+                return self.tokenizer.encode(text)
+        else:
+            return FakeTokenizer().encode(text)['input_ids']
+
     def get_messages(self, prompts):
         from langchain.schema import AIMessage, SystemMessage, HumanMessage
         messages = []
@@ -2235,14 +2239,6 @@ class H2OChatGoogle(ChatAGenerateStreamFirst, GenerateStream, ExtraChat, ChatGoo
     count_input_tokens: Any = 0
     count_output_tokens: Any = 0
 
-    def get_token_ids(self, text: str) -> List[int]:
-        if self.tokenizer is not None:
-            return self.tokenizer.encode(text)
-        else:
-            return FakeTokenizer().encode(text)['input_ids']
-
-    # max_new_tokens0: Any = None  # FIXME: Doesn't seem to have same max_tokens == -1 for prompts==1
-
 
 class H2OChatMistralAI(ChatAGenerateStreamFirst, GenerateStream2, ExtraChat, ChatMistralAI):
     system_prompt: Any = None
@@ -2256,12 +2252,6 @@ class H2OChatMistralAI(ChatAGenerateStreamFirst, GenerateStream2, ExtraChat, Cha
 
     # max_new_tokens0: Any = None  # FIXME: Doesn't seem to have same max_tokens == -1 for prompts==1
 
-    def get_token_ids(self, text: str) -> List[int]:
-        if self.tokenizer is not None:
-            return self.tokenizer.encode(text)
-        else:
-            return FakeTokenizer().encode(text)['input_ids']
-
 
 class H2OChatGroq(ChatAGenerateStreamFirst, GenerateStream2, ExtraChat, ChatGroq):
     system_prompt: Any = None
@@ -2272,14 +2262,6 @@ class H2OChatGroq(ChatAGenerateStreamFirst, GenerateStream2, ExtraChat, ChatGroq
     count_input_tokens: Any = 0
     count_output_tokens: Any = 0
     response_format: Any = None
-
-    # max_new_tokens0: Any = None  # FIXME: Doesn't seem to have same max_tokens == -1 for prompts==1
-
-    def get_token_ids(self, text: str) -> List[int]:
-        if self.tokenizer is not None:
-            return self.tokenizer.encode(text)
-        else:
-            return FakeTokenizer().encode(text)['input_ids']
 
 
 class H2OAzureOpenAI(H2OTextGenOpenAI, AzureOpenAI):

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -6555,6 +6555,7 @@ def run_target(query='',
                                         response_prefix = "Computing Extraction Step %d:\n------------------\n" % (
                                                 1 + count_map_reduces)
                                 else:
+                                    response_prefix = ''
                                     llm_answers[llm_answers_key] = output1
                                 res_dict = dict(prompt=query, response=response_prefix + output1,
                                                 sources='', num_prompt_tokens=0,

--- a/src/gpt_langchain.py
+++ b/src/gpt_langchain.py
@@ -5840,7 +5840,7 @@ def run_qa_db(**kwargs):
     # hard-coded defaults
     kwargs['answer_with_sources'] = kwargs.get('answer_with_sources', True)
     kwargs['show_rank'] = kwargs.get('show_rank', False)
-    kwargs['sources_show_in_accordion'] = kwargs.get('sources_show_in_accordion', True)
+    kwargs['sources_show_text_in_accordion'] = kwargs.get('sources_show_text_in_accordion', True)
     kwargs['hyde_show_intermediate_in_accordion'] = kwargs.get('hyde_show_intermediate_in_accordion', True)
     kwargs['map_reduce_show_intermediate_in_accordion'] = kwargs.get('map_reduce_show_intermediate_in_accordion', True)
     kwargs['show_link_in_sources'] = kwargs.get('show_link_in_sources', True)
@@ -5948,7 +5948,7 @@ def _run_qa_db(query=None,
                allow_chat_system_prompt=True,
                sanitize_bot_response=False,
                show_rank=False,
-               sources_show_in_accordion=True,
+               sources_show_text_in_accordion=True,
                hyde_show_intermediate_in_accordion=True,
                map_reduce_show_intermediate_in_accordion=True,
                show_link_in_sources=True,
@@ -6284,7 +6284,7 @@ Respond to prompt of Final Answer with your final well-structured%s answer to th
     if isinstance(document_content_substrings, str):
         document_content_substrings = [document_content_substrings]
 
-    get_answer_kwargs = dict(sources_show_in_accordion=sources_show_in_accordion,
+    get_answer_kwargs = dict(sources_show_text_in_accordion=sources_show_text_in_accordion,
                              hyde_show_intermediate_in_accordion=hyde_show_intermediate_in_accordion,
                              map_reduce_show_intermediate_in_accordion=map_reduce_show_intermediate_in_accordion,
                              show_link_in_sources=show_link_in_sources,
@@ -8370,7 +8370,7 @@ def get_sources_answer(query, docs, answer,
                        answer_with_sources,
                        append_sources_to_answer,
                        append_sources_to_chat,
-                       sources_show_in_accordion=True,
+                       sources_show_text_in_accordion=True,
                        hyde_show_intermediate_in_accordion=True,
                        map_reduce_show_intermediate_in_accordion=True,
                        show_link_in_sources=True,
@@ -8412,7 +8412,7 @@ def get_sources_answer(query, docs, answer,
                        get_url(doc, font_size=font_size),
                        get_accordion(doc, font_size=font_size, head_acc=head_acc)) for score, doc in
                       zip(scores, docs)]
-    if not sources_show_in_accordion:
+    if not sources_show_text_in_accordion:
         answer_sources_dict = defaultdict(list)
         [answer_sources_dict[url].append((score, accordion)) for score, url, accordion in answer_sources]
         answers_dict = {}
@@ -8429,7 +8429,7 @@ def get_sources_answer(query, docs, answer,
         answer_sources = answer_sources[:top_k_docs_max_show]
         sorted_sources_urls = "Ranked Sources:<br>" + "<br>".join(answer_sources)
     else:
-        if sources_show_in_accordion:
+        if sources_show_text_in_accordion:
             if show_link_in_sources:
                 answer_sources = ['<font size="%s"><li>%.2g | %s</li>%s</font>' % (font_size, score, url, accordion)
                                   for score, url, accordion in answer_sources]
@@ -8444,7 +8444,7 @@ def get_sources_answer(query, docs, answer,
                 answer_sources = ['<font size="%s"><li>%.2g</li></font>' % (font_size, score)
                                   for score, url, accordion in answer_sources]
         answer_sources = answer_sources[:top_k_docs_max_show]
-        if sources_show_in_accordion:
+        if sources_show_text_in_accordion:
             sorted_sources_urls = f"<font size=\"{font_size}\">{source_prefix}<ul></font>" + "".join(answer_sources)
         else:
             sorted_sources_urls = f"<font size=\"{font_size}\">{source_prefix}<p><ul></font>" + "<p>".join(

--- a/src/gradio_runner.py
+++ b/src/gradio_runner.py
@@ -2702,19 +2702,19 @@ def go_gradio(**kwargs):
         db_events.extend([event_attach1, event_attach2])
 
         get_sources_fun_kwargs = dict(dbs=dbs, docs_state0=docs_state0,
-                                         load_db_if_exists=load_db_if_exists,
-                                         db_type=db_type,
-                                         use_openai_embedding=use_openai_embedding,
-                                         hf_embedding_model=hf_embedding_model,
-                                         migrate_embedding_model=migrate_embedding_model,
-                                         auto_migrate_db=auto_migrate_db,
-                                         verbose=verbose,
-                                         get_userid_auth=get_userid_auth,
-                                         n_jobs=n_jobs,
-                                         enforce_h2ogpt_api_key=kwargs['enforce_h2ogpt_api_key'],
-                                         enforce_h2ogpt_ui_key=kwargs['enforce_h2ogpt_ui_key'],
-                                         h2ogpt_api_keys=kwargs['h2ogpt_api_keys'],
-                                         )
+                                      load_db_if_exists=load_db_if_exists,
+                                      db_type=db_type,
+                                      use_openai_embedding=use_openai_embedding,
+                                      hf_embedding_model=hf_embedding_model,
+                                      migrate_embedding_model=migrate_embedding_model,
+                                      auto_migrate_db=auto_migrate_db,
+                                      verbose=verbose,
+                                      get_userid_auth=get_userid_auth,
+                                      n_jobs=n_jobs,
+                                      enforce_h2ogpt_api_key=kwargs['enforce_h2ogpt_api_key'],
+                                      enforce_h2ogpt_ui_key=kwargs['enforce_h2ogpt_ui_key'],
+                                      h2ogpt_api_keys=kwargs['h2ogpt_api_keys'],
+                                      )
 
         get_sources1 = functools.partial(get_sources_gr, **get_sources_fun_kwargs)
 
@@ -2788,19 +2788,19 @@ def go_gradio(**kwargs):
         # show button, else only show when add.
         # Could add to above get_sources for download/dropdown, but bit much maybe
         show_sources1_fun_kwargs = dict(dbs=dbs,
-                                          load_db_if_exists=load_db_if_exists,
-                                          db_type=db_type,
-                                          use_openai_embedding=use_openai_embedding,
-                                          hf_embedding_model=hf_embedding_model,
-                                          migrate_embedding_model=migrate_embedding_model,
-                                          auto_migrate_db=auto_migrate_db,
-                                          verbose=verbose,
-                                          get_userid_auth=get_userid_auth,
-                                          n_jobs=n_jobs,
-                                          enforce_h2ogpt_api_key=kwargs['enforce_h2ogpt_api_key'],
-                                          enforce_h2ogpt_ui_key=kwargs['enforce_h2ogpt_ui_key'],
-                                          h2ogpt_api_keys=kwargs['h2ogpt_api_keys'],
-                                          )
+                                        load_db_if_exists=load_db_if_exists,
+                                        db_type=db_type,
+                                        use_openai_embedding=use_openai_embedding,
+                                        hf_embedding_model=hf_embedding_model,
+                                        migrate_embedding_model=migrate_embedding_model,
+                                        auto_migrate_db=auto_migrate_db,
+                                        verbose=verbose,
+                                        get_userid_auth=get_userid_auth,
+                                        n_jobs=n_jobs,
+                                        enforce_h2ogpt_api_key=kwargs['enforce_h2ogpt_api_key'],
+                                        enforce_h2ogpt_ui_key=kwargs['enforce_h2ogpt_ui_key'],
+                                        h2ogpt_api_keys=kwargs['h2ogpt_api_keys'],
+                                        )
         show_sources1 = functools.partial(get_source_files_given_langchain_mode_gr,
                                           **show_sources1_fun_kwargs,
                                           )
@@ -6650,17 +6650,24 @@ def go_gradio(**kwargs):
                 get_sources_fun_kwargs_login['for_login'] = True
                 get_sources1_login = functools.partial(get_sources_gr, **get_sources_fun_kwargs_login)
                 get_sources_kwargs_login = dict(fn=get_sources1_login,
-                                          inputs=[my_db_state, selection_docs_state, requests_state, langchain_mode,
-                                                  h2ogpt_key],
-                                          outputs=[file_source, docs_state, text_doc_count],
-                                          queue=queue)
+                                                inputs=[my_db_state, selection_docs_state, requests_state,
+                                                        langchain_mode,
+                                                        h2ogpt_key],
+                                                outputs=[file_source, docs_state, text_doc_count],
+                                                queue=queue)
                 load_event3 = load_event2.then(**get_sources_kwargs_login)
                 load_event4 = load_event3.then(fn=update_dropdown, inputs=docs_state, outputs=document_choice)
                 show_sources1_fun_kwargs_login = show_sources1_fun_kwargs.copy()
                 show_sources1_fun_kwargs_login['for_login'] = True
-                show_sources_kwargs_login = functools.partial(get_source_files_given_langchain_mode_gr,
-                                                  **show_sources1_fun_kwargs_login,
-                                                  )
+                show_sources1_login = functools.partial(get_source_files_given_langchain_mode_gr,
+                                                        **show_sources1_fun_kwargs_login,
+                                                        )
+                show_sources_kwargs_login = dict(fn=show_sources1_login,
+                                                 inputs=[my_db_state, selection_docs_state, requests_state,
+                                                         langchain_mode,
+                                                         h2ogpt_key],
+                                                 outputs=sources_text)
+
                 load_event5 = load_event4.then(**show_sources_kwargs_login)
                 load_event6 = load_event5.then(**get_viewable_sources_args)
                 load_event7 = load_event6.then(**viewable_kwargs)

--- a/src/gradio_runner.py
+++ b/src/gradio_runner.py
@@ -2820,7 +2820,7 @@ def go_gradio(**kwargs):
             return gr.Dropdown(choices=x,
                                value=viewable_docs_state0[0] if len(viewable_docs_state0) > 0 else None)
 
-        get_viewable_sources1 = functools.partial(get_sources_gr, dbs=dbs, docs_state0=viewable_docs_state0,
+        get_viewable_sources1_fun_kwargs = dict(dbs=dbs, docs_state0=viewable_docs_state0,
                                                   load_db_if_exists=load_db_if_exists,
                                                   db_type=db_type,
                                                   use_openai_embedding=use_openai_embedding,
@@ -2834,6 +2834,8 @@ def go_gradio(**kwargs):
                                                   enforce_h2ogpt_ui_key=kwargs['enforce_h2ogpt_ui_key'],
                                                   h2ogpt_api_keys=kwargs['h2ogpt_api_keys'],
                                                   )
+
+        get_viewable_sources1 = functools.partial(get_sources_gr, **get_viewable_sources1_fun_kwargs)
         get_viewable_sources_args = dict(fn=get_viewable_sources1,
                                          inputs=[my_db_state, selection_docs_state, requests_state, langchain_mode,
                                                  h2ogpt_key],
@@ -6667,9 +6669,19 @@ def go_gradio(**kwargs):
                                                          langchain_mode,
                                                          h2ogpt_key],
                                                  outputs=sources_text)
-
                 load_event5 = load_event4.then(**show_sources_kwargs_login)
-                load_event6 = load_event5.then(**get_viewable_sources_args)
+
+
+                get_viewable_sources1_fun_kwargs_login = get_viewable_sources1_fun_kwargs.copy()
+                get_viewable_sources1_fun_kwargs_login['for_login'] = True
+                get_viewable_sources1_login = functools.partial(get_sources_gr, **get_viewable_sources1_fun_kwargs_login)
+                get_viewable_sources_args_login = dict(fn=get_viewable_sources1_login,
+                                                 inputs=[my_db_state, selection_docs_state, requests_state, langchain_mode,
+                                                         h2ogpt_key],
+                                                 outputs=[file_source, viewable_docs_state, text_viewable_doc_count],
+                                                 queue=queue)
+
+                load_event6 = load_event5.then(**get_viewable_sources_args_login)
                 load_event7 = load_event6.then(**viewable_kwargs)
 
     demo.queue(**queue_kwargs, api_open=kwargs['api_open'])

--- a/src/gradio_runner.py
+++ b/src/gradio_runner.py
@@ -26,6 +26,7 @@ from gradio_utils.css import get_css
 from gradio_utils.prompt_form import make_chatbots, get_chatbot_name
 from src.db_utils import set_userid, get_username_direct, length_db1, get_userid_direct, fetch_user, upsert_user
 from src.tts_utils import combine_audios
+from src.utils_langchain import make_sources_file
 from src.vision.utils_vision import base64_to_img
 
 # This is a hack to prevent Gradio from phoning home when it gets imported
@@ -2786,8 +2787,7 @@ def go_gradio(**kwargs):
 
         # show button, else only show when add.
         # Could add to above get_sources for download/dropdown, but bit much maybe
-        show_sources1 = functools.partial(get_source_files_given_langchain_mode_gr,
-                                          dbs=dbs,
+        show_sources1_fun_kwargs = dict(dbs=dbs,
                                           load_db_if_exists=load_db_if_exists,
                                           db_type=db_type,
                                           use_openai_embedding=use_openai_embedding,
@@ -2800,6 +2800,9 @@ def go_gradio(**kwargs):
                                           enforce_h2ogpt_api_key=kwargs['enforce_h2ogpt_api_key'],
                                           enforce_h2ogpt_ui_key=kwargs['enforce_h2ogpt_ui_key'],
                                           h2ogpt_api_keys=kwargs['h2ogpt_api_keys'],
+                                          )
+        show_sources1 = functools.partial(get_source_files_given_langchain_mode_gr,
+                                          **show_sources1_fun_kwargs,
                                           )
         eventdb8a = show_sources_btn.click(user_state_setup,
                                            inputs=[my_db_state, requests_state, guest_name, show_sources_btn,
@@ -6653,7 +6656,12 @@ def go_gradio(**kwargs):
                                           queue=queue)
                 load_event3 = load_event2.then(**get_sources_kwargs_login)
                 load_event4 = load_event3.then(fn=update_dropdown, inputs=docs_state, outputs=document_choice)
-                load_event5 = load_event4.then(**show_sources_kwargs)
+                show_sources1_fun_kwargs_login = show_sources1_fun_kwargs.copy()
+                show_sources1_fun_kwargs_login['for_login'] = True
+                show_sources_kwargs_login = functools.partial(get_source_files_given_langchain_mode_gr,
+                                                  **show_sources1_fun_kwargs_login,
+                                                  )
+                load_event5 = load_event4.then(**show_sources_kwargs_login)
                 load_event6 = load_event5.then(**get_viewable_sources_args)
                 load_event7 = load_event6.then(**viewable_kwargs)
 
@@ -7179,7 +7187,8 @@ def get_sources_gr(db1s, selection_docs_state1, requests_state1, langchain_mode,
     from_ui = is_from_ui(requests_state1)
     if not valid_key:
         if for_login:
-            return '', [], ''
+            sources_file = make_sources_file(langchain_mode, [])
+            return sources_file, [], ''
         else:
             raise ValueError(invalid_key_msg)
 
@@ -7222,6 +7231,7 @@ def get_source_files_given_langchain_mode_gr(db1s, selection_docs_state1, reques
                                              enforce_h2ogpt_api_key=True,
                                              enforce_h2ogpt_ui_key=True,
                                              h2ogpt_api_keys=[],
+                                             for_login=False,
                                              ):
     valid_key = is_valid_key(enforce_h2ogpt_api_key,
                              enforce_h2ogpt_ui_key,
@@ -7231,7 +7241,10 @@ def get_source_files_given_langchain_mode_gr(db1s, selection_docs_state1, reques
                              )
     from_ui = is_from_ui(requests_state1)
     if not valid_key:
-        raise ValueError(invalid_key_msg)
+        if for_login:
+            return "Sources: N/A"
+        else:
+            raise ValueError(invalid_key_msg)
 
     from src.gpt_langchain import get_source_files_given_langchain_mode
     return get_source_files_given_langchain_mode(db1s, selection_docs_state1, requests_state1, None,

--- a/src/gradio_runner.py
+++ b/src/gradio_runner.py
@@ -6671,7 +6671,6 @@ def go_gradio(**kwargs):
                                                  outputs=sources_text)
                 load_event5 = load_event4.then(**show_sources_kwargs_login)
 
-
                 get_viewable_sources1_fun_kwargs_login = get_viewable_sources1_fun_kwargs.copy()
                 get_viewable_sources1_fun_kwargs_login['for_login'] = True
                 get_viewable_sources1_login = functools.partial(get_sources_gr, **get_viewable_sources1_fun_kwargs_login)
@@ -7206,7 +7205,7 @@ def get_sources_gr(db1s, selection_docs_state1, requests_state1, langchain_mode,
     from_ui = is_from_ui(requests_state1)
     if not valid_key:
         if for_login:
-            sources_file = make_sources_file(langchain_mode, [])
+            sources_file = make_sources_file(langchain_mode, '')
             return sources_file, [], ''
         else:
             raise ValueError(invalid_key_msg)

--- a/src/gradio_runner.py
+++ b/src/gradio_runner.py
@@ -4106,8 +4106,8 @@ def go_gradio(**kwargs):
             # control kwargs1 for evaluate
             if 'answer_with_sources' not in user_kwargs:
                 kwargs1['answer_with_sources'] = -1  # just text chunk, not URL etc.
-            if 'sources_show_in_accordion' not in user_kwargs:
-                kwargs1['sources_show_in_accordion'] = False
+            if 'sources_show_text_in_accordion' not in user_kwargs:
+                kwargs1['sources_show_text_in_accordion'] = False
             if 'append_sources_to_chat' not in user_kwargs:
                 kwargs1['append_sources_to_chat'] = False
             if 'append_sources_to_answer' not in user_kwargs:

--- a/src/gradio_runner.py
+++ b/src/gradio_runner.py
@@ -4106,8 +4106,8 @@ def go_gradio(**kwargs):
             # control kwargs1 for evaluate
             if 'answer_with_sources' not in user_kwargs:
                 kwargs1['answer_with_sources'] = -1  # just text chunk, not URL etc.
-            if 'show_accordions' not in user_kwargs:
-                kwargs1['show_accordions'] = False
+            if 'sources_show_in_accordion' not in user_kwargs:
+                kwargs1['sources_show_in_accordion'] = False
             if 'append_sources_to_chat' not in user_kwargs:
                 kwargs1['append_sources_to_chat'] = False
             if 'append_sources_to_answer' not in user_kwargs:

--- a/src/gradio_runner.py
+++ b/src/gradio_runner.py
@@ -6651,7 +6651,7 @@ def go_gradio(**kwargs):
                                                   h2ogpt_key],
                                           outputs=[file_source, docs_state, text_doc_count],
                                           queue=queue)
-                load_event3 = load_event2.then(**get_sources_kwargs)
+                load_event3 = load_event2.then(**get_sources_kwargs_login)
                 load_event4 = load_event3.then(fn=update_dropdown, inputs=docs_state, outputs=document_choice)
                 load_event5 = load_event4.then(**show_sources_kwargs)
                 load_event6 = load_event5.then(**get_viewable_sources_args)

--- a/src/sagemaker.py
+++ b/src/sagemaker.py
@@ -39,7 +39,7 @@ class BaseContentHandler(LLMContentHandler):
         return response_json[0]["generation"]
 
 
-class H2OSagemakerEndpoint(AGenerateStreamFirst, SagemakerEndpoint):
+class H2OSagemakerEndpoint(SagemakerEndpoint):
     aws_access_key_id: str = ""
     aws_secret_access_key: str = ""
     tokenizer: typing.Any = None

--- a/src/sagemaker.py
+++ b/src/sagemaker.py
@@ -39,7 +39,7 @@ class BaseContentHandler(LLMContentHandler):
         return response_json[0]["generation"]
 
 
-class H2OSagemakerEndpoint(SagemakerEndpoint):
+class H2OSagemakerEndpoint(AGenerateStreamFirst, SagemakerEndpoint):
     aws_access_key_id: str = ""
     aws_secret_access_key: str = ""
     tokenizer: typing.Any = None

--- a/src/utils.py
+++ b/src/utils.py
@@ -742,8 +742,42 @@ def get_source(x):
     return x.metadata.get('source', "UNKNOWN SOURCE")
 
 
+def markdown_to_html(content):
+    import markdown
+
+    # Create a Markdown object
+    markdowner = markdown.Markdown()
+
+    # Convert the Markdown block to HTML
+    try:
+        html = markdowner.reset().convert(content)
+    except Exception as e:
+        # FIXME:
+        print("Invalid conversion of markdown to html: %s\n\n%s" % (content, str(e)))
+        html = content
+
+    return html
+
+
+def is_markdown(string):
+    """Returns True if the string is markdown, False otherwise."""
+
+    # Check for the presence of double square brackets
+    if re.search(r'\[\[.+?\]\]', string):
+        return True
+
+    # Check for the presence of angle brackets
+    if re.search(r'<.+?>', string):
+        return False
+
+    # If neither of the above patterns are found, assume the string is markdown
+    return True
+
+
 def get_accordion_named(content, title, font_size=8):
-    content = content.replace('\n', '<br>')
+    # content = content.replace('\n', '<br>')
+    if is_markdown(content):
+        content = markdown_to_html(content)
     return f"""<details><summary><font size="{font_size}">{title}</font></summary><font size="{font_size}">{content}</font></details>"""
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -743,6 +743,7 @@ def get_source(x):
 
 
 def get_accordion_named(content, title, font_size=8):
+    content = content.replace('\n', '<br>')
     return f"""<details><summary><font size="{font_size}">{title}</font></summary><font size="{font_size}">{content}</font></details>"""
 
 

--- a/src/utils_langchain.py
+++ b/src/utils_langchain.py
@@ -19,7 +19,7 @@ from langchain.chains.summarize import map_reduce_prompt, LoadingCallable, _load
 from langchain.schema.language_model import BaseLanguageModel
 from langchain_community.embeddings import HuggingFaceHubEmbeddings
 
-from src.utils import hash_file, get_sha, split_list
+from src.utils import hash_file, get_sha, split_list, makedirs
 
 from langchain.callbacks.base import BaseCallbackHandler, Callbacks
 from langchain.schema import LLMResult
@@ -500,3 +500,12 @@ class H2OHuggingFaceHubEmbeddings(HuggingFaceHubEmbeddings):
             if verbose:
                 print("done batch %s %s %s" % (ii, len(text_batch), batchii), flush=True)
         return rets
+
+
+def make_sources_file(langchain_mode, source_files_added):
+    sources_dir = "sources_dir"
+    sources_dir = makedirs(sources_dir, exist_ok=True, tmp_ok=True, use_base=True)
+    sources_file = os.path.join(sources_dir, 'sources_%s_%s' % (langchain_mode, str(uuid.uuid4())))
+    with open(sources_file, "wt", encoding="utf-8") as f:
+        f.write(source_files_added)
+    return sources_file

--- a/src/utils_langchain.py
+++ b/src/utils_langchain.py
@@ -218,10 +218,10 @@ class H2OMapReduceDocumentsChain(MapReduceDocumentsChain):
             result, extra_return_dict = self.reduce_documents_chain.combine_docs(
                 result_docs, token_max=token_max, callbacks=callbacks, **kwargs
             )
-            self.terminate_callbacks()
             if self.return_intermediate_steps:
                 intermediate_steps = [r[question_result_key] for r in map_results]
                 extra_return_dict["intermediate_steps"] = intermediate_steps
+        self.terminate_callbacks()
         return result, extra_return_dict
 
     async def acombine_docs(
@@ -259,10 +259,10 @@ class H2OMapReduceDocumentsChain(MapReduceDocumentsChain):
             result, extra_return_dict = await self.reduce_documents_chain.acombine_docs(
                 result_docs, token_max=token_max, callbacks=callbacks, **kwargs
             )
-            self.terminate_callbacks()
             if self.return_intermediate_steps:
                 intermediate_steps = [r[question_result_key] for r in map_results]
                 extra_return_dict["intermediate_steps"] = intermediate_steps
+        self.terminate_callbacks()
         return result, extra_return_dict
 
     def terminate_callbacks(self):

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = "8f6380a1ec140cb244c61a20ca13ef0415ae4484"
+__version__ = "f730b969ba5795a5d0edc392bc0d380d9b8a8d01"

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = "b93ab5ebcf05c9ee342e775cbc9b7efb64b18a8b"
+__version__ = "fc3cd35d2d45c4496a460c19052102200fdcbefb"

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = "d97aff0f5a1f20a9cc87aa73e82be8b828e87f29"
+__version__ = "7dbf5e1adb77c7fb19b4965eac1f3add1bc152c1"

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = "971bb7897aebb6fc031c5ccd86acdcf2714ff564"
+__version__ = "b12fdb91a5ca7ddc3585f5928fe768f50222f139"

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = "dd1714f00659a4297f6bde6d9f53938c8dd52fea"
+__version__ = "c1e97d307208ef5fc7f1d16e7d0e8f2d7e804dbf"

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = "fc3cd35d2d45c4496a460c19052102200fdcbefb"
+__version__ = "8f6380a1ec140cb244c61a20ca13ef0415ae4484"

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = "8a771417c1e027146796fd9a5bb4c47b48b1ffda"
+__version__ = "31170374c843e92169e5aa37b56e33b12966ad16"

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = "ef7e11fb8c07f947dbe457d23d0e481cde48f0bd"
+__version__ = "aec8addd634cd78424cd881c3d39da245bb32fc8"

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = "9373443d5b9a9c6490af2621f1bcfa96bdb51d92"
+__version__ = "59e1c1f87fd780e7b18e5e26dd08a46baf655e18"

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = "74b060f0185f1864a2f3bff969d02fbb25826818"
+__version__ = "dd1714f00659a4297f6bde6d9f53938c8dd52fea"

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = "a5f23d23407d9b0a7b64d9542fe4f6903947d19d"
+__version__ = "a38af532c366ab7888ba62be1c216c12aee2be25"

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = "053b8dbea2c339985b59ea03a1bc2656a5ece91b"
+__version__ = "4ebe47852298bb3bea6575b9750d260cb325a6f3"

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = "e5a251d2eb2f9adeb4c1b723c15869f837cac84a"
+__version__ = "9d415200f7310db528e4c80810e0e76bb9ff11ff"

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = "9422f0fbd0d2d512fdb34b9aec99e0ace7019dcb"
+__version__ = "f6e4c1cf2e0a785c35e9dd053815204abb8f63ca"

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = "31170374c843e92169e5aa37b56e33b12966ad16"
+__version__ = "e5a251d2eb2f9adeb4c1b723c15869f837cac84a"

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = "f6e4c1cf2e0a785c35e9dd053815204abb8f63ca"
+__version__ = "b93531d8f19a610dca29f5a9b841e8d9d04f96f0"

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = "aec8addd634cd78424cd881c3d39da245bb32fc8"
+__version__ = "a5f23d23407d9b0a7b64d9542fe4f6903947d19d"

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = "b12fdb91a5ca7ddc3585f5928fe768f50222f139"
+__version__ = "b93ab5ebcf05c9ee342e775cbc9b7efb64b18a8b"

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = "a38af532c366ab7888ba62be1c216c12aee2be25"
+__version__ = "9422f0fbd0d2d512fdb34b9aec99e0ace7019dcb"

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = "7dbf5e1adb77c7fb19b4965eac1f3add1bc152c1"
+__version__ = "ef7e11fb8c07f947dbe457d23d0e481cde48f0bd"

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = "4ebe47852298bb3bea6575b9750d260cb325a6f3"
+__version__ = "b4904c85262caf25c6c58bf25652b5fbdc9418d0"

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = "f730b969ba5795a5d0edc392bc0d380d9b8a8d01"
+__version__ = "74b060f0185f1864a2f3bff969d02fbb25826818"

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = "c1e97d307208ef5fc7f1d16e7d0e8f2d7e804dbf"
+__version__ = "c344d6c6537b1995d53818c1aebf422ca885c22e"

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = "b4904c85262caf25c6c58bf25652b5fbdc9418d0"
+__version__ = "c64ab94d8e1dc295d742368e9dd89e9fc1103d91"

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = "b93531d8f19a610dca29f5a9b841e8d9d04f96f0"
+__version__ = "9373443d5b9a9c6490af2621f1bcfa96bdb51d92"

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = "c64ab94d8e1dc295d742368e9dd89e9fc1103d91"
+__version__ = "d97aff0f5a1f20a9cc87aa73e82be8b828e87f29"

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = "9d415200f7310db528e4c80810e0e76bb9ff11ff"
+__version__ = "053b8dbea2c339985b59ea03a1bc2656a5ece91b"

--- a/tests/test_client_calls.py
+++ b/tests/test_client_calls.py
@@ -136,6 +136,7 @@ def test_client1api_lean(save_dir, admin_pass):
     os.environ['ADMIN_PASS'] = admin_pass
     main(base_model=base_model, prompt_type='human_bot', chat=False,
          stream_output=False, gradio=True, num_beams=1, block_gradio_exit=False,
+         system_api_open=True,
          save_dir=save_dir)
 
     client1 = get_client(serialize=False)
@@ -4912,22 +4913,8 @@ def test_client1_images_qa(langchain_action, langchain_mode, base_model):
     pdf_images = [os.path.join(image_dir, x) for x in pdf_images]
     pdf_images.sort(key=get_creation_date)
 
-    inference_server = os.getenv('TEST_SERVER', 'https://gpt.h2o.ai')
-    if inference_server == 'https://gpt.h2o.ai':
-        auth_kwargs = dict(auth=('guest', 'guest'))
-    else:
-        auth_kwargs = {}
-
-    from src.gen import get_inf_models
-    base_models = get_inf_models(inference_server)
-    base_models_touse = [base_model]
-    assert len(set(base_models_touse).difference(set(base_models))) == 0
+    client, base_models = get_test_server_client(base_model)
     h2ogpt_key = os.environ['H2OGPT_H2OGPT_KEY']
-
-    # inference_server = 'http://localhost:7860'
-
-    from gradio_client import Client
-    client = Client(inference_server, *auth_kwargs)
 
     prompt = 'What is used to optimize the likelihoods of the rationales?'
 

--- a/tests/test_client_calls.py
+++ b/tests/test_client_calls.py
@@ -5055,13 +5055,14 @@ vllm_base_models = ['h2oai/h2ogpt-4096-llama2-70b-chat', 'h2oai/h2ogpt-4096-llam
 
 def get_test_server_client(base_model):
     inference_server = os.getenv('TEST_SERVER', 'https://gpt.h2o.ai')
+    # inference_server = 'http://localhost:7860'
+
     if inference_server == 'https://gpt.h2o.ai':
         auth_kwargs = dict(auth=('guest', 'guest'))
         inference_server_for_get = inference_server + ':guest:guest'
     else:
         auth_kwargs = {}
         inference_server_for_get = inference_server
-    # inference_server = 'http://localhost:7860'
 
     base_models_touse = [base_model]
     from src.gen import get_inf_models

--- a/tests/test_langchain_units.py
+++ b/tests/test_langchain_units.py
@@ -2079,13 +2079,15 @@ def test_hyde_acc():
     answer = 'answer'
     llm_answers = dict(response_raw='raw')
     hyde_show_intermediate_in_accordion = False
-    hyde = get_hyde_acc(answer, llm_answers, hyde_show_intermediate_in_accordion)
+    map_reduce_show_intermediate_in_accordion = False
+    hyde = get_hyde_acc(answer, llm_answers, hyde_show_intermediate_in_accordion, map_reduce_show_intermediate_in_accordion)
     assert hyde == ''
 
     answer = ['answer']
     llm_answers = dict(response_raw='raw')
     hyde_show_intermediate_in_accordion = False
-    hyde = get_hyde_acc(answer, llm_answers, hyde_show_intermediate_in_accordion)
+    map_reduce_show_intermediate_in_accordion = False
+    hyde = get_hyde_acc(answer, llm_answers, hyde_show_intermediate_in_accordion, map_reduce_show_intermediate_in_accordion)
     assert hyde is None
 
 

--- a/tests/test_langchain_units.py
+++ b/tests/test_langchain_units.py
@@ -2080,14 +2080,14 @@ def test_hyde_acc():
     llm_answers = dict(response_raw='raw')
     hyde_show_intermediate_in_accordion = False
     map_reduce_show_intermediate_in_accordion = False
-    hyde = get_hyde_acc(answer, llm_answers, hyde_show_intermediate_in_accordion, map_reduce_show_intermediate_in_accordion)
+    answer, hyde = get_hyde_acc(answer, llm_answers, hyde_show_intermediate_in_accordion, map_reduce_show_intermediate_in_accordion)
     assert hyde == ''
 
     answer = ['answer']
     llm_answers = dict(response_raw='raw')
     hyde_show_intermediate_in_accordion = False
     map_reduce_show_intermediate_in_accordion = False
-    hyde = get_hyde_acc(answer, llm_answers, hyde_show_intermediate_in_accordion, map_reduce_show_intermediate_in_accordion)
+    answer, hyde = get_hyde_acc(answer, llm_answers, hyde_show_intermediate_in_accordion, map_reduce_show_intermediate_in_accordion)
     assert hyde is None
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -432,6 +432,6 @@ def test_repair_json():
         if i > 50:
             assert len(good_json_string) > 5
         tdelta = time.time() - t0
-        assert tdelta < 0.002, "Too slow: %s" % tdelta
+        assert tdelta < 0.005, "Too slow: %s" % tdelta
         print("%s : %s : %s" % (i, tdelta, good_json_string))
         json.loads(good_json_string)


### PR DESCRIPTION
- [x] streaming occurs now, but map step is all overlapping.  Want maybe only first map to stream, rest maps not
- [x] non-chat for openai/vllm
- [x] google chat
- [x] anthropic chat
- [x] openai chat
- [ ] sagemaker  (async not supported for now, let do normal async without streaming first only)
- [ ] replicate  (async not supported by base class, let do normal async without streaming first only)
- [x] mistralai
- [x] groq
- [x] gradio
- [x] gradiollava
- [ ] torch/hf/pipe (just not supported, do normal)
- [ ] llama.cpp (can't do async really anyways, not thread safe but even if was with new updates, would just slow down to do async)
- [ ] exllama (wouldn't make much sense)
- [x] reduce stream
- [ ] Add other first batch of parallel things to UI compute steps?
- [x] Add testing for async streaming
- [x] Improve rendering when accordion used, e.g. markdown loses markdown in gradio when surrounded by HTML.  maybe use markdown for the accordion if possible?