### PR TITLE
Use a newer vllm image and update the docs and helm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ DEFAULT_MARKERS              ?= "not need_tokens and not need_gpu"
 
 # h2ogpt base, vllm, and lmdeploy images built elsewhere and referenced here:
 DOCKER_BASE_OS_IMAGE     := gcr.io/vorvan/h2oai/h2ogpt-oss-wolfi-base:5
-DOCKER_VLLM_IMAGE        := gcr.io/vorvan/h2oai/h2ogpte-vllm:0.5.3.post1-8bd7fa3c
+DOCKER_VLLM_IMAGE        := gcr.io/vorvan/h2oai/h2ogpte-vllm:0.5.3.post1-a0e7e29e
 DOCKER_LMDEPLOY_IMAGE    := gcr.io/vorvan/h2oai/h2ogpte-lmdeploy:0.5.1-f88699a
 
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -616,8 +616,9 @@ docker run -d \
     -p 5000:5000 \
     -e NCCL_IGNORE_DISABLED_P2P=1 \
     -e HUGGING_FACE_HUB_TOKEN=$HUGGING_FACE_HUB_TOKEN \
-    -e export VLLM_NO_USAGE_STATS=1 -e DO_NOT_TRACK=1 \
-    -e VLLM_NCCL_SO_PATH=/usr/local/lib/python3.10/dist-packages/nvidia/nccl/lib/libnccl.so.2 -e NUMBA_CACHE_DIR=/tmp/ \
+    -e VLLM_NO_USAGE_STATS=1 \
+    -e DO_NOT_TRACK=1 \
+    -e NUMBA_CACHE_DIR=/tmp/ \
     -v /etc/passwd:/etc/passwd:ro \
     -v /etc/group:/etc/group:ro \
     -u `id -u`:`id -g` \
@@ -645,8 +646,9 @@ docker run -d \
     -p 5002:5002 \
     -e NCCL_IGNORE_DISABLED_P2P=1 \
     -e HUGGING_FACE_HUB_TOKEN=$HUGGING_FACE_HUB_TOKEN \
-    -e export VLLM_NO_USAGE_STATS=1 -e DO_NOT_TRACK=1 \
-    -e VLLM_NCCL_SO_PATH=/usr/local/lib/python3.10/dist-packages/nvidia/nccl/lib/libnccl.so.2 -e NUMBA_CACHE_DIR=/tmp/ \
+    -e VLLM_NO_USAGE_STATS=1 \
+    -e DO_NOT_TRACK=1 \
+    -e NUMBA_CACHE_DIR=/tmp/ \
     -v /etc/passwd:/etc/passwd:ro \
     -v /etc/group:/etc/group:ro \
     -u `id -u`:`id -g` \
@@ -675,8 +677,9 @@ docker run -d \
     -p 5001:5001 \
     -e NCCL_IGNORE_DISABLED_P2P=1 \
     -e HUGGING_FACE_HUB_TOKEN=$HUGGING_FACE_HUB_TOKEN \
-    -e export VLLM_NO_USAGE_STATS=1 -e DO_NOT_TRACK=1 \
-    -e VLLM_NCCL_SO_PATH=/usr/local/lib/python3.10/dist-packages/nvidia/nccl/lib/libnccl.so.2 -e NUMBA_CACHE_DIR=/tmp/ \
+    -e VLLM_NO_USAGE_STATS=1 \
+    -e DO_NOT_TRACK=1 \
+    -e NUMBA_CACHE_DIR=/tmp/ \
     -v /etc/passwd:/etc/passwd:ro \
     -v /etc/group:/etc/group:ro \
     -u `id -u`:`id -g` \
@@ -704,8 +707,9 @@ docker run -d \
     -p 5003:5003 \
     -e NCCL_IGNORE_DISABLED_P2P=1 \
     -e HUGGING_FACE_HUB_TOKEN=$HUGGING_FACE_HUB_TOKEN \
-    -e export VLLM_NO_USAGE_STATS=1 -e DO_NOT_TRACK=1 \
-    -e VLLM_NCCL_SO_PATH=/usr/local/lib/python3.10/dist-packages/nvidia/nccl/lib/libnccl.so.2 -e NUMBA_CACHE_DIR=/tmp/ \
+    -e VLLM_NO_USAGE_STATS=1 \
+    -e DO_NOT_TRACK=1 \
+    -e NUMBA_CACHE_DIR=/tmp/ \
     -v /etc/passwd:/etc/passwd:ro \
     -v /etc/group:/etc/group:ro \
     -u `id -u`:`id -g` \
@@ -733,8 +737,9 @@ docker run -d \
     -p 5004:5004 \
     -e NCCL_IGNORE_DISABLED_P2P=1 \
     -e HUGGING_FACE_HUB_TOKEN=$HUGGING_FACE_HUB_TOKEN \
