### PR TITLE
Final Response Agent

### DIFF
--- a/openai_server/autogen_agents.py
+++ b/openai_server/autogen_agents.py
@@ -204,3 +204,36 @@ def get_main_group_chat_manager(
         name="main_group_chat_manager",
     )
     return main_group_chat_manager
+
+def get_final_response_agent(
+        llm_config: dict,
+        autogen_max_consecutive_auto_reply: int = 1,
+):
+    # Final Response Generating Agent
+    from openai_server.autogen_utils import H2OConversableAgent
+    system_prompt = """
+    You are a helpful AI Agent tasked with providing a direct answer to the user's initial query based on the findings in the chat history.
+
+    Guidelines:
+    * You should sound like you are talking to the user directly.
+    * Identify the first user request in the chat history.
+    * Provide a direct answer to that request by only using the info avaiable in the chat history.
+    * If there is not enough information to provide a direct answer, mention that you couldn't find enough information for the task or for some of the sub-tasks.
+    * If there were any crucial internal steps or discoveries in the chat history, mention them briefly as well if they are directly related to the answer.
+    * You can only use code blocks as is, you cannot add to them, you cannot subtract from them. Including code comments, you can not change anything. Keep them as is.
+    * If the user was asking for seeing codes directly, make sure to provide the code block in the answer.
+    * Don't mention things like 'Here's a brief, direct answer to the user's initial query..', because you don't sound like you are directly talking to the user.
+    * Never say things that can mean 'I'm sharing this again..' or 'I'm repeating this..'. You should sound like you are answering the user for the first time.
+    * Never mention words like 'Here's final response', 'initial request' etc. You have to start with the answer directly.
+    * In your response, you must add an inline markdown of any key image, chart, or graphic (e.g.) ![image](filename.png) without any code block. Only use the basename of the file, not the full path.
+    * You can use markdown syntax for formatting the text in the response to make it more readable and easy to follow.
+    """
+
+    final_response_agent = H2OConversableAgent(
+        name="final_response_agent",
+        system_message=system_prompt,
+        llm_config=llm_config,
+        human_input_mode="NEVER",
+        max_consecutive_auto_reply=autogen_max_consecutive_auto_reply,
+    )
+    return final_response_agent

--- a/openai_server/autogen_agents.py
+++ b/openai_server/autogen_agents.py
@@ -215,16 +215,14 @@ def get_final_response_agent(
     You are a helpful AI Agent tasked with providing a direct answer to the user's initial query based on the findings in the chat history.
 
     Guidelines:
-    * You should sound like you are talking to the user directly.
     * Identify the first user request in the chat history.
-    * Provide a direct answer to that request by only using the info avaiable in the chat history.
+    * Provide a direct answer to that request by only using the information avaiable in the chat history.
+    * You should sound like you are talking to the user directly for the first time as if there were no internal chats.
+    * Don't mention things like 'user's initial query', 'I'm sharing this again' or 'final request', because you don't sound like you are directly talking to the user for the first time.
     * If there is not enough information to provide a direct answer, mention that you couldn't find enough information for the task or for some of the sub-tasks.
     * If there were any crucial internal steps or discoveries in the chat history, mention them briefly as well if they are directly related to the answer.
-    * You can only use code blocks as is, you cannot add to them, you cannot subtract from them. Including code comments, you can not change anything. Keep them as is.
     * If the user was asking for seeing codes directly, make sure to provide the code block in the answer.
-    * Don't mention things like 'Here's a brief, direct answer to the user's initial query..', because you don't sound like you are directly talking to the user.
-    * Never say things that can mean 'I'm sharing this again..' or 'I'm repeating this..'. You should sound like you are answering the user for the first time.
-    * Never mention words like 'Here's final response', 'initial request' etc. You have to start with the answer directly.
+    * You can only use code blocks as is, you cannot add to them, you cannot subtract from them. Including code comments, you can not change anything. Use them as they are.
     * In your response, you must add an inline markdown of any key image, chart, or graphic (e.g.) ![image](filename.png) without any code block. Only use the basename of the file, not the full path.
     * You can use markdown syntax for formatting the text in the response to make it more readable and easy to follow.
     """

--- a/openai_server/autogen_utils.py
+++ b/openai_server/autogen_utils.py
@@ -879,3 +879,18 @@ def get_all_conversable_agents(group_chat_manager: GroupChatManager) -> List[Con
         else:
             all_conversable_agents.append(agent)
     return all_conversable_agents
+
+def prepare_final_response_agent_messages(chat_history: list) -> list:
+    # Prepare messages for final response agent
+    messages = copy.deepcopy(chat_history)
+    # drop the last messager if the content == ''
+    if len(messages)>0 and messages[-1]['content'] == '':
+        messages.pop()
+    # Define the roles in the alternating order so that the new message will always be 'user'.
+    roles = ["assistant", "user"]
+    for i in range(len(messages)-1, -1, -1):
+        messages[i]['role'] = roles[(len(messages) - 1 - i) % 2]
+    # Add the final response prompt
+    final_response_prompt = {'content': 'Generate final response to the user who passed the first request in the chat history.', 'role': 'user'}
+    messages.append(final_response_prompt)
+    return messages


### PR DESCRIPTION
- This PR is more like an idea placeholder for a **Final Response Agent** to generate guided final responses after each agent conversation terminates. (for 2agent type)
- Requires more testing with OSS as well for sure
- Main motivation working on this agent is, quite frequently, I'm still seeing the issue where final agent response includes words like 'Thank you for running the code!' or 'The code execution was successful' etc. Or, when the user asks just for a code snippet, the final answer doesnt include the code at all, which is what user is actually interested in.
- I've started playing with changing `<no_code_executed_notes>` and actual `code_writer_agent` `system_message` to instruct the llm to avoid such mentions, however even Claude 3.5 doesnt follow these instructions for some reason. (Need to play with this idea more) So, based on my first exploration, I find it easy to instruct llms via this extra final response call with a small system_message. We might consider having this final step and more control over the final responses at the cost of having one extra llm call 🤔 
- Again, this is more like a placeholder rn, needs more testing + we need to make sure that the method I mentioned one-point above doesnt work at all.

#### How it looks on main branch right now (without Final Response Agent)
- Note that the final code_writer_agent still says Thank you or 'execution was successful'. Or doesnt put code snippets in the final message at all
https://github.com/user-attachments/assets/adffe394-b969-4aa2-8ac7-7fb1d83fee1d


- In this PR, I've introduced new  Final Response Agent which takes the previous agent conversations as llm messages, crafts a final response. It should be paying attention on:
   - The final response to sound as if talking to the main user directly for the first time
   - Writing down the new message based on the information avail in the chat history only
   - Answering main user request first
   - Sharing interesting and relevant findings from the internal agent conversations
 
#### How it looks  in this PR  (with Final Response Agent)
https://github.com/user-attachments/assets/1f11cbd6-daf2-48b1-ba03-04757b776097

