### PR TITLE
feat(helm): expose agent and openai port to service

### DIFF
--- a/helm/h2ogpt-chart/templates/deployment.yaml
+++ b/helm/h2ogpt-chart/templates/deployment.yaml
@@ -210,6 +210,12 @@ spec:
             - name: gpt
               containerPort: 8888
               protocol: TCP
+            - name: agent
+              containerPort: 5004
+              protocol: TCP
+            - name: openai
+              containerPort: 5000
+              protocol: TCP
           {{- if .Values.h2ogpt.livenessProbe }}
           livenessProbe:
             httpGet:

--- a/helm/h2ogpt-chart/templates/service.yaml
+++ b/helm/h2ogpt-chart/templates/service.yaml
@@ -13,9 +13,18 @@ spec:
   selector:
     app: {{ include "h2ogpt.fullname" . }}
   ports:
-    - protocol: TCP
+    - name: http
+      protocol: TCP
       port: {{ .Values.h2ogpt.service.webPort }}
       targetPort: 7860
+    - name: agent
+      protocol: TCP
+      port: 5004
+      targetPort: 5004
+    - name: openai
+      protocol: TCP
+      port: 5000
+      targetPort: 5000
   type: {{ .Values.h2ogpt.service.type }}
 {{- end }}
 ---


### PR DESCRIPTION
# Description

This PR exposes ports 5004 and 5000 on the Helm deployment