### PR TITLE
new multi agent  flow with terminate agent

### DIFF
--- a/openai_server/autogen_multi_agent_backend.py
+++ b/openai_server/autogen_multi_agent_backend.py
@@ -53,7 +53,7 @@ def run_autogen_multi_agent(query=None,
     if autogen_run_code_in_docker is None:
         autogen_run_code_in_docker = False
     if autogen_max_consecutive_auto_reply is None:
-        autogen_max_consecutive_auto_reply = 40
+        autogen_max_consecutive_auto_reply = 10
     if autogen_max_turns is None:
         autogen_max_turns = 40
     if autogen_timeout is None:
@@ -134,7 +134,7 @@ def run_autogen_multi_agent(query=None,
             llm_config=llm_config,
             prompt=query,
             agents=[chat_agent, code_writer_agent, code_executor_agent, terminate_agent],
-            max_round=40,
+            max_round=20,
         )
     # apply chat history to human_proxy_agent and main_group_chat_manager
     # TODO: check if working


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9072a4cb-2eb2-464a-a288-bebd5f70c347)

- Better for prompts where user is only asking for the code but not for the execution.
   - Now GroupManager decides whether code execution is needed or not based on # execution: VALUE tag coming from code generator agent.
- Now Group manager has capability of terminating the chat as soon as user request is met. It's done by selecting the next agent as 'terminate_agent'.
   - This termination process can be extended to detecting repetitive errors in the agents' conversation. If Group manager decides that there has been repetitive/unsolvable errors in the chat history, it can decide to terminate the chat.

Based on current h2ogpte agents pytest, it shows similar results to the other agent types. The most distinctive success comes with the question "Write a code to show an image in matplotlib.  Do not execute any code." Because this new flow is the only flow that does not even call 'code_execution_agent'.

- [ ] testing