### PR TITLE
multi_agent_type correct cost/usage calculations

### DIFF
--- a/openai_server/autogen_utils.py
+++ b/openai_server/autogen_utils.py
@@ -594,3 +594,15 @@ def merge_group_chat_messages(a, b):
             b_contents.add(content_a)
 
     return merged_list
+
+def get_all_conversable_agents(group_chat_manager: GroupChatManager) -> List[ConversableAgent]:
+    """
+    Get all conversable agents from a group chat manager and its sub-managers.
+    """
+    all_conversable_agents = []
+    for agent in group_chat_manager.groupchat.agents:
+        if isinstance(agent, GroupChatManager):
+            all_conversable_agents += get_all_conversable_agents(agent)
+        else:
+            all_conversable_agents.append(agent)
+    return all_conversable_agents


### PR DESCRIPTION
- Fixes #1838
- Now returns desired outputs like: 
```
{'usage_including_cached_inference': {'total_cost': 0.040175,
  'gpt-4o-2024-05-13': {'cost': 0.040175,
   'prompt_tokens': 7021,
   'completion_tokens': 338,
   'total_tokens': 7359}},
 'usage_excluding_cached_inference': {'total_cost': 0.040175,
  'gpt-4o-2024-05-13': {'cost': 0.040175,
   'prompt_tokens': 7021,
   'completion_tokens': 338,
   'total_tokens': 7359}}}
```

Reference: https://github.com/microsoft/autogen/blob/63d3297ffc66120a16e60391af538354a11e5d35/autogen/agentchat/utils.py#L29