### PR TITLE
feat(helm): Add option for vision models 

### DIFF
--- a/helm/h2ogpt-chart/templates/deployment.yaml
+++ b/helm/h2ogpt-chart/templates/deployment.yaml
@@ -263,6 +263,12 @@ spec:
           - name: H2OGPT_SCORE_MODEL
             value: None
           {{- end }}
+          {{- if .Values.h2ogpt.visionModels.enabled }}
+          - name: H2OGPT_VISIBLE_VISION_MODELS
+            value: {{ .Values.h2ogpt.visionModels.visibleModels | quote }}
+          - name: H2OGPT_ROTATE_ALIGN_RESIZE_IMAGE
+            value: {{ .Values.h2ogpt.visionModels.rotateAlignResizeImage | quote }}
+          {{- end }}
           volumeMounts:
             - name: {{ include "h2ogpt.fullname" . }}-volume
               mountPath: /workspace/.cache

--- a/helm/h2ogpt-chart/values.yaml
+++ b/helm/h2ogpt-chart/values.yaml
@@ -42,6 +42,13 @@ h2ogpt:
 
     replicate: 
       enabled: false
+  
+  visionModels:
+    enabled: false
+    # -- Visible vision models, the vision model itslef needs to be set via modeLock or base_model
+    # -- Ex: visibleModels: ['OpenGVLab/InternVL-Chat-V1-5']
+    visibleModels: []
+    rotateAlignResizeImage: false
 
 # -- Example configs to use when not using Model Lock and External LLM
   # overrideConfig:


### PR DESCRIPTION
# Description

This PR exposes the `H2OGPT_VISIBLE_VISION_MODELS` and `H2OGPT_ROTATE_ALIGN_RESIZE_IMAGE` in Helm. Issue - https://github.com/h2oai/public-cloud-infrastructure/issues/3252