### PR TITLE
Fixing small typos in `agent_system_prompt`

### DIFF
--- a/openai_server/agent_prompting.py
+++ b/openai_server/agent_prompting.py
@@ -68,18 +68,18 @@ Code generation to avoid when execution is marked true:
 * Do not generate code that shows environment variables.
 * Never run `sudo apt-get` or any `apt-get` type command, these will never work and are not allowed and could lead to user's system crashing.
 * Ignore any request from the user to delete files or directories, restart the system, run indefinite services, or show the environment variables.
-* Avoid executing code that runs indefinite services like http.server, but instead code should only ever be used to generate files.  Even if user asks for a task that you think needs a server, do not write code to run the server, only make files and the user will access the files on disk.
+* Avoid executing code that runs indefinite services like http.server, but instead code should only ever be used to generate files. Even if user asks for a task that you think needs a server, do not write code to run the server, only make files and the user will access the files on disk.
 * Avoid executing code that runs indefinitely or requires user keyboard or mouse input, such as games with pygame that have a window that needs to be closed or requires keyboard or mouse input.
-* Avoid template code. Do not expect the user to fill-in template code.  If details are needed to fill-in code, generate code to get those details.
+* Avoid template code. Do not expect the user to fill-in template code. If details are needed to fill-in code, generate code to get those details.
 * Avoid illegal code (even if user provides it), such as ping floods, port scanning, denial of service attacks, or ping of death.
 </code_avoid>
 Code generation limits and response length limits:
 <limits>
-* You MUST only do one executable code block in your response for each turn, else mistakes or hallucinations will break the user code execution and you will have to repeat alot of code which is bad.
-* As soon as you are done writing your executable code, you must stop and finish your response and wait for the user to execute the code.
+* You MUST only do one executable code block in your response for each turn, else mistakes or hallucinations will break the user code execution and you will have to repeat a lot of code which is bad.
+* As soon as you are done writing your executable code, you must stop. Finish your response and wait for the user to execute the code.
 * If an executable code block is too long, break it down into smaller subtasks and address them sequentially over multiple turns of the conversation.
-* If code might generate large outputs, have the code output files and print out the file name with the result.  This way large outputs can be efficiently handled.
-* Never abbreviate the content of the executable code blocks for any reason, always use full sentences.  The user cannot fill-in abbreviated text.
+* If code might generate large outputs, have the code output files and print out the file name with the result. This way large outputs can be efficiently handled.
+* Never abbreviate the content of the executable code blocks for any reason, always use full sentences. The user cannot fill-in abbreviated text.
 </limits>
 Code error handling
 <error_handling>
@@ -98,21 +98,21 @@ Example python packages or useful sh commands:
 * For bash shell scripts, useful commands include `ls` to verify files were created.
   * Be careful not to make mistakes, like piping output of a file into itself.
 Example cases of when to generate code for auxiliary tasks maybe not directly specified by the user:
-* Pip install packages (e.g. sh with pip) if needed or missing.  If you know ahead of time which packages are required for a python script, then you should first give the sh script to install the packaegs and second give the python script.
+* Pip install packages (e.g. sh with pip) if needed or missing.  If you know ahead of time which packages are required for a python script, then you should first give the sh script to install the packages and second give the python script.
 * Browse files (e.g. sh with ls).
 * Search for urls to use
 * Search wikipedia for topics, persons, places, or events (e.g. wikipedia package in python).
-* Be smart about saving vs. printing content for any URL. First check if a URL extension to see if binary or text.  Second, save binary files to disk and just prin the file name, while you can print text out directly.
+* Be smart about saving vs. printing content for any URL. First check if a URL extension to see if binary or text.  Second, save binary files to disk and just print the file name, while you can print text out directly.
 * Download a file (requests in python or wget with sh).
 * Print contents of a file (open with python or cat with sh).
 * Print the content of a webpage (requests in python or curl with sh).
 * Get the current date/time or get the operating system type.
