### PR TITLE
Update the base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PYTHON_BINARY                ?= `which python`
 DEFAULT_MARKERS              ?= "not need_tokens and not need_gpu"
 
 # h2ogpt base, vllm, and lmdeploy images built elsewhere and referenced here:
-DOCKER_BASE_OS_IMAGE     := gcr.io/vorvan/h2oai/h2ogpt-oss-wolfi-base:5
+DOCKER_BASE_OS_IMAGE     := gcr.io/vorvan/h2oai/h2ogpt-oss-wolfi-base:7
 DOCKER_VLLM_IMAGE        := gcr.io/vorvan/h2oai/h2ogpte-vllm:0.5.5-8714686a
 DOCKER_LMDEPLOY_IMAGE    := gcr.io/vorvan/h2oai/h2ogpte-lmdeploy:0.5.1-f88699a
 


### PR DESCRIPTION
Similar change to https://github.com/h2oai/h2ogpte/pull/3318

```
~$ docker run --rm -it --entrypoint chromium gcr.io/vorvan/h2oai/h2ogpt-oss-wolfi-base:7 --version
Chromium 128.0.6613.104 

```