### PR TITLE
Change to make h2ogpt work on Mac M2 chip

### DIFF
--- a/docs/README_MACOS.md
+++ b/docs/README_MACOS.md
@@ -80,6 +80,12 @@ python generate.py --base_model=TheBloke/zephyr-7B-beta-GGUF --prompt_type=zephy
 ```
 and run `sh run.sh` from the terminal placed in the parent folder of `run.sh`
 
+To run with latest llama 3.1 gguf model, you can run:
+```
+python generate.py --base_model=llama --model_path_llama=https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/resolve/main/Meta-Llama-3.1-8B-Instruct-Q6_K_L.gguf?download=true --tokenizer_base_model=meta-llama/Meta-Llama-3.1-8B-Instruct --max_seq_len=8192
+```
+For more info about llama 3 models see [FAQ](https://github.com/h2oai/h2ogpt/blob/main/docs/FAQ.md#llama-3-or-other-chat-template-based-models)
+
 ---
 
 ## Issues
@@ -119,9 +125,7 @@ and run `sh run.sh` from the terminal placed in the parent folder of `run.sh`
 * If you encounter an error while building a wheel during the `pip install` process, you may need to install a C++ compiler on your computer.
 * If you see the error `TypeError: Trying to convert BFloat16 to the MPS backend but it does not have support for that dtype.`:
   ```bash
-  pip install -U torch==2.3.0.dev20240229 --extra-index https://download.pytorch.org/whl/nightly/cpu --pre
-  pip install -U torchvision==0.18.0.dev20240229 --extra-index https://download.pytorch.org/whl/nightly/cpu --pre
+  pip install -U torch==2.3.1
+  pip install -U torchvision==0.18.1
   ```
   * Support for BFloat16 is added to MacOS from Sonama (14.0)
-  * Based on that a fix is added to torch with PR https://github.com/pytorch/pytorch/pull/119641 and it is still only available in nighlty. Expecting the feature with release `torch-2.3.0`
-  * **Note:** Updating torch to nighlty is experimental and it might break features in h2ogpt

--- a/reqs_optional/reqs_constraints.txt
+++ b/reqs_optional/reqs_constraints.txt
@@ -1,5 +1,5 @@
 # ensure doesn't drift, e.g. Issue #1348
-torch==2.2.1
+torch==2.3.1
 gradio==4.26.0
 gradio_client==0.15.1
 transformers>=4.43.2

--- a/reqs_optional/requirements_optional_llamacpp_gpt4all.txt
+++ b/reqs_optional/requirements_optional_llamacpp_gpt4all.txt
@@ -1,5 +1,5 @@
 gpt4all==1.0.5
 
 # requires env to be set for specific systems
-llama-cpp-python==0.2.76
+llama-cpp-python==0.2.85
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,8 +17,8 @@ huggingface_hub>=0.23.3
 appdirs>=1.4.4
 fire>=0.5.0
 docutils>=0.20.1
-torch==2.2.1; sys_platform != "darwin" and platform_machine != "arm64"
-torch==2.2.1; sys_platform == "darwin" and platform_machine == "arm64"
+torch==2.3.1; sys_platform != "darwin" and platform_machine != "arm64"
+torch==2.3.1; sys_platform == "darwin" and platform_machine == "arm64"
 evaluate>=0.4.0
 rouge_score>=0.1.2
 sacrebleu>=2.3.1
@@ -32,7 +32,8 @@ matplotlib>=3.7.1
 
 # transformers
 loralib>=0.1.2
-bitsandbytes>=0.43.1
+#bitsandbytes downgraded because of Mac M1/M2 support issue. See https://github.com/axolotl-ai-cloud/axolotl/issues/1436
+bitsandbytes==0.42.0
 accelerate>=0.30.1
 peft>=0.7.0
 transformers>=4.43.2


### PR DESCRIPTION
These are the changes I involved to make llama 3.1 gguf work on Mac M2. 

I had to downgrade Bitsandbytes to 0.42.0 (from 0.43.1) because of a similar issue to this one : https://github.com/axolotl-ai-cloud/axolotl/issues/1436

I also had to bump some package versions :
- llama-cpp-python==0.2.85
- torch==2.3.1

Please note that I still have these warnings from llama_cpp when generating answers, but it doesn't seem to affect quality too much: 
```
h2ogpt/lib/python3.10/site-packages/llama_cpp/llama.py:1129: RuntimeWarning: Detected duplicate leading "<|begin_of_text|>" in prompt, this will likely reduce response quality, consider removing it...

``` 

I hope that it does also work on other platforms but I am not able to test