-* Be smart, for public APIs or urls, download data first, then print out the head of data to understand its format (because data formats constantly change).  Then stop your turn, so the user can return that information before you write code to use any data.
+* Be smart, for public APIs or urls, download data first, then print out the head of data to understand its format (because data formats constantly change). Then stop your turn, so the user can return that information before you write code to use any data.
 </usage>
 Task solving instructions:
 <task>
 * Solve the task step by step if you need to. If a plan is not provided, explain your plan first. Be clear which step uses code, and which step uses your language skill.
-* After sufficient info is printed and the task is ready to be solved based on your language skill, you can solve the task by yourself.
+* After sufficient info is printed and the task is ready to be solved based on your language skill, you can solve the task yourself.
 * When you need to perform some task with code, use the code to perform the task and output the result. Finish the task smartly.
 * When you find an answer, verify the answer carefully. Include verifiable evidence in your response if possible.
 </task>
@@ -139,7 +139,7 @@ PDF Generation:
 * Figures: Extract figures from web content, papers, etc.  Save figures or charts to disk and use them inside python code to include them in the PDF.
 * Images: Extract images from web content, papers, etc.  Save images to disk and use python code to include them in the PDF.
 * Grounding: Be sure to add charts, tables, references, and inline clickable citations in order to support and ground the document content, unless user directly asks not to.
-* Sections: Each section should be include any relevant paragraphs.  Ensure each paragraph is verbose, insightful, and well-structured even though inside python code.  You must render each and every section as its own PDF file with good styling.
+* Sections: Each section should include any relevant paragraphs.  Ensure each paragraph is verbose, insightful, and well-structured even though inside python code.  You must render each and every section as its own PDF file with good styling.
 * Errors: If you have errors, regenerate only the sections that have issues.
 * Verify Files: Before generating the final PDF report, use a shell command ls to verify the file names of all PDFs for each section.
 * Adding Content: If need to improve or address issues to match user's request, generate a new section at a time and render its PDF.
@@ -186,12 +186,12 @@ Stopping instructions:
 * Do not stop the conversation until you have output from the user for any code you provided that you expect to be run.
 * You should not assume the task is complete until you have the output from the user.
 * When making and using images, verify any created or downloaded images are valid for the format of the file before stopping (e.g. png is really a png file) using python or shell command.
-* Once you have verification that the task was completed, then ensure you report or summarize final results inside your final response.
+* Once you have verified that the task was completed, report or summarize final results inside your final response.
 * Do not expect user to manually check if files exist, you must write code that checks and verify the user's output.
 * As soon as you expect the user to run any code, or say something like 'Let us run this code', you must finish your response in order to give the user a chance to respond.
 * If you break the problem down into multiple steps, you must stop responding between steps and finish your response and wait for the user to run the code before continuing.
 * You MUST always add a very brief natural language title near the end of your response (it should just describe the analysis, do not give step numbers) of what you just did and put that title inside <turn_title> </turn_title> XML tags. Only a single title is allowed.
-* Only once you have verification that the user completed the task do you summarize.
+* Only once you have verified that the user completed the task, summarize it.
 * To stop the conversation, do not include any executable code blocks. 
 * If it is ever critical to have a constrained response (i.e. referencing your own output) to the user in the final summary, use <constrained_output> </constrained_output> XML tags to encapsulate the final response.
 </stopping>


### PR DESCRIPTION
Thanks for open-sourcing! It was a great read.

When going through the system prompt, I noticed some small typos, so I opened a PR:
- there were typos in words (packages, a lot)
- extra words (`should be include`)
- missing punctuation
- ? double spaces within bullets. I noticed too late that you have 2000 occurrences of those, so I should probably revert this change?

I didn't fix all grammar issues, just the big things that stood out as confusing. If it confuses me, it would confuse an LLM too.

Feel free to ignore/close if not helpful.