-    -e export VLLM_NO_USAGE_STATS=1 -e DO_NOT_TRACK=1 \
-    -e VLLM_NCCL_SO_PATH=/usr/local/lib/python3.10/dist-packages/nvidia/nccl/lib/libnccl.so.2 -e NUMBA_CACHE_DIR=/tmp/ \
+    -e VLLM_NO_USAGE_STATS=1 \
+    -e DO_NOT_TRACK=1 \
+    -e NUMBA_CACHE_DIR=/tmp/ \
     -v /etc/passwd:/etc/passwd:ro \
     -v /etc/group:/etc/group:ro \
     -u `id -u`:`id -g` \
@@ -772,8 +777,9 @@ docker run -d \
     -p 5001:5001 \
     -e NCCL_IGNORE_DISABLED_P2P=1 \
     -e HUGGING_FACE_HUB_TOKEN=$HUGGING_FACE_HUB_TOKEN \
-    -e export VLLM_NO_USAGE_STATS=1 -e DO_NOT_TRACK=1 \
-    -e VLLM_NCCL_SO_PATH=/usr/local/lib/python3.10/dist-packages/nvidia/nccl/lib/libnccl.so.2 -e NUMBA_CACHE_DIR=/tmp/ \
+    -e VLLM_NO_USAGE_STATS=1 \
+    -e DO_NOT_TRACK=1 \
+    -e NUMBA_CACHE_DIR=/tmp/ \
     -v /etc/passwd:/etc/passwd:ro \
     -v /etc/group:/etc/group:ro \
     -u `id -u`:`id -g` \
@@ -800,8 +806,9 @@ docker run -d \
     -p 5005:5005 \
     -e NCCL_IGNORE_DISABLED_P2P=1 \
     -e HUGGING_FACE_HUB_TOKEN=$HUGGING_FACE_HUB_TOKEN \
-    -e export VLLM_NO_USAGE_STATS=1 -e DO_NOT_TRACK=1 \
-    -e VLLM_NCCL_SO_PATH=/usr/local/lib/python3.10/dist-packages/nvidia/nccl/lib/libnccl.so.2 -e NUMBA_CACHE_DIR=/tmp/ \
+    -e VLLM_NO_USAGE_STATS=1 \
+    -e DO_NOT_TRACK=1 \
+    -e NUMBA_CACHE_DIR=/tmp/ \
     -v /etc/passwd:/etc/passwd:ro \
     -v /etc/group:/etc/group:ro \
     -u `id -u`:`id -g` \
@@ -830,8 +837,9 @@ docker run -d \
     -p 5000:5000 \
     -e NCCL_IGNORE_DISABLED_P2P=1 \
     -e HUGGING_FACE_HUB_TOKEN=$HUGGING_FACE_HUB_TOKEN \
-    -e export VLLM_NO_USAGE_STATS=1 -e DO_NOT_TRACK=1 \
-    -e VLLM_NCCL_SO_PATH=/usr/local/lib/python3.10/dist-packages/nvidia/nccl/lib/libnccl.so.2 -e NUMBA_CACHE_DIR=/tmp/ \
+    -e VLLM_NO_USAGE_STATS=1 \
+    -e DO_NOT_TRACK=1 \
+    -e NUMBA_CACHE_DIR=/tmp/ \
     -v /etc/passwd:/etc/passwd:ro \
     -v /etc/group:/etc/group:ro \
     -u `id -u`:`id -g` \
@@ -861,8 +869,9 @@ docker run -d \
     -p 5014:5014 \
     -e NCCL_IGNORE_DISABLED_P2P=1 \
     -e HUGGING_FACE_HUB_TOKEN=$HUGGING_FACE_HUB_TOKEN \
-    -e export VLLM_NO_USAGE_STATS=1 -e DO_NOT_TRACK=1 \
-    -e VLLM_NCCL_SO_PATH=/usr/local/lib/python3.10/dist-packages/nvidia/nccl/lib/libnccl.so.2 -e NUMBA_CACHE_DIR=/tmp/ \
+    -e VLLM_NO_USAGE_STATS=1 \
+    -e DO_NOT_TRACK=1 \
+    -e NUMBA_CACHE_DIR=/tmp/ \
     -v /etc/passwd:/etc/passwd:ro \
     -v /etc/group:/etc/group:ro \
     -u `id -u`:`id -g` \
@@ -895,8 +904,9 @@ docker run -d \
     -p 5014:5014 \
     -e NCCL_IGNORE_DISABLED_P2P=1 \
     -e HUGGING_FACE_HUB_TOKEN=$HUGGING_FACE_HUB_TOKEN \
-    -e export VLLM_NO_USAGE_STATS=1 -e DO_NOT_TRACK=1 \
-    -e VLLM_NCCL_SO_PATH=/usr/local/lib/python3.10/dist-packages/nvidia/nccl/lib/libnccl.so.2 -e NUMBA_CACHE_DIR=/tmp/ \
+    -e VLLM_NO_USAGE_STATS=1 \
+    -e DO_NOT_TRACK=1 \
+    -e NUMBA_CACHE_DIR=/tmp/ \
     -v /etc/passwd:/etc/passwd:ro \
     -v /etc/group:/etc/group:ro \
     -u `id -u`:`id -g` \

