### PR TITLE
Revert "Add image models config"

### DIFF
--- a/helm/h2ogpt-chart/templates/deployment.yaml
+++ b/helm/h2ogpt-chart/templates/deployment.yaml
@@ -281,8 +281,6 @@ spec:
           {{- if .Values.h2ogpt.externalLLM.enabled }}
           - name: H2OGPT_MODEL_LOCK
             value: {{ toJson .Values.h2ogpt.externalLLM.modelLock | quote }}
-          - name: H2OGPT_VISIBLE_VISION_MODELS
-            value: {{ toJson .Values.h2ogpt.externalLLM.visibleImageModels | quote }}
           - name: H2OGPT_SCORE_MODEL
             value: None
           {{- end }}

--- a/helm/h2ogpt-chart/values.yaml
+++ b/helm/h2ogpt-chart/values.yaml
@@ -34,8 +34,6 @@ h2ogpt:
 
     modelLock:
 
-    visibleImageModels:
-
     openAIAzure:
       enabled: false
 


### PR DESCRIPTION
Reverts h2oai/h2ogpt#1708 because changes were superseeded by https://github.com/h2oai/h2ogpt/pull/1712