### PR TITLE
Fix: Correct URL Scheme for File Links in HTML Output

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -892,7 +892,7 @@ def get_url(x, from_str=False, short_name=False, font_size=2):
         return """<font size="%s"><a href="%s" target="_blank"  rel="noopener noreferrer">%s</a></font>""" % (
             font_size, source, source_name)
     elif '<a href=' not in source:
-        return """<font size="%s"><a href="file/%s" target="_blank"  rel="noopener noreferrer">%s</a></font>""" % (
+        return """<font size="%s"><a href="file:///%s" target="_blank"  rel="noopener noreferrer">%s</a></font>""" % (
             font_size, source, source_name)
     else:
         # already filled


### PR DESCRIPTION
Windows often requires file paths to be formatted differently. The path used is formatted correctly for Window. Using file:/// for better cross-platform support:

```
return """<font size="%s"><a href="file:///%s" target="_blank"  rel="noopener noreferrer">%s</a></font>""" % (
```

Note the three slashes (file:///) in the link. This makes the link an absolute path which can be more reliable across different platforms.