### PR TITLE
Improvments for h2ogpte

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,8 @@ RUN rm -rf /workspace/.cache && \
     rm -rf /workspace/notebooks && \
     rm -rf /workspace/papers
 
+RUN mkdir -p /workspace/save
+
 # make main workspace writable
 RUN chmod -R a+rwx /workspace
 
@@ -71,6 +73,9 @@ COPY --from=intermediate-stage    /docker_cache/nvidia/           /usr/lib/pytho
 COPY --from=intermediate-stage    /docker_cache/torch/            /usr/lib/python3.10/site-packages/torch/
 COPY --from=intermediate-stage    /docker_cache/onnxruntime/      /usr/lib/python3.10/site-packages/onnxruntime/
 COPY --from=intermediate-stage    /docker_cache/triton/           /usr/lib/python3.10/site-packages/triton/
+
+COPY --from=intermediate-stage    /workspace/build_info.txt       /build_info.txt
+COPY --from=intermediate-stage    /workspace/git_hash.txt         /git_hash.txt
 COPY --from=intermediate-stage    /workspace                      /workspace
 RUN chmod a+rwx /workspace  # only for top dir, as docker COPY skips it.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
-# devel needed for bitsandbytes requirement of libcudart.so, otherwise runtime sufficient
-FROM nvidia/cuda:12.1.1-cudnn8-devel-ubuntu20.04
+FROM gcr.io/vorvan/h2oai/h2ogpt-oss-wolfi-base:1 AS build-stage
 
-ENV DEBIAN_FRONTEND=noninteractive
-
-ENV PATH="/h2ogpt_conda/envs/h2ogpt/bin:${PATH}"
-ARG PATH="/h2ogpt_conda/envs/h2ogpt/bin:${PATH}"
+USER root
 
 ENV HOME=/workspace
 ENV CUDA_HOME=/usr/local/cuda-12.1
@@ -14,22 +10,18 @@ ENV HF_HUB_ENABLE_HF_TRANSFER=1
 
 WORKDIR /workspace
 
-COPY . /workspace/
+# copy code
+COPY .              /workspace/
 
+# copy build info
 COPY build_info.txt /workspace/
+COPY git_hash.txt   /workspace/
 
-COPY git_hash.txt /workspace/
+# copy install script
+COPY linux_install_wolfi.sh    /workspace/
 
-RUN cd /workspace && ./docker_build_script_ubuntu.sh
-
-RUN chmod -R a+rwx /workspace
-
-ARG user=h2ogpt
-ARG group=h2ogpt
-ARG uid=1000
-ARG gid=1000
-
-RUN groupadd -g ${gid} ${group} && useradd -u ${uid} -g ${group} -s /bin/bash ${user}
+# run setup
+RUN cd /workspace && ./linux_install_wolfi.sh
 
 EXPOSE 8888
 EXPOSE 7860

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/vorvan/h2oai/h2ogpt-oss-wolfi-base:1 AS build-stage
+FROM gcr.io/vorvan/h2oai/h2ogpt-oss-wolfi-base:1 AS base-stage
 
 USER root
 
@@ -10,7 +10,9 @@ ENV HF_HUB_ENABLE_HF_TRANSFER=1
 
 WORKDIR /workspace
 
-# copy code
+FROM base-stage as intermediate-stage
+
+## copy code
 COPY .              /workspace/
 
 # copy build info
@@ -22,6 +24,47 @@ COPY linux_install_wolfi.sh    /workspace/
 
 # run setup
 RUN cd /workspace && ./linux_install_wolfi.sh
