### PR TITLE
final answer improvements

### DIFF
--- a/openai_server/autogen_agents.py
+++ b/openai_server/autogen_agents.py
@@ -13,7 +13,7 @@ def get_code_execution_agent(
         llm_config=False,  # Turn off LLM for this agent.
         code_execution_config={"executor": executor},  # Use the local command line code executor.
         human_input_mode="NEVER",  # Always take human input for this agent for safety.
-        is_termination_msg=terminate_message_func,
+        # is_termination_msg=terminate_message_func,
         max_consecutive_auto_reply=autogen_max_consecutive_auto_reply,
     )
     return code_executor_agent

--- a/openai_server/autogen_utils.py
+++ b/openai_server/autogen_utils.py
@@ -858,6 +858,7 @@ class H2OConversableAgent(ConversableAgent):
         return """
 You should terminate the chat with your final answer.
 <final_answer_guidelines>
+* Your answer should start by answering the user's first request.
 * You should give a well-structured and complete answer, insights gained, and recommendations suggested.
 * Don't mention things like 'user's initial query', 'I'm sharing this again', 'final request' or 'Thank you for running the code' etc., because that wouldn't sound like you are directly talking to the user about their query.
 * If no good answer was found, discuss the failures, give insights, and provide recommendations.

--- a/openai_server/autogen_utils.py
+++ b/openai_server/autogen_utils.py
@@ -406,6 +406,7 @@ os.environ['TERM'] = 'dumb'
 * For example, you may have shown code for demonstration purposes.
 * If you intended to execute code, be sure to add the comment: # execution: true and try again.
 * If no code execution was expected, do not respond or react to this "no_code_execution" text and instead directly and immediately provide the actual answer to the user's original question. You can repeat your non-executable code mentioned in your previous message if that's what the user is looking for.
+* If there is no more task left, terminate the chat by having <FINISHED_ALL_TASKS> string in your final answer.
 </no_code_executed_notes>
 """)
         except Exception as e:
@@ -819,7 +820,10 @@ class H2OConversableAgent(ConversableAgent):
             if not message["content"]:
                 continue
             code_blocks = self._code_executor.code_extractor.extract_code_blocks(message["content"])
-            if len(code_blocks) == 0:
+            if (
+                len(code_blocks) == 0 or
+                "<FINISHED_ALL_TASKS>" in message["content"]
+                ):
                 # force immediate termination regardless of what LLM generates
                 self._is_termination_msg = lambda x: True
                 return True, self.final_answer_guidelines()


### PR DESCRIPTION
- visiting final_answer_guidelines when there is no code but FINISHED_ALL_TASKS tag too.
- new guideline point for llm to start its final answer by focusing on user's initial request.