### PR TITLE
set podSecurityContext to null, so umbrella can overwrite on openshift

### DIFF
--- a/helm/h2ogpt-chart/values.yaml
+++ b/helm/h2ogpt-chart/values.yaml
@@ -68,9 +68,9 @@ h2ogpt:
 
   podSecurityContext:
     runAsNonRoot: true
-    runAsUser: 1000
-    runAsGroup: 1000
-    fsGroup: 1000
+    runAsUser: 
+    runAsGroup: 
+    fsGroup: 
 
   securityContext:
     runAsNonRoot: true
@@ -177,9 +177,9 @@ vllm:
 
   podSecurityContext:
     runAsNonRoot: true
-    runAsUser: 1000
-    runAsGroup: 1000
-    fsGroup: 1000
+    runAsUser: 
+    runAsGroup: 
+    fsGroup: 
 
   securityContext:
     runAsNonRoot: true


### PR DESCRIPTION
when deployed on openshift these values need to be nullified.

https://github.com/h2oai/h2ogpt/issues/1616
https://github.com/h2oai/platform-charts/pull/261