+
+# mv to separate locations so can copy from under a enw docker layer
+RUN \
+    mkdir -p /docker_cache && \
+    mv /usr/lib/python3.10/site-packages/nvidia         /docker_cache/nvidia && \
+    mv /usr/lib/python3.10/site-packages/torch          /docker_cache/torch && \
+    mv /usr/lib/python3.10/site-packages/onnxruntime    /docker_cache/onnxruntime && \
+    mv /usr/lib/python3.10/site-packages/triton         /docker_cache/triton && \
+    mv /usr/lib/python3.10                              /docker_cache/python_data && \
+    cp -R /usr                                          /docker_cache/user_data
+
+# remove since already in base image and didn't change
+RUN \
+    rm -rf /docker_cache/user_data/lib && \
+    rm -rf /docker_cache/user_data/libexec && \
+    rm -rf /docker_cache/user_data/local && \
+    rm -rf /docker_cache/user_data/bin/pandoc && \
+    rm -rf /docker_cache/user_data/bin/node && \
+    rm -rf /docker_cache/user_data/bin/lto-dump-11 && \
+    rm -rf /docker_cache/user_data/bin/lto-dump && \
+    rm -rf /docker_cache/user_data/share/misc/magic.mgc && \
+    rm -rf /docker_cache/user_data/share/icu && \
+    rm -rf /docker_cache/user_data/x86_64-pc-linux-gnu && \
+    rm -rf /docker_cache/python_data/site-packages/future/backports/test
+
+# remove pip cache
+RUN rm -rf /workspace/.cache
+
+# make main workspace writable
+RUN chmod -R a+rwx /workspace
+
+FROM base-stage as final-stage
+
+COPY --from=intermediate-stage    /docker_cache/user_data         /usr
+COPY --from=intermediate-stage    /docker_cache/python_data/      /usr/lib/python3.10/
+COPY --from=intermediate-stage    /docker_cache/nvidia/           /usr/lib/python3.10/site-packages/nvidia/
+COPY --from=intermediate-stage    /docker_cache/torch/            /usr/lib/python3.10/site-packages/torch/
+COPY --from=intermediate-stage    /docker_cache/onnxruntime/      /usr/lib/python3.10/site-packages/onnxruntime/
+COPY --from=intermediate-stage    /docker_cache/triton/           /usr/lib/python3.10/site-packages/triton/
+COPY --from=intermediate-stage    /workspace                      /workspace
+RUN chmod a+rwx /workspace  # only for top dir, as docker COPY skips it.
 
 EXPOSE 8888
 EXPOSE 7860

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,16 @@ RUN \
     rm -rf /docker_cache/user_data/x86_64-pc-linux-gnu && \
     rm -rf /docker_cache/python_data/site-packages/future/backports/test
 
-# remove pip cache
-RUN rm -rf /workspace/.cache
+# cleanup
+RUN rm -rf /workspace/.cache && \
+    rm -rf /workspace/spaces && \
+    rm -rf /workspace/benchmarks && \
+    rm -rf /workspace/data && \
+    rm -rf /workspace/cloud && \
+    rm -rf /workspace/docs && \
+    rm -rf /workspace/helm && \
+    rm -rf /workspace/notebooks && \
+    rm -rf /workspace/papers
 
 # make main workspace writable
 RUN chmod -R a+rwx /workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/vorvan/h2oai/h2ogpt-oss-wolfi-base:1 AS base-stage
+FROM gcr.io/vorvan/h2oai/h2ogpt-oss-wolfi-base:2 AS base-stage
 
 USER root
 

--- a/Dockerfile-vllm
+++ b/Dockerfile-vllm
@@ -1,0 +1,18 @@
+FROM h2ogpt:current
+
+USER root
+
+# vllm server
+RUN \
+    python -m pip install vllm==0.4.0.post1 && \
+    python -m pip install gputil==1.4.0 hf_transfer==0.1.6 && \
+    python -m pip install setuptools==69.5.1 && \
+    python -m pip install flash-attn==2.5.6 --no-build-isolation --no-deps --no-cache-dir
+
+EXPOSE 8888
+EXPOSE 7860
+EXPOSE 5000
+
+USER h2ogpt
+
+ENTRYPOINT ["python3.10"]

--- a/Makefile
+++ b/Makefile
@@ -70,29 +70,29 @@ docker_build_runner: docker_build
 	-docker pull $(DOCKER_TEST_IMAGE)
 	-docker pull $(DOCKER_TEST_IMAGE_VLLM)
 
