### PR TITLE
Set NUMBA_CACHE_DIR to a writable location by the docker user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV HOME=/workspace
 ENV CUDA_HOME=/usr/local/cuda-12.1
 ENV VLLM_CACHE=/workspace/.vllm_cache
 ENV TIKTOKEN_CACHE_DIR=/workspace/tiktoken_cache
+ENV NUMBA_CACHE_DIR=/workspace/numba_cache
 ENV HF_HUB_ENABLE_HF_TRANSFER=1
 
 WORKDIR /workspace


### PR DESCRIPTION
Address:

```
~:~$ docker run --rm -it --entrypoint bash gcr.io/vorvan/h2oai/h2oai-h2ogpt-vllm:0.2.0-656
bash-5.2$ python 
Python 3.10.14 (main, May  1 2024, 21:48:03) [GCC 13.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import outlines.generate
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.10/site-packages/outlines/__init__.py", line 2, in <module>
    import outlines.generate
  File "/usr/lib/python3.10/site-packages/outlines/generate/__init__.py", line 1, in <module>
    from .api import SequenceGenerator
  File "/usr/lib/python3.10/site-packages/outlines/generate/api.py", line 5, in <module>
    from outlines.fsm.fsm import FSMState
  File "/usr/lib/python3.10/site-packages/outlines/fsm/fsm.py", line 9, in <module>
    from outlines.fsm.regex import create_fsm_index_tokenizer, make_deterministic_fsm
  File "/usr/lib/python3.10/site-packages/outlines/fsm/regex.py", line 96, in <module>
    def create_fsm_info(
  File "/usr/lib/python3.10/site-packages/numba/core/decorators.py", line 229, in wrapper
    disp.enable_caching()
  File "/usr/lib/python3.10/site-packages/numba/core/dispatcher.py", line 856, in enable_caching
    self._cache = FunctionCache(self.py_func)
  File "/usr/lib/python3.10/site-packages/numba/core/caching.py", line 601, in __init__
    self._impl = self._impl_class(py_func)
  File "/usr/lib/python3.10/site-packages/numba/core/caching.py", line 337, in __init__
    raise RuntimeError("cannot cache function %r: no locator available "
RuntimeError: cannot cache function 'create_fsm_info': no locator available for file '/usr/lib/python3.10/site-packages/outlines/fsm/regex.py'
>>> 
bash-5.2$ 
bash-5.2$ NUMBA_CACHE_DIR=/workspace/numba_cache python3.10
Python 3.10.14 (main, May  1 2024, 21:48:03) [GCC 13.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import outlines.generate
>>> 
```