### PR TITLE
fix: correct typos 'seperator' and 'dont\''

### DIFF
--- a/openai_server/autogen_utils.py
+++ b/openai_server/autogen_utils.py
@@ -455,7 +455,7 @@ os.environ['TERM'] = 'dumb'
         except Exception as e:
             if danger_mark in str(e):
                 print(f"Code Danger Error: {e}\n\n{code_blocks}", file=sys.stderr)
-                # dont' fail, just return the error so LLM can adjust
+                # don't fail, just return the error so LLM can adjust
                 ret = CommandLineCodeResult(exit_code=1, output=str(e))
             else:
                 raise
@@ -464,7 +464,7 @@ os.environ['TERM'] = 'dumb'
         except Exception as e:
             if bad_output_mark in str(e):
                 print(f"Code Output Danger Error: {e}\n\n{code_blocks}\n\n{ret}", file=sys.stderr)
-                # dont' fail, just return the error so LLM can adjust
+                # don't fail, just return the error so LLM can adjust
                 ret = CommandLineCodeResult(exit_code=1, output=str(e))
             else:
                 raise

--- a/src/prompter.py
+++ b/src/prompter.py
@@ -1834,7 +1834,7 @@ class Prompter(object):
                 # prefix with output counter
                 output = "\n=========== Output %d\n\n" % (1 + oi) + output
                 if oi > 0:
-                    # post fix outputs with seperator
+                    # post fix outputs with separator
                     output += '\n'
             output = self.fix_text(self.prompt_type, output)
             outputs[oi] = output


### PR DESCRIPTION
Fixes minor typos in comments:
- seperator → separator in prompter.py
- dont' → don't in autogen_utils.py