### PR TITLE
Update nvidia-container-toolkit link

### DIFF
--- a/docs/README_DOCKER.md
+++ b/docs/README_DOCKER.md
@@ -28,11 +28,10 @@ which avoids having to reboot.  Or just reboot to have docker access.  If this c
 
 Ensure docker installed and ready (requires sudo), can skip if system is already capable of running nvidia containers.  Example here is for Ubuntu, see [NVIDIA Containers](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker) for more examples.
 ```bash
-distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \
-    && curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
-    && curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list | \
-        sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
-        sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
+  && curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+    sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+    sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
 sudo apt-get update && sudo apt-get install -y nvidia-container-toolkit-base
 sudo apt install -y nvidia-container-runtime
 sudo nvidia-ctk runtime configure --runtime=docker


### PR DESCRIPTION
Update the nvidia container toolkit link according to the updated nvidia documentation. It allows the installation method to work properly on more diverse distributions, such as Ubuntu 24.04.

https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html