### PR TITLE
code_block and ENDOFTURN control via API streaming

### DIFF
--- a/openai_server/backend.py
+++ b/openai_server/backend.py
@@ -321,11 +321,6 @@ async def get_response(chunk_response=True, **kwargs):
             await asyncio.sleep(0.005)
             job_outputs_num += job_outputs_num_new
 
-        if check_if_response_was_from_code_writer_agent():
-            # If the last response was from code_writer_agent, then we always have to return "ENDOFTURN" at the end of the message.
-            print("Finishing code_writer_agent message with 'ENDOFTURN'", flush=True)
-            yield "\n\nENDOFTURN"
-
         outputs_list = job.outputs().copy()
         job_outputs_num_new = len(outputs_list[job_outputs_num:])
         for num in range(job_outputs_num_new):


### PR DESCRIPTION
This PR:
- makes sure that each code_writer_agent message will end with ENDOFTURN string
- makes sure that code_writer_agent string will end after each executable code block to be able to run it (num code block limit is 1)

@pseudotensor this is my first attempt based on discussion on slack. Here I'm controlling number of code blocks + ENDOFTURN behaviours on API steaming side.

There were things that I could do better but didnt know how, so left some TODO comments. Feel free to change the code and let me know what you think with the code.