-	docker tag $(DOCKER_TEST_IMAGE) gcr.io/vorvan/h2oai/h2ogpt-runtime:$(BUILD_TAG)
-	docker tag $(DOCKER_TEST_IMAGE_VLLM) gcr.io/vorvan/h2oai/h2ogpt-vllm:$(BUILD_TAG)
+	docker tag $(DOCKER_TEST_IMAGE) gcr.io/vorvan/h2oai/h2oai-h2ogpt-runtime:$(BUILD_TAG)
+	docker tag $(DOCKER_TEST_IMAGE_VLLM) gcr.io/vorvan/h2oai/h2oai-h2ogpt-vllm:$(BUILD_TAG)
 
-	docker tag $(DOCKER_TEST_IMAGE) gcr.io/vorvan/h2oai/h2ogpt-runtime:$(PACKAGE_VERSION)
-	docker tag $(DOCKER_TEST_IMAGE_VLLM) gcr.io/vorvan/h2oai/h2ogpt-vllm:$(PACKAGE_VERSION)
+	docker tag $(DOCKER_TEST_IMAGE) gcr.io/vorvan/h2oai/h2oai-h2ogpt-runtime:$(PACKAGE_VERSION)
+	docker tag $(DOCKER_TEST_IMAGE_VLLM) gcr.io/vorvan/h2oai/h2oai-h2ogpt-vllm:$(PACKAGE_VERSION)
 
-	docker tag $(DOCKER_TEST_IMAGE) gcr.io/vorvan/h2oai/h2ogpt-runtime:latest
-	docker tag $(DOCKER_TEST_IMAGE_VLLM) gcr.io/vorvan/h2oai/h2ogpt-vllm:latest
+	docker tag $(DOCKER_TEST_IMAGE) gcr.io/vorvan/h2oai/h2oai-h2ogpt-runtime:latest
+	docker tag $(DOCKER_TEST_IMAGE_VLLM) gcr.io/vorvan/h2oai/h2oai-h2ogpt-vllm:latest
 
-	docker push gcr.io/vorvan/h2oai/h2ogpt-runtime:$(BUILD_TAG)
-	docker push gcr.io/vorvan/h2oai/h2ogpt-runtime:$(PACKAGE_VERSION)
-	docker push gcr.io/vorvan/h2oai/h2ogpt-runtime:latest
+	docker push gcr.io/vorvan/h2oai/h2oai-h2ogpt-runtime:$(BUILD_TAG)
+	docker push gcr.io/vorvan/h2oai/h2oai-h2ogpt-runtime:$(PACKAGE_VERSION)
+	docker push gcr.io/vorvan/h2oai/h2oai-h2ogpt-runtime:latest
 
-	docker push gcr.io/vorvan/h2oai/h2ogpt-vllm:$(BUILD_TAG)
-	docker push gcr.io/vorvan/h2oai/h2ogpt-vllm:$(PACKAGE_VERSION)
-	docker push gcr.io/vorvan/h2oai/h2ogpt-vllm:latest
+	docker push gcr.io/vorvan/h2oai/h2oai-h2ogpt-vllm:$(BUILD_TAG)
+	docker push gcr.io/vorvan/h2oai/h2oai-h2ogpt-vllm:$(PACKAGE_VERSION)
+	docker push gcr.io/vorvan/h2oai/h2oai-h2ogpt-vllm:latest
 
 ifdef BUILD_ID
-	docker tag $(DOCKER_TEST_IMAGE) gcr.io/vorvan/h2oai/h2ogpt-runtime:$(PACKAGE_VERSION)-$(BUILD_ID)
-	docker push gcr.io/vorvan/h2oai/h2ogpt-runtime:$(PACKAGE_VERSION)-$(BUILD_ID)
+	docker tag $(DOCKER_TEST_IMAGE) gcr.io/vorvan/h2oai/h2oai-h2ogpt-runtime:$(PACKAGE_VERSION)-$(BUILD_ID)
+	docker push gcr.io/vorvan/h2oai/h2oai-h2ogpt-runtime:$(PACKAGE_VERSION)-$(BUILD_ID)
 