--- a/docs/README_DOCKER.md
+++ b/docs/README_DOCKER.md
@@ -232,8 +232,9 @@ docker run \
     --rm --init \
     -e NCCL_IGNORE_DISABLED_P2P=1 \
     -e HUGGING_FACE_HUB_TOKEN=$HUGGING_FACE_HUB_TOKEN \
-    -e export VLLM_NO_USAGE_STATS=1 -e DO_NOT_TRACK=1 \
-    -e VLLM_NCCL_SO_PATH=/usr/local/lib/python3.10/dist-packages/nvidia/nccl/lib/libnccl.so.2 -e NUMBA_CACHE_DIR=/tmp/ \
+    -e VLLM_NO_USAGE_STATS=1 \
+    -e DO_NOT_TRACK=1 \
+    -e NUMBA_CACHE_DIR=/tmp/ \
     -v /etc/passwd:/etc/passwd:ro \
     -v /etc/group:/etc/group:ro \
     -u `id -u`:`id -g` \
@@ -273,8 +274,9 @@ docker run -d \
     -p 5000:5000 \
     -e NCCL_IGNORE_DISABLED_P2P=1 \
     -e HUGGING_FACE_HUB_TOKEN=$HUGGING_FACE_HUB_TOKEN \
-    -e export VLLM_NO_USAGE_STATS=1 -e DO_NOT_TRACK=1 \
-    -e VLLM_NCCL_SO_PATH=/usr/local/lib/python3.10/dist-packages/nvidia/nccl/lib/libnccl.so.2 -e NUMBA_CACHE_DIR=/tmp/ \
+    -e VLLM_NO_USAGE_STATS=1 \
+    -e DO_NOT_TRACK=1 \
+    -e NUMBA_CACHE_DIR=/tmp/ \
     -v /etc/passwd:/etc/passwd:ro \
     -v /etc/group:/etc/group:ro \
     -u `id -u`:`id -g` \
@@ -309,8 +311,9 @@ docker run -d \
     -p 5000:5000 \
     -e NCCL_IGNORE_DISABLED_P2P=1 \
     -e HUGGING_FACE_HUB_TOKEN=$HUGGING_FACE_HUB_TOKEN \
-    -e export VLLM_NO_USAGE_STATS=1 -e DO_NOT_TRACK=1 \
-    -e VLLM_NCCL_SO_PATH=/usr/local/lib/python3.10/dist-packages/nvidia/nccl/lib/libnccl.so.2 -e NUMBA_CACHE_DIR=/tmp/ \
+    -e VLLM_NO_USAGE_STATS=1 \
+    -e DO_NOT_TRACK=1 \
+    -e NUMBA_CACHE_DIR=/tmp/ \
     -v /etc/passwd:/etc/passwd:ro \
     -v /etc/group:/etc/group:ro \
     -u `id -u`:`id -g` \

--- a/docs/README_GPU.md
+++ b/docs/README_GPU.md
@@ -104,8 +104,9 @@ docker run -d \
     -p 5000:5000 \
     -e NCCL_IGNORE_DISABLED_P2P=1 \
     -e HUGGING_FACE_HUB_TOKEN=$HUGGING_FACE_HUB_TOKEN \
-    -e export VLLM_NO_USAGE_STATS=1 -e DO_NOT_TRACK=1 \
-    -e VLLM_NCCL_SO_PATH=/usr/local/lib/python3.10/dist-packages/nvidia/nccl/lib/libnccl.so.2 -e NUMBA_CACHE_DIR=/tmp/ \
+    -e VLLM_NO_USAGE_STATS=1 \
+    -e DO_NOT_TRACK=1 \
+    -e NUMBA_CACHE_DIR=/tmp/ \
     -v /etc/passwd:/etc/passwd:ro \
     -v /etc/group:/etc/group:ro \
     -u `id -u`:`id -g` \

--- a/helm/h2ogpt-chart/values.yaml
+++ b/helm/h2ogpt-chart/values.yaml
@@ -230,7 +230,9 @@ vllm:
         - ALL
     seccompProfile:
 
-  env: {}
+  env:
+    VLLM_NO_USAGE_STATS: "1"
+    DO_NOT_TRACK: "1"
 
   resources:
 

--- a/tests/test_inference_servers.py
+++ b/tests/test_inference_servers.py
@@ -271,7 +271,6 @@ def run_vllm_docker(inf_port, base_model, tokenizer=None):
               '--shm-size', '10.24g',
               '-e', 'HUGGING_FACE_HUB_TOKEN=%s' % os.environ['HUGGING_FACE_HUB_TOKEN'],
               '-p', '%s:5000' % inf_port,
-              '-e', 'VLLM_NCCL_SO_PATH=/usr/local/lib/python3.10/dist-packages/nvidia/nccl/lib/libnccl.so.2',
               '-e', 'NCCL_IGNORE_DISABLED_P2P=1',
               '-e', 'NUMBA_CACHE_DIR=/tmp/',
               '-v', '/etc/passwd:/etc/passwd:ro',


### PR DESCRIPTION
Port https://github.com/h2oai/h2ogpt/pull/1797 to the `main` branch.