### PR TITLE
fix autogen ConversableAgent import

### DIFF
--- a/openai_server/autogen_utils.py
+++ b/openai_server/autogen_utils.py
@@ -7,7 +7,7 @@ from typing import List
 
 from autogen.coding import LocalCommandLineCodeExecutor, CodeBlock
 from autogen.coding.base import CommandLineCodeResult
-from autogen import ConversableAgent
+from autogen.agentchat.conversable_agent import ConversableAgent
 import backoff
 
 verbose = os.getenv('VERBOSE', '0').lower() == '1'


### PR DESCRIPTION
fixes `ConversableAgent` import for `h2ogpt/openai_server/autogen_utils.py`

Otherwise it hits the error:
```
  File "/home/fatih/anaconda3/envs/h2ogpt/lib/python3.10/site-packages/openai/_base_client.py", line 1041, in _request
    raise self._make_status_error_from_response(err.response) from None
openai.BadRequestError: cannot import name 'ConversableAgent' from 'autogen' (unknown location)
```