-	docker tag $(DOCKER_TEST_IMAGE_VLLM) gcr.io/vorvan/h2oai/h2ogpt-vllm:$(PACKAGE_VERSION)-$(BUILD_ID)
-	docker push gcr.io/vorvan/h2oai/h2ogpt-vllm:$(PACKAGE_VERSION)-$(BUILD_ID)
+	docker tag $(DOCKER_TEST_IMAGE_VLLM) gcr.io/vorvan/h2oai/h2oai-h2ogpt-vllm:$(PACKAGE_VERSION)-$(BUILD_ID)
+	docker push gcr.io/vorvan/h2oai/h2oai-h2ogpt-vllm:$(PACKAGE_VERSION)-$(BUILD_ID)
 endif
 
 print-%:

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 all: clean dist
 
-PACKAGE_VERSION       := `cat version.txt | tr -d '\n'`
-BUILD_TAG             := $(shell git describe --always --dirty)
-DOCKER_TEST_IMAGE     := harbor.h2o.ai/h2ogpt/test-image:$(BUILD_TAG)
-PYTHON_BINARY         ?= `which python`
-DEFAULT_MARKERS       ?= "not need_tokens and not need_gpu"
+PACKAGE_VERSION        := `cat version.txt | tr -d '\n'`
+BUILD_TAG              := $(shell git describe --always --dirty)
+DOCKER_TEST_IMAGE      := harbor.h2o.ai/h2ogpt/test-image:$(BUILD_TAG)
+DOCKER_TEST_IMAGE_VLLM := harbor.h2o.ai/h2ogpt/test-image-vllm:$(BUILD_TAG)
+PYTHON_BINARY          ?= `which python`
+DEFAULT_MARKERS        ?= "not need_tokens and not need_gpu"
 
 .PHONY: venv dist test publish docker_build build_info.txt
 
@@ -54,25 +55,44 @@ docker_build: build_info.txt git_hash.txt
 ifeq ($(shell curl --connect-timeout 4 --write-out %{http_code} -sS --output /dev/null -X GET http://harbor.h2o.ai/api/v2.0/projects/h2ogpt/repositories/test-image/artifacts/$(BUILD_TAG)/tags),200)
 	@echo "Image already pushed to Harbor: $(DOCKER_TEST_IMAGE)"
 else
-	DOCKER_BUILDKIT=1 docker build -t $(DOCKER_TEST_IMAGE) -f Dockerfile .
+	DOCKER_BUILDKIT=1 docker build -t $(DOCKER_TEST_IMAGE) -t h2ogpt:current -f Dockerfile .
+	DOCKER_BUILDKIT=1 docker build -t $(DOCKER_TEST_IMAGE_VLLM) -f Dockerfile-vllm .
 	docker push $(DOCKER_TEST_IMAGE)
+	docker push $(DOCKER_TEST_IMAGE_VLLM)
 endif
 
 just_docker_build: build_info.txt git_hash.txt
 	docker pull $(DOCKER_BASE_OS_IMAGE)
-	DOCKER_BUILDKIT=1 docker build -t $(DOCKER_TEST_IMAGE) -f Dockerfile .
+	DOCKER_BUILDKIT=1 docker build -t $(DOCKER_TEST_IMAGE) -t h2ogpt:current -f Dockerfile .
+	DOCKER_BUILDKIT=1 docker build -t $(DOCKER_TEST_IMAGE_VLLM) -f Dockerfile-vllm .
 
 docker_build_runner: docker_build
 	-docker pull $(DOCKER_TEST_IMAGE)
+	-docker pull $(DOCKER_TEST_IMAGE_VLLM)
+
 	docker tag $(DOCKER_TEST_IMAGE) gcr.io/vorvan/h2oai/h2ogpt-runtime:$(BUILD_TAG)
+	docker tag $(DOCKER_TEST_IMAGE_VLLM) gcr.io/vorvan/h2oai/h2ogpt-vllm:$(BUILD_TAG)
+
 	docker tag $(DOCKER_TEST_IMAGE) gcr.io/vorvan/h2oai/h2ogpt-runtime:$(PACKAGE_VERSION)
+	docker tag $(DOCKER_TEST_IMAGE_VLLM) gcr.io/vorvan/h2oai/h2ogpt-vllm:$(PACKAGE_VERSION)
+
 	docker tag $(DOCKER_TEST_IMAGE) gcr.io/vorvan/h2oai/h2ogpt-runtime:latest
+	docker tag $(DOCKER_TEST_IMAGE_VLLM) gcr.io/vorvan/h2oai/h2ogpt-vllm:latest
+
 	docker push gcr.io/vorvan/h2oai/h2ogpt-runtime:$(BUILD_TAG)
 	docker push gcr.io/vorvan/h2oai/h2ogpt-runtime:$(PACKAGE_VERSION)
 	docker push gcr.io/vorvan/h2oai/h2ogpt-runtime:latest
+
+	docker push gcr.io/vorvan/h2oai/h2ogpt-vllm:$(BUILD_TAG)
+	docker push gcr.io/vorvan/h2oai/h2ogpt-vllm:$(PACKAGE_VERSION)
+	docker push gcr.io/vorvan/h2oai/h2ogpt-vllm:latest
+
 ifdef BUILD_ID
 	docker tag $(DOCKER_TEST_IMAGE) gcr.io/vorvan/h2oai/h2ogpt-runtime:$(PACKAGE_VERSION)-$(BUILD_ID)
 	docker push gcr.io/vorvan/h2oai/h2ogpt-runtime:$(PACKAGE_VERSION)-$(BUILD_ID)
+
+	docker tag $(DOCKER_TEST_IMAGE_VLLM) gcr.io/vorvan/h2oai/h2ogpt-vllm:$(PACKAGE_VERSION)-$(BUILD_ID)
+	docker push gcr.io/vorvan/h2oai/h2ogpt-vllm:$(PACKAGE_VERSION)-$(BUILD_ID)
 endif
 
 print-%:

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,10 @@ build_info.txt:
 git_hash.txt:
 	@echo "$(shell git rev-parse HEAD)" >> $@
 
+DOCKER_BASE_OS_IMAGE := gcr.io/vorvan/h2oai/h2ogpt-oss-wolfi-base:2
+
 docker_build: build_info.txt git_hash.txt
+	docker pull $(DOCKER_BASE_OS_IMAGE)
 ifeq ($(shell curl --connect-timeout 4 --write-out %{http_code} -sS --output /dev/null -X GET http://harbor.h2o.ai/api/v2.0/projects/h2ogpt/repositories/test-image/artifacts/$(BUILD_TAG)/tags),200)
 	@echo "Image already pushed to Harbor: $(DOCKER_TEST_IMAGE)"
 else
@@ -56,6 +59,7 @@ else
 endif
 
 just_docker_build: build_info.txt git_hash.txt
+	docker pull $(DOCKER_BASE_OS_IMAGE)
 	DOCKER_BUILDKIT=1 docker build -t $(DOCKER_TEST_IMAGE) -f Dockerfile .
 
 docker_build_runner: docker_build

--- a/helm/h2ogpt-chart/templates/deployment.yaml
+++ b/helm/h2ogpt-chart/templates/deployment.yaml
@@ -87,7 +87,7 @@ spec:
             {{- toYaml .Values.vllm.securityContext | nindent 12 }}
           image: "{{ .Values.vllm.image.repository }}:{{ .Values.vllm.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.vllm.image.pullPolicy }}
-          command: ["/h2ogpt_conda/vllm_env/bin/python3.10"]
+          command: ["python3.10"]
           args: 
             - "-m" 
             - "vllm.entrypoints.openai.api_server"
@@ -578,7 +578,7 @@ spec:
             {{- toYaml .Values.vllm.securityContext | nindent 12 }}
           image: "{{ .Values.vllm.image.repository }}:{{ .Values.vllm.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.vllm.image.pullPolicy }}
-          command: ["/h2ogpt_conda/vllm_env/bin/python3.10"]
+          command: ["python3.10"]
           args: 
             - "-m" 
             - "vllm.entrypoints.openai.api_server"

--- a/helm/h2ogpt-chart/values.yaml
+++ b/helm/h2ogpt-chart/values.yaml
@@ -139,7 +139,7 @@ vllm:
   replicaCount: 1
 
   image:
-    repository: gcr.io/vorvan/h2oai/h2ogpt-runtime
+    repository: gcr.io/vorvan/h2oai/h2ogpt-runtime-vllm
     tag:
     pullPolicy: IfNotPresent
 

--- a/helm/h2ogpt-chart/values.yaml
+++ b/helm/h2ogpt-chart/values.yaml
@@ -10,7 +10,7 @@ h2ogpt:
   replicaCount: 1
   imagePullSecrets: 
   image:
-    repository: gcr.io/vorvan/h2oai/h2ogpt-runtime
+    repository: gcr.io/vorvan/h2oai/h2oai-h2ogpt-runtime
     tag: 
     pullPolicy: IfNotPresent
   initImage:
@@ -139,7 +139,7 @@ vllm:
   replicaCount: 1
 
   image:
-    repository: gcr.io/vorvan/h2oai/h2ogpt-runtime-vllm
+    repository: gcr.io/vorvan/h2oai/h2oai-h2ogpt-vllm
     tag:
     pullPolicy: IfNotPresent
 

--- a/linux_install_wolfi.sh
+++ b/linux_install_wolfi.sh
@@ -164,3 +164,4 @@ chmod -R a+rwx /workspace
 
 # remove pip cache
 rm -rf /workspace/.cache
+rm -rf /usr/lib/python3.10/site-packages/future/backports/test

--- a/linux_install_wolfi.sh
+++ b/linux_install_wolfi.sh
@@ -158,9 +158,6 @@ for enc in model_encodings:
 print('Done!')
 "
 
-# mitigate CVE-2024-22423
-pip install yt-dlp>=2024.4.9 --no-cache-dir -c reqs_optional/reqs_constraints.txt
-
 # more cleanup
 rm -rf /bin/busybox
 

--- a/linux_install_wolfi.sh
+++ b/linux_install_wolfi.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+set -o pipefail
+set -ex
+
+
+# broad support, but no training-time or data creation dependencies
+pip install -r requirements.txt -c reqs_optional/reqs_constraints.txt
+
+# Required for Doc Q/A: LangChain:
+pip install -r reqs_optional/requirements_optional_langchain.txt -c reqs_optional/reqs_constraints.txt
+
+# Required for CPU: LLaMa/GPT4All:
+C=gcc-11 CXX=g++-11 pip install -r reqs_optional/requirements_optional_llamacpp_gpt4all.txt -c reqs_optional/reqs_constraints.txt --no-cache-dir
+
+# Optional: PyMuPDF/ArXiv:
+pip install -r reqs_optional/requirements_optional_langchain.gpllike.txt -c reqs_optional/reqs_constraints.txt
+
+# Optional: FAISS
+pip install -r reqs_optional/requirements_optional_gpu_only.txt -c reqs_optional/reqs_constraints.txt
+
+# Optional: Selenium/PlayWright:
+pip install -r reqs_optional/requirements_optional_langchain.urls.txt -c reqs_optional/reqs_constraints.txt
+
+# Optional: For DocTR
+pip install -r reqs_optional/requirements_optional_doctr.txt -c reqs_optional/reqs_constraints.txt
+
+# For DocTR: go back to older onnx so Tesseract OCR still works
+pip install onnxruntime==1.15.0 -c reqs_optional/reqs_constraints.txt
+# GPU only:
+pip install onnxruntime-gpu==1.15.0 -c reqs_optional/reqs_constraints.txt
+
+# Optional: for supporting unstructured package
+for i in 1 2 3 4; do python -m nltk.downloader all && break || sleep 1; done  # retry as frequently fails with github downloading issues
+
+# Audio transcription from Youtube videos and local mp3 files:
+pip install pydub==0.25.1 librosa==0.10.1 ffmpeg==1.4 yt_dlp==2023.10.13 wavio==0.0.8 -c reqs_optional/reqs_constraints.txt
+
+# Audio speed-up and slowdown (best quality), if not installed can only speed-up with lower quality
+# may not work as it needs its CLI, example from ubuntu: sudo apt-get install -y rubberband-cli
+pip install pyrubberband==0.3.0 -c reqs_optional/reqs_constraints.txt
+# https://stackoverflow.com/questions/75813603/python-working-with-sound-librosa-and-pyrubberband-conflict
+pip uninstall -y pysoundfile soundfile
+pip install soundfile==0.12.1 -c reqs_optional/reqs_constraints.txt
+
+# for any TTS:
+pip install torchaudio soundfile==0.12.1 -c reqs_optional/reqs_constraints.txt
+# GPU Only: for Coqui XTTS (ensure CUDA_HOME set and consistent with added postfix for extra-index):
+# relaxed versions to avoid conflicts
+pip install TTS deepspeed noisereduce emoji ffmpeg-python==0.2.0 trainer pysbd coqpit -c reqs_optional/reqs_constraints.txt
+
+# for Coqui XTTS language helpers (specific versions probably not required)
+pip install cutlet==0.3.0 langid==1.1.6 g2pkk==0.1.2 jamo==0.4.1 gruut[de,es,fr]==2.2.3 jieba==0.42.1 -c reqs_optional/reqs_constraints.txt
+# For faster whisper:
+#pip install git+https://github.com/SYSTRAN/faster-whisper.git -c reqs_optional/reqs_constraints.txt
+# needed for librosa/soundfile to work, but violates TTS, but that's probably just too strict as we have seen before)
+pip install numpy==1.23.0 --no-deps --upgrade -c reqs_optional/reqs_constraints.txt
+# TTS or other deps load old librosa, fix:
+pip install librosa==0.10.1 --no-deps --upgrade -c reqs_optional/reqs_constraints.txt
+
+#
+#* STT and TTS Notes:
+#
+# STT: Ensure microphone is on and in browser go to http://localhost:7860 instead of http://0.0.0.0:7860 for microphone to be possible to allow in browser.
+# TTS: For XTT models, ensure `CUDA_HOME` is set correctly, because deepspeed compiles at runtime using torch and nvcc.  Those must match CUDA version.  E.g. if used `--extra-index https://download.pytorch.org/whl/cu118`, then must have ENV `CUDA_HOME=/usr/local/cuda-11.7` or ENV from conda must be that version.  Since conda only has up to cuda 11.7 for dev toolkit, but H100+ need cuda 11.8, for those cases one should download the toolkit from NVIDIA.
+# Vision/Image packages
+pip install fiftyone -c reqs_optional/reqs_constraints.txt
+pip install pytube -c reqs_optional/reqs_constraints.txt
+pip install diffusers==0.24.0 -c reqs_optional/reqs_constraints.txt
+
+#
+#* HNSW issue:
+#
+# In some cases old chroma migration package will install old hnswlib and that may cause issues when making a database, then do:
+pip uninstall -y hnswlib chroma-hnswlib
+# restore correct version
+pip install chroma-hnswlib==0.7.3 --upgrade -c reqs_optional/reqs_constraints.txt
+
+#
+#* GPU Optional: For AutoGPTQ support on x86_64 linux
+#
+# in-transformers support of AutoGPTQ, requires also auto-gptq above to be installed since used internally by transformers/optimum
+pip install optimum==1.17.1 -c reqs_optional/reqs_constraints.txt
+#    See [AutoGPTQ](README_GPU.md#autogptq) about running AutoGPT models.
+
+#
+#* GPU Optional: For AutoAWQ support on x86_64 linux
+pip uninstall -y autoawq ; pip install autoawq -c reqs_optional/reqs_constraints.txt
+# fix version since don't need lm-eval to have its version of 1.5.0
+pip install sacrebleu==2.3.1 --upgrade -c reqs_optional/reqs_constraints.txt
+
+# ensure not installed if remade env on top of old env
+pip uninstall llama_cpp_python_cuda -y
+
+#* GPU Optional: For exllama support on x86_64 linux
+ #pip uninstall -y exllama ; pip install https://github.com/jllllll/exllama/releases/download/0.0.18/exllama-0.0.18+cu121-cp310-cp310-linux_x86_64.whl --no-cache-dir -c reqs_optional/reqs_constraints.txt
+#    See [exllama](README_GPU.md#exllama) about running exllama models.
+pip install autoawq-kernels -c reqs_optional/reqs_constraints.txt
+
+pip install auto-gptq==0.7.1 exllamav2==0.0.16
+
+#
+#* GPU Optional: Support amazon/MistralLite with flash attention 2
+#
+pip install --upgrade pip
+pip install flash-attn==2.4.2 --no-build-isolation --no-cache-dir -c reqs_optional/reqs_constraints.txt
+
+#
+#* Control Core Count for chroma < 0.4 using chromamigdb package:
+#
+# Duckdb used by Chroma < 0.4 uses DuckDB 0.8.1 that has no control over number of threads per database, `import duckdb` leads to all virtual cores as threads and each db consumes another number of threads equal to virtual cores.  To prevent this, one can rebuild duckdb using [this modification](https://github.com/h2oai/duckdb/commit/dcd8c1ffc53dd020623630efb99ba6a3a4cbc5ad) or one can try to use the prebuild wheel for x86_64 built on Ubuntu 20.
+pip uninstall -y pyduckdb duckdb
+pip install https://h2o-release.s3.amazonaws.com/h2ogpt/duckdb-0.8.2.dev4025%2Bg9698e9e6a8.d20230907-cp310-cp310-linux_x86_64.whl --no-cache-dir --force-reinstall --no-deps -c reqs_optional/reqs_constraints.txt
+
+#
+#* SERP for search:
+#
+pip install -r reqs_optional/requirements_optional_agents.txt -c reqs_optional/reqs_constraints.txt
+#  For more info see [SERP Docs](README_SerpAPI.md).
+
+# https://github.com/h2oai/h2ogpt/issues/1483
+pip uninstall flash_attn autoawq autoawq-kernels -y
+pip install flash_attn autoawq autoawq-kernels --no-cache-dir -c reqs_optional/reqs_constraints.txt
+
+
+bash ./docs/run_patches.sh
+
+# setup tiktoken cache
+python3.10 -c "
+import tiktoken
+from tiktoken_ext import openai_public
+# FakeTokenizer etc. needs tiktoken for general tasks
+for enc in openai_public.ENCODING_CONSTRUCTORS:
+    encoding = tiktoken.get_encoding(enc)
+model_encodings = [
+    'gpt-4',
+    'gpt-4-0314',
+    'gpt-4-32k',
+    'gpt-4-32k-0314',
+    'gpt-3.5-turbo',
+    'gpt-3.5-turbo-16k',
+    'gpt-3.5-turbo-0301',
+    'text-ada-001',
+    'ada',
+    'text-babbage-001',
+    'babbage',
+    'text-curie-001',
+    'curie',
+    'davinci',
+    'text-davinci-003',
+    'text-davinci-002',
+    'code-davinci-002',
+    'code-davinci-001',
+    'code-cushman-002',
+    'code-cushman-001'
+]
+for enc in model_encodings:
+    encoding = tiktoken.encoding_for_model(enc)
+print('Done!')
+"
+
+
+# make main workspace writable
+chmod -R a+rwx /workspace
+
+# remove pip cache
+rm -rf /workspace/.cache

--- a/linux_install_wolfi.sh
+++ b/linux_install_wolfi.sh
@@ -158,12 +158,6 @@ for enc in model_encodings:
 print('Done!')
 "
 
-# more cleanup
-rm -rf /bin/busybox
 
-# remove pip cache
-rm -rf /workspace/.cache
-rm -rf /usr/lib/python3.10/site-packages/future/backports/test
-
-# make main workspace writable
-chmod -R a+rwx /workspace
+# mitigate CVE-2024-22423
+pip install yt-dlp==2024.4.9 --no-deps --no-cache-dir

--- a/linux_install_wolfi.sh
+++ b/linux_install_wolfi.sh
@@ -158,10 +158,15 @@ for enc in model_encodings:
 print('Done!')
 "
 
+# mitigate CVE-2024-22423
+pip install yt-dlp>=2024.4.9 --no-cache-dir -c reqs_optional/reqs_constraints.txt
 
-# make main workspace writable
-chmod -R a+rwx /workspace
+# more cleanup
+rm -rf /bin/busybox
 
 # remove pip cache
 rm -rf /workspace/.cache
 rm -rf /usr/lib/python3.10/site-packages/future/backports/test
+
+# make main workspace writable
+chmod -R a+rwx /workspace


### PR DESCRIPTION
some changes:
- [x] use a CVE clean base.
- [x] split vllm from main h2ogpt runtime.
- [x] breakdown the layers to speed up docker pull and extract.
- [x] save wasted docker space.