### PR TITLE
Expose caCertificates in helm

### DIFF
--- a/helm/h2ogpt-chart/templates/config-map.yaml
+++ b/helm/h2ogpt-chart/templates/config-map.yaml
@@ -40,3 +40,16 @@ data:
   {{ printf "%s" $key | upper }}: {{ $value | quote }}
 {{- end }}
 {{- end }}
+---
+{{- if .Values.caCertificates}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "h2ogpt.fullname" . }}-ca-certificates
+  namespace: {{ include "h2ogpt.namespace" . | quote }}
+  labels:
+    {{- include "h2ogpt.labels" . | nindent 4 }}
+data:
+  root-ca-bundle.crt:  |
+    {{ .Values.caCertificates | nindent 4 | trim }}
+{{- end }}

--- a/helm/h2ogpt-chart/templates/deployment.yaml
+++ b/helm/h2ogpt-chart/templates/deployment.yaml
@@ -276,6 +276,11 @@ spec:
             - name: {{ include "h2ogpt.fullname" . }}-volume
               mountPath: /workspace/save
               subPath: save
+            {{- if .Values.caCertificates }}
+            - name: ca-certificates
+              mountPath: /etc/ssl/certs/root-ca-bundle.crt
+              subPath: root-ca-bundle.crt
+            {{- end }}
             {{ with .Values.h2ogpt.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -311,6 +316,11 @@ spec:
                     storage: {{ .Values.vllm.storage.size | quote }}
                 storageClassName: {{ .Values.vllm.storage.class }}
           {{- end }}
+        {{- end }}
+        {{- if .Values.caCertificates }}
+        - name: ca-certificates
+          configMap:
+            name: {{ include "h2ogpt.fullname" . }}-ca-certificates
         {{- end }}
         {{- with .Values.h2ogpt.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/helm/h2ogpt-chart/values.yaml
+++ b/helm/h2ogpt-chart/values.yaml
@@ -211,3 +211,6 @@ vllm:
   podAnnotations: {}
   podLabels: {}
   autoscaling: {}
+
+# -- CA certs
+caCertificates: ""

--- a/src/gen.py
+++ b/src/gen.py
@@ -5351,6 +5351,7 @@ def append_certificates(certs_dir):
     import certifi
     cert_bundle_path = certifi.where()
 
+    default_bundle_from_helm = "/etc/ssl/certs/root-ca-bundle.crt"
     ssl_cache_dir = os.getenv("SSL_CACHE_DIR", ".cache/.ssl_cache")
     ssl_cache_dir = os.path.abspath(makedirs(ssl_cache_dir, exist_ok=True, tmp_ok=True, use_base=True))
     output_file = os.path.join(ssl_cache_dir, "ca-bundle.pem")
@@ -5370,6 +5371,12 @@ def append_certificates(certs_dir):
                     with open(cert_file_path, 'r') as cert:
                         combined_cert_content += '\n' + cert.read()
                     additional_certs_found = True
+
+    if os.path.exists(default_bundle_from_helm) and os.path.isfile(default_bundle_from_helm):
+        print(f"adding default helm cert {default_bundle_from_helm}")
+        with open(default_bundle_from_helm, 'r') as cert:
+            combined_cert_content += '\n' + cert.read()
+        additional_certs_found = True
 
     if additional_certs_found:
         with open(output_file, 'w') as output:


### PR DESCRIPTION
Expose caCertificates in helm to it is more aligned with other h2o products.

ref: https://github.com/h2oai/h2ogpt/issues/1743#issuecomment